### PR TITLE
Add typed useService hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ const figbird = new Figbird({
   adapter: new FeathersAdapter(feathersClient),
 })
 
-export const { useFind, useGet, useMutation } = createHooks(figbird)
+export const { useFind, useGet, useMutation, useService } = createHooks(figbird)
 
 function App() {
   return (
@@ -31,15 +31,19 @@ function App() {
 
 function Notes() {
   const { data } = useFind('notes')
-  const { patch } = useMutation('notes')
+  const notesService = useService('notes')
 
   return data?.map(note => (
-    <div key={note.id} onClick={() => patch(note.id, { read: true })}>
+    <div key={note.id} onClick={() => notesService.patch(note.id, { read: true })}>
       {note.content}
     </div>
   ))
 }
 ```
+
+`useService('notes')` returns the Feathers service for that schema service. When you create hooks
+from a typed Figbird instance, the returned service is narrowed by the literal service name and
+includes typed CRUD methods plus any custom methods declared in the schema.
 
 ## Features
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -46,6 +46,7 @@ export { FigbirdProvider, useFigbird } from './react/react.js'
 export { useFeathers } from './react/useFeathers.js'
 export { useMutation } from './react/useMutation.js'
 export { useFind, useGet } from './react/useQuery.js'
+export { useService } from './react/useService.js'
 
 // Query-related types for advanced usage
 export type {

--- a/lib/react/createHooks.ts
+++ b/lib/react/createHooks.ts
@@ -1,10 +1,15 @@
 import type { AdapterFindMeta, AdapterParams } from '../adapters/adapter.js'
-import type { FeathersClient, TypedFeathersClient } from '../adapters/feathers.js'
+import type {
+  FeathersClient,
+  TypedFeathersClient,
+  TypedFeathersService,
+} from '../adapters/feathers.js'
 import { splitConfig, type Figbird, type QueryConfig } from '../core/figbird.js'
 import type {
   Schema,
   ServiceCreate,
   ServiceItem,
+  ServiceMethods,
   ServiceNames,
   ServicePatch,
   ServiceQuery,
@@ -51,6 +56,19 @@ type UseMutationForSchema<S extends Schema> = <N extends ServiceNames<S>>(
   ServicePatch<S, N>
 >
 
+type TypedServiceForSchema<S extends Schema, N extends ServiceNames<S>> = TypedFeathersService<
+  ServiceItem<S, N>,
+  ServiceCreate<S, N>,
+  ServiceUpdate<S, N>,
+  ServicePatch<S, N>,
+  ServiceQuery<S, N>,
+  ServiceMethods<S, N>
+>
+
+type UseServiceForSchema<S extends Schema> = <N extends ServiceNames<S>>(
+  serviceName: N,
+) => TypedServiceForSchema<S, N>
+
 type UseFeathersForSchema<S extends Schema> = () => TypedFeathersClient<S>
 
 // Type helper to extract schema and adapter types from a Figbird instance
@@ -75,6 +93,7 @@ type InferMeta<F> = AdapterFindMeta<InferAdapter<F>>
  *
  * function MyComponent() {
  *   const people = useFind('api/people') // Fully typed to QueryResult<Person[], FeathersFindMeta>
+ *   const peopleService = useService('api/people') // Fully typed Feathers service
  * }
  * ```
  */
@@ -86,6 +105,7 @@ export function createHooks<F extends Figbird<any, any>>(
   useGet: UseGetForSchema<InferSchema<F>, InferParams<F>>
   useFind: UseFindForSchema<InferSchema<F>, InferParams<F>, InferMeta<F>>
   useMutation: UseMutationForSchema<InferSchema<F>>
+  useService: UseServiceForSchema<InferSchema<F>>
   useFeathers: UseFeathersForSchema<InferSchema<F>>
 } {
   type S = InferSchema<F>
@@ -142,6 +162,12 @@ export function createHooks<F extends Figbird<any, any>>(
     >
   }
 
+  function useTypedService<N extends ServiceNames<S>>(serviceName: N) {
+    const service = findServiceByName(figbird.schema, serviceName)
+    const actualServiceName = service?.name ?? serviceName
+    return useTypedFeathers().service(actualServiceName as N)
+  }
+
   function useTypedFeathers() {
     const adapter = figbird.adapter as { feathers?: FeathersClient }
     if (!adapter?.feathers) {
@@ -156,6 +182,7 @@ export function createHooks<F extends Figbird<any, any>>(
     useGet: useTypedGet as UseGetForSchema<S, TParams>,
     useFind: useTypedFind as UseFindForSchema<S, TParams, TMeta>,
     useMutation: useTypedMutation as UseMutationForSchema<S>,
+    useService: useTypedService as UseServiceForSchema<S>,
     useFeathers: useTypedFeathers as UseFeathersForSchema<S>,
   }
 }

--- a/lib/react/useService.ts
+++ b/lib/react/useService.ts
@@ -1,0 +1,19 @@
+import type { FeathersClient, FeathersService } from '../adapters/feathers.js'
+import { findServiceByName } from '../core/schema.js'
+import { useFigbird } from './react.js'
+
+/**
+ * Specific to Feathers adapter. Returns an untyped Feathers service.
+ * For schema-aware service types, prefer `createHooks(figbird).useService`.
+ */
+export function useService(serviceName: string): FeathersService {
+  const figbird = useFigbird()
+  const adapter = figbird.adapter as { feathers?: FeathersClient }
+
+  if (!adapter?.feathers) {
+    throw new Error('useService must be used with a Feathers adapter')
+  }
+
+  const service = findServiceByName(figbird.schema, serviceName)
+  return adapter.feathers.service(service?.name ?? serviceName)
+}

--- a/test/figbird.test.tsx
+++ b/test/figbird.test.tsx
@@ -1,6 +1,12 @@
 import test from 'ava'
 import React, { StrictMode, useEffect, useState } from 'react'
-import type { FeathersClient, QueryResult, QueryStatus, UseMutationResult } from '../lib'
+import type {
+  FeathersClient,
+  FeathersService,
+  QueryResult,
+  QueryStatus,
+  UseMutationResult,
+} from '../lib'
 import {
   createHooks,
   createSchema,
@@ -9,6 +15,7 @@ import {
   FigbirdProvider,
   service,
   useFeathers,
+  useService as useGlobalService,
 } from '../lib'
 import { dom, mockFeathers, queueTask } from './helpers'
 
@@ -22,10 +29,14 @@ interface Note {
   _xid?: number
   _foo?: number
   version?: number
+  archived?: boolean
 }
 
 interface NoteService {
   item: Note
+  methods: {
+    archive: (id: number) => Promise<{ id: number; archived: boolean }>
+  }
 }
 
 // Create schema for typed hooks
@@ -70,7 +81,7 @@ function app({ feathers, figbird, config }: AppOptions = {}) {
     figbird || new Figbird({ schema, adapter, eventBatchProcessingInterval: 0 })
 
   // Create typed hooks from the figbird instance
-  const { useGet, useFind, useMutation } = createHooks(figbirdInstance)
+  const { useGet, useFind, useMutation, useService } = createHooks(figbirdInstance)
 
   function App({ children }: { children?: React.ReactNode }) {
     return (
@@ -82,7 +93,7 @@ function app({ feathers, figbird, config }: AppOptions = {}) {
     )
   }
 
-  return { App, useGet, useFind, useMutation, figbird: figbirdInstance, feathers }
+  return { App, useGet, useFind, useMutation, useService, figbird: figbirdInstance, feathers }
 }
 
 interface ErrorHandlerState {
@@ -202,6 +213,50 @@ test('useGet updates after realtime patch', async t => {
   })
 
   t.is($('.note')!.innerHTML, 'realtime')
+
+  unmount()
+})
+
+test('useService returns a Feathers service with CRUD and custom methods', async t => {
+  const { render, flush, unmount } = dom()
+  const { App, useService, feathers } = app()
+  type ArchiveService = FeathersService & { archive: NoteService['methods']['archive'] }
+  const notesService = feathers.service('notes') as unknown as ArchiveService
+  notesService.archive = async id => {
+    const note = (await notesService.patch(id, { archived: true })) as Note
+    return { id: note.id, archived: note.archived === true }
+  }
+
+  let typedGetResult: Note | undefined
+  let typedArchiveResult: { id: number; archived: boolean } | undefined
+  let globalGetResult: Note | undefined
+
+  function NoteServiceUser() {
+    const typedNotes = useService('notes')
+    const globalNotes = useGlobalService('notes')
+
+    useEffect(() => {
+      ;(async () => {
+        typedGetResult = await typedNotes.get(1)
+        typedArchiveResult = await typedNotes.archive(1)
+        globalGetResult = (await globalNotes.get(1)) as Note
+      })()
+    }, [globalNotes, typedNotes])
+
+    return <div>Testing service hook</div>
+  }
+
+  render(
+    <App>
+      <NoteServiceUser />
+    </App>,
+  )
+
+  await flush()
+
+  t.is(typedGetResult!.content, 'hello')
+  t.deepEqual(typedArchiveResult, { id: 1, archived: true })
+  t.true(globalGetResult!.archived)
 
   unmount()
 })

--- a/test/fixtures/typed-feathers-client.ts
+++ b/test/fixtures/typed-feathers-client.ts
@@ -57,8 +57,8 @@ const feathers = {} as FeathersClient
 const adapter = new FeathersAdapter(feathers)
 const figbird = new Figbird({ schema, adapter })
 
-// Create typed hooks including useFeathers
-const { useFeathers } = createHooks(figbird)
+// Create typed hooks including useFeathers and useService
+const { useFeathers, useService } = createHooks(figbird)
 
 // Get typed feathers client
 const typedFeathers = useFeathers()
@@ -70,6 +70,10 @@ const _notesService = typedFeathers.service('notes')
 // Get tasks service
 // oxlint-disable-next-line @typescript-eslint/no-unused-vars
 const _tasksService = typedFeathers.service('tasks')
+
+// Get typed service directly from the hook
+// oxlint-disable-next-line @typescript-eslint/no-unused-vars
+const _notesHookService = useService('notes')
 
 // ========================================
 // Type exports for CRUD methods on notes
@@ -110,9 +114,19 @@ export type NotesArchiveResult = Awaited<ReturnType<typeof _notesService.archive
 export type NotesSearchResult = Awaited<ReturnType<typeof _notesService.search>>
 
 // ========================================
+// useService hook type exports
+// ========================================
+
+export type NotesHookGetResult = Awaited<ReturnType<typeof _notesHookService.get>>
+export type NotesHookCreateResult = Awaited<ReturnType<typeof _notesHookService.create>>
+export type NotesHookArchiveResult = Awaited<ReturnType<typeof _notesHookService.archive>>
+export type NotesHookSearchResult = Awaited<ReturnType<typeof _notesHookService.search>>
+
+// ========================================
 // Test service type is correctly narrowed
 // ========================================
 
 // The typed client should narrow based on service name
 export type NotesServiceType = typeof _notesService
 export type TasksServiceType = typeof _tasksService
+export type NotesHookServiceType = typeof _notesHookService

--- a/test/typed-feathers-client.test.ts
+++ b/test/typed-feathers-client.test.ts
@@ -131,6 +131,25 @@ test('typed feathers client - search custom method returns correct type', t => {
   t.is(type, 'Note[]')
 })
 
+test('typed useService hook - CRUD methods return schema types', t => {
+  const getType = getTypeAtPosition(fixturePath, 'NotesHookGetResult')
+  const createType = getTypeAtPosition(fixturePath, 'NotesHookCreateResult')
+
+  t.is(getType, 'Note')
+  t.true(
+    createType === 'Note' || createType === 'Note[]' || createType === 'Note | Note[]',
+    `Expected Note, Note[], or Note | Note[], got: ${createType}`,
+  )
+})
+
+test('typed useService hook - custom methods return schema types', t => {
+  const archiveType = getTypeAtPosition(fixturePath, 'NotesHookArchiveResult')
+  const searchType = getTypeAtPosition(fixturePath, 'NotesHookSearchResult')
+
+  t.is(archiveType, '{ count: number; }')
+  t.is(searchType, 'Note[]')
+})
+
 // ========================================
 // Service type narrowing tests
 // ========================================
@@ -143,6 +162,7 @@ test('typed feathers client - tasks service returns Task type', t => {
 test('typed feathers client - service types are correctly narrowed and distinct', t => {
   const notesType = getTypeAtPosition(fixturePath, 'NotesServiceType')
   const tasksType = getTypeAtPosition(fixturePath, 'TasksServiceType')
+  const notesHookType = getTypeAtPosition(fixturePath, 'NotesHookServiceType')
 
   // Types should be different - each service should have its own typed methods
   t.not(notesType, tasksType, 'Notes and Tasks service types should be distinct')
@@ -152,4 +172,10 @@ test('typed feathers client - service types are correctly narrowed and distinct'
 
   // Tasks service should include Task type
   t.true(tasksType.includes('Task'), `Tasks service type should include Task, got: ${tasksType}`)
+
+  // useService should expose the same service-specific custom methods
+  t.true(
+    notesHookType.includes('archive') && notesHookType.includes('search'),
+    `useService notes type should include custom methods, got: ${notesHookType}`,
+  )
 })


### PR DESCRIPTION
## Summary
- add typed createHooks(figbird).useService with CRUD and custom method inference
- add untyped global useService hook for Feathers services
- document the new API and cover runtime/type inference behavior

## Validation
- npm run tsc
- npm run lint
- npm run ava
- npm run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `useService()` hook for accessing Feathers services directly in React components with type safety.
  * Supports complete CRUD operations and any custom service methods you've defined.
  * Service types are automatically narrowed based on your Figbird schema, enabling intelligent IDE autocomplete and compile-time type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->