### PR TITLE
Implement refetchDebounce option for realtime #refetch

### DIFF
--- a/lib/core/figbird.js
+++ b/lib/core/figbird.js
@@ -59,6 +59,7 @@ export function splitConfig(combinedConfig) {
     realtime = 'merge',
     fetchPolicy = 'swr',
     matcher,
+    refetchDebounce,
     ...params // pass through params
   } = combinedConfig
 
@@ -79,6 +80,7 @@ export function splitConfig(combinedConfig) {
     fetchPolicy,
     allPages,
     matcher,
+    refetchDebounce,
   }
 
   return { desc, config }
@@ -142,6 +144,7 @@ class QueryStore {
   #eventQueue = []
   #eventBatchProcessingTimer = null
   #eventBatchProcessingInterval = 100
+  #refetchTimers = new Map()
 
   constructor({ adapter, eventBatchProcessingInterval = 100 }) {
     this.#adapter = adapter
@@ -529,7 +532,21 @@ class QueryStore {
     const service = this.getState().get(serviceName)
     for (const query of service.queries.values()) {
       if (query.config.realtime === 'refetch' && this.#listenerCount(query.queryId) > 0) {
-        this.refetch(query.queryId)
+        const delay = query.config.refetchDebounce
+        if (typeof delay === 'number' && delay > 0) {
+          const existing = this.#refetchTimers.get(query.queryId)
+          if (existing) clearTimeout(existing)
+          const timer = setTimeout(() => {
+            this.#refetchTimers.delete(query.queryId)
+            const stillHasListeners = this.#listenerCount(query.queryId) > 0
+            if (this.#getQuery(query.queryId) && stillHasListeners) {
+              this.refetch(query.queryId)
+            }
+          }, delay)
+          this.#refetchTimers.set(query.queryId, timer)
+        } else {
+          this.refetch(query.queryId)
+        }
       }
     }
   }
@@ -663,6 +680,11 @@ class QueryStore {
       queryId,
       (service, query) => {
         if (query) {
+          const pendingTimer = this.#refetchTimers.get(queryId)
+          if (pendingTimer) {
+            clearTimeout(pendingTimer)
+            this.#refetchTimers.delete(queryId)
+          }
           if (query.state.data) {
             for (const item of getItems(query)) {
               const id = this.#adapter.getId(item)

--- a/test/figbird.test.js
+++ b/test/figbird.test.js
@@ -860,6 +860,62 @@ test('refetch only works with active listeners', async t => {
   dom2.unmount()
 })
 
+test('useFind with realtime refetch and debounce', async t => {
+  const { render, flush, unmount, $ } = dom()
+
+  function Note() {
+    const notes = useFind('notes', {
+      query: { tag: 'idea' },
+      realtime: 'refetch',
+      refetchDebounce: 1000,
+    })
+
+    return <NoteList notes={notes} />
+  }
+
+  const feathers = createFeathers()
+
+  render(
+    <App feathers={feathers}>
+      <Note />
+    </App>,
+  )
+
+  await flush()
+
+  t.is(feathers.service('notes').counts.find, 1, 'initial fetch occurs once')
+
+  await flush(async () => {
+    await feathers.service('notes').patch(1, { content: 'first debounce', tag: 'idea' })
+  })
+
+  await flush(async () => {
+    await new Promise(resolve => setTimeout(resolve, 100))
+    await feathers.service('notes').patch(1, { content: 'second debounce', tag: 'idea' })
+  })
+
+  await flush(async () => {
+    await new Promise(resolve => setTimeout(resolve, 900))
+  })
+
+  t.is(
+    feathers.service('notes').counts.find,
+    1,
+    'should not refetch while debounce window is active',
+  )
+
+  await flush(async () => {
+    await new Promise(resolve => setTimeout(resolve, 200))
+  })
+
+  await flush()
+
+  t.is(feathers.service('notes').counts.find, 2, 'debounced events trigger a single refetch')
+  t.is($('.note').innerHTML, 'second debounce')
+
+  unmount()
+})
+
 test('useFind with allPages', async t => {
   const { render, flush, unmount, $all } = dom()
   function Note() {


### PR DESCRIPTION
Option to only trigger a refetch on the final trigger within a timeframe. 

Useful when a realtime refetch hits an expensive endpoint and you only need the latest data (i.e., api/tasks on home/sidebar), but there is a possibility that multiple realtime events will trigger refetches in a small timeframe (because of a multi patch for example).