### PR TITLE
Do not refetch if no listeners

### DIFF
--- a/lib/core/figbird.js
+++ b/lib/core/figbird.js
@@ -286,6 +286,7 @@ class QueryStore {
 
   refetch(queryId) {
     const q = this.#getQuery(queryId)
+
     if (!q.state.isFetching) {
       this.#queue(queryId)
     } else {
@@ -527,7 +528,7 @@ class QueryStore {
   #refetchRefetchableQueries(serviceName) {
     const service = this.getState().get(serviceName)
     for (const query of service.queries.values()) {
-      if (query.config.realtime === 'refetch') {
+      if (query.config.realtime === 'refetch' && this.#listenerCount(query.queryId) > 0) {
         this.refetch(query.queryId)
       }
     }
@@ -629,7 +630,7 @@ class QueryStore {
       })
     })
 
-    if (shouldRefetch) {
+    if (shouldRefetch && this.#listenerCount(queryId) > 0) {
       this.#queue(queryId)
     }
   }
@@ -652,7 +653,7 @@ class QueryStore {
       })
     })
 
-    if (shouldRefetch) {
+    if (shouldRefetch && this.#listenerCount(queryId) > 0) {
       this.#queue(queryId)
     }
   }


### PR DESCRIPTION
No longer auto refetch if the query is no longer mounted (or subscribed by any listeners).
But still allow refetching manually when calling .refetch().