### PR TITLE
Fix multi operations - mutate next instead of curr when looping items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Figbird Changelog
 
+## 0.13.1
+
+- Fix an issue where multi operations in useMutation (e.g. creating an array of items) would not correctly update the cache after completing
+
 ## 0.13.0
 
 - Switch the cache store from `tiny-atom` to `kinfolk`. Breaking change if you're relying on using the cache directly. Refer to [`kinfolk`](https://github.com/KidkArolis/kinfolk/ documentation] for how to consume the new cache.

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -99,8 +99,8 @@ function fetched(
   let next = curr
 
   const { data: items, ...meta } = data
-  const entities = realtime === 'merge' ? { ...getIn(curr, ['entities', serviceName]) } : {}
-  const index = realtime === 'merge' ? { ...getIn(curr, ['index', serviceName]) } : {}
+  const entities = realtime === 'merge' ? { ...getIn(next, ['entities', serviceName]) } : {}
+  const index = realtime === 'merge' ? { ...getIn(next, ['index', serviceName]) } : {}
   for (const item of items) {
     const itemId = idField(item)
     entities[itemId] = item
@@ -151,12 +151,12 @@ function updated(curr, { serviceName, item }, { idField, updatedAtField }) {
     }
   }
 
-  let next
+  let next = curr
   if (currItem) {
-    next = setIn(curr, ['entities', serviceName, itemId], item)
+    next = setIn(next, ['entities', serviceName, itemId], item)
   } else {
     const index = { queries: {}, size: 0 }
-    next = setIn(curr, ['entities', serviceName, itemId], item)
+    next = setIn(next, ['entities', serviceName, itemId], item)
     next = setIn(next, ['index', serviceName, itemId], index)
   }
 
@@ -174,8 +174,9 @@ function removed(curr, { serviceName, item: itemOrItems }, { idField, updatedAtF
   if (!exists) return curr
 
   // updating queries updates state, get a fresh copy
-  curr = updateQueries(
-    curr,
+  let next = curr
+  next = updateQueries(
+    next,
     {
       serviceName,
       method: 'remove',
@@ -185,8 +186,7 @@ function removed(curr, { serviceName, item: itemOrItems }, { idField, updatedAtF
   )
 
   // now remove it from entities
-  const serviceEntities = { ...getIn(curr, ['entities', serviceName]) }
-  let next = curr
+  const serviceEntities = { ...getIn(next, ['entities', serviceName]) }
   const removedIds = []
   for (const item of items) {
     delete serviceEntities[idField(item)]
@@ -202,8 +202,8 @@ function updateQueries(curr, { serviceName, method, item }, { idField, updatedAt
 
   for (const item of items) {
     const itemId = idField(item)
-    const queries = { ...getIn(curr, ['queries', serviceName]) }
-    const index = { ...getIn(curr, ['index', serviceName, itemId]) }
+    const queries = { ...getIn(next, ['queries', serviceName]) }
+    const index = { ...getIn(next, ['index', serviceName, itemId]) }
     index.queries = { ...index.queries }
     index.size = index.size || 0
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -122,14 +122,19 @@ class Service {
       this.data = { ...this.data }
       for (const datum of data) {
         this.data[datum.id] = { ...datum, updatedAt: datum.updatedAt || Date.now() }
-        this.emit('created', this.data[datum.id])
+        setTimeout(() => {
+          this.emit('created', this.data[datum.id])
+        }, 1)
       }
       return Promise.all(ids.map(id => this.get(id)))
     }
     this.counts.create++
     const { id } = data
     this.data = { ...this.data, [id]: { ...data, updatedAt: data.updatedAt || Date.now() } }
-    this.emit('created', this.data[id])
+    const mutatedItem = this.data[id]
+    setTimeout(() => {
+      this.emit('created', mutatedItem)
+    }, 1)
     return this.get(id)
   }
 
@@ -139,25 +144,33 @@ class Service {
       ...this.data,
       [id]: { ...this.data[id], ...data, updatedAt: data.updatedAt || Date.now() },
     }
-    this.emit('patched', this.data[id])
+    const mutatedItem = this.data[id]
+    setTimeout(() => {
+      this.emit('patched', mutatedItem)
+    }, 1)
     return this.get(id)
   }
 
   update(id, data, params) {
     this.counts.update++
     this.data = { ...this.data, [id]: { ...data, updatedAt: data.updatedAt || Date.now() } }
-    this.emit('updated', this.data[id])
+    const mutatedItem = this.data[id]
+    setTimeout(() => {
+      this.emit('updated', mutatedItem)
+    }, 1)
     return this.get(id)
   }
 
   remove(id, params) {
     this.counts.remove++
     this.data = { ...this.data }
-    const item = this.data[id]
+    const mutatedItem = this.data[id]
     delete this.data[id]
-    this.emit('removed', item)
+    setTimeout(() => {
+      this.emit('removed', mutatedItem)
+    }, 1)
     // TODO - check if feathers throws 404 in this case
-    return Promise.resolve(item)
+    return Promise.resolve(mutatedItem)
   }
 }
 


### PR DESCRIPTION
Otherwise, we keep seeing origina/stale state in each loop iteration

Update tests to emit realtime events async to catch this in tests