### PR TITLE
Return no results when skip fetch call

### DIFF
--- a/lib/useQuery.js
+++ b/lib/useQuery.js
@@ -142,7 +142,7 @@ export function useQuery(serviceName, options = {}, queryHookOptions = {}) {
 
   return useMemo(
     () => ({
-      ...cachedData,
+      ...(skip ? { data: null } : cachedData),
       status: loading ? 'loading' : state.error ? 'error' : 'success',
       refetch,
       isFetching: reloading,
@@ -151,7 +151,17 @@ export function useQuery(serviceName, options = {}, queryHookOptions = {}) {
       loading, // deprecated, use status and isFetching instead
       reloading, // deprecated, use isFetching instead
     }),
-    [cachedData.data, loading, state.error, refetch, reloading, state.error, loading, reloading]
+    [
+      skip,
+      cachedData.data,
+      loading,
+      state.error,
+      refetch,
+      reloading,
+      state.error,
+      loading,
+      reloading,
+    ]
   )
 }
 


### PR DESCRIPTION
useQuery still returns result from cache when skip param is true. 
This is an unexpected behaviour that might lead to some errors