### PR TITLE
Add generated schema helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ function Notes() {
 - **Fetch policies** - `swr`, `cache-first`, or `network-only` per query
 - **Full TypeScript** - define a schema once, get inference everywhere
 
+## Generated Schemas
+
+If your API contract is generated as a service map, use `defineSchemaFor` to create a typed schema from service names.
+
+```ts
+import { defineSchemaFor } from 'figbird'
+import type { ApiSchemaTypes } from './generated-api'
+
+const schema = defineSchemaFor<ApiSchemaTypes>()({
+  services: ['api/people', 'api/tasks'],
+})
+```
+
 ## Documentation
 
 Visit [humaans.github.io/figbird](https://humaans.github.io/figbird/) for full documentation and API reference.

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -50,8 +50,8 @@ import {
   Figbird,
   FeathersAdapter,
   FigbirdProvider,
-  createSchema,
-  service,
+  defineSchema,
+  defineService,
   createHooks
 } from 'figbird'
 import { feathersClient } from './feathers'
@@ -62,9 +62,9 @@ interface Note {
   content: string
 }
 
-const schema = createSchema({
+const schema = defineSchema({
   services: {
-    notes: service<{ item: Note }>(),
+    notes: defineService<{ item: Note }>(),
   },
 })
 
@@ -105,7 +105,7 @@ Figbird provides full TypeScript inference through a lightweight schema DSL. Def
 A schema declares your services and their types. Each service specifies an `item` shape, and optionally custom types for queries and mutation payloads.
 
 ```ts
-import { createSchema, service } from 'figbird'
+import { defineSchema, defineService } from 'figbird'
 
 interface Task {
   id: string
@@ -122,14 +122,29 @@ interface TaskService {
   query?: TaskQuery
 }
 
-const schema = createSchema({
+const schema = defineSchema({
   services: {
-    tasks: service<TaskService>(),
+    tasks: defineService<TaskService>(),
   },
 })
 ```
 
 Service keys are preserved as literal types - so `'api/people'` and `'tasks'` remain distinct, and all APIs narrow correctly based on the service name you pass.
+
+## Generated Schema Maps
+
+If your API contract already exists as a generated map, you can derive Figbird services from it without manually wrapping every entry in `ServiceTypeDefinition`.
+
+```ts
+import { defineSchemaFor } from 'figbird'
+import type { ApiSchemaTypes } from './generated-api'
+
+const schema = defineSchemaFor<ApiSchemaTypes>()({
+  services: ['api/people', 'api/tasks'],
+})
+```
+
+Each generated service entry should follow Figbird's service contract shape: `item` is required, while `query`, `create`, `update`, `patch`, and `methods` are optional.
 
 ## Type-Safe Hooks
 
@@ -202,9 +217,9 @@ interface NotesService {
   }
 }
 
-const schema = createSchema({
+const schema = defineSchema({
   services: {
-    notes: service<NotesService>(),
+    notes: defineService<NotesService>(),
   },
 })
 ```

--- a/lib/core/schema.ts
+++ b/lib/core/schema.ts
@@ -42,44 +42,63 @@ export interface Service<
 }
 
 // Helper types to derive payload types from service definition
-type DeriveCreate<TServiceDef extends ServiceTypeDefinition> =
-  TServiceDef['create'] extends undefined ? Partial<TServiceDef['item']> : TServiceDef['create']
+type DeriveCreate<TServiceDef extends ServiceTypeDefinition> = 'create' extends keyof TServiceDef
+  ? Exclude<TServiceDef['create'], undefined>
+  : Partial<TServiceDef['item']>
 
-type DeriveUpdate<TServiceDef extends ServiceTypeDefinition> =
-  TServiceDef['update'] extends undefined ? TServiceDef['item'] : TServiceDef['update']
+type DeriveUpdate<TServiceDef extends ServiceTypeDefinition> = 'update' extends keyof TServiceDef
+  ? Exclude<TServiceDef['update'], undefined>
+  : TServiceDef['item']
 
-type DerivePatch<TServiceDef extends ServiceTypeDefinition> = TServiceDef['patch'] extends undefined
-  ? Partial<TServiceDef['item']>
-  : TServiceDef['patch']
+type DerivePatch<TServiceDef extends ServiceTypeDefinition> = 'patch' extends keyof TServiceDef
+  ? Exclude<TServiceDef['patch'], undefined>
+  : Partial<TServiceDef['item']>
 
-type DeriveMethods<TServiceDef extends ServiceTypeDefinition> =
-  TServiceDef['methods'] extends undefined
-    ? Record<string, never>
-    : NonNullable<TServiceDef['methods']> & AnyMethodsType
+type DeriveMethods<TServiceDef extends ServiceTypeDefinition> = 'methods' extends keyof TServiceDef
+  ? Exclude<TServiceDef['methods'], undefined> & AnyMethodsType
+  : Record<string, never>
 
 type DeriveQuery<TServiceDef extends ServiceTypeDefinition> = 'query' extends keyof TServiceDef
   ? Exclude<TServiceDef['query'], undefined>
   : Record<string, unknown>
 
-// Phase 1: Create a service definition (no name yet)
-export function service<TServiceDef extends ServiceTypeDefinition>(): Service<
+type ServiceDefinitions<TServiceDefs> = {
+  [K in keyof TServiceDefs]: ServiceTypeDefinition
+}
+
+type ServiceFromDefinition<
+  TServiceDef extends ServiceTypeDefinition,
+  TName extends string = string,
+> = Service<
   TServiceDef['item'],
   DeriveQuery<TServiceDef>,
-  string,
+  TName,
   DeriveCreate<TServiceDef>,
   DeriveUpdate<TServiceDef>,
   DerivePatch<TServiceDef>,
   DeriveMethods<TServiceDef>
-> {
-  return { name: '' } as Service<
-    TServiceDef['item'],
-    DeriveQuery<TServiceDef>,
-    string,
-    DeriveCreate<TServiceDef>,
-    DeriveUpdate<TServiceDef>,
-    DerivePatch<TServiceDef>,
-    DeriveMethods<TServiceDef>
-  >
+>
+
+type ServiceMapFromDefinitions<
+  TServiceDefs extends ServiceDefinitions<TServiceDefs>,
+  TServiceName extends keyof TServiceDefs & string,
+> = {
+  readonly [K in TServiceName]: ServiceFromDefinition<TServiceDefs[K], K>
+}
+
+type DefineSchemaFor<TServiceDefs extends ServiceDefinitions<TServiceDefs>> = <
+  const TServiceNames extends readonly (keyof TServiceDefs & string)[],
+>(config: {
+  services: TServiceNames
+}) => {
+  services: ServiceMapFromDefinitions<TServiceDefs, TServiceNames[number]>
+}
+
+// Phase 1: Create a service definition (no name yet)
+export function defineService<
+  TServiceDef extends ServiceTypeDefinition,
+>(): ServiceFromDefinition<TServiceDef> {
+  return { name: '' } as ServiceFromDefinition<TServiceDef>
 }
 
 // Base schema interface - flexible to preserve specific service types
@@ -102,7 +121,7 @@ type ExtractServiceWithName<S, N extends string> =
     : never
 
 // Phase 2: Create a schema with services object map (preserves literal keys)
-export function createSchema<
+export function defineSchema<
   const TServiceMap extends Record<string, Service<unknown, unknown, string>>,
 >(config: {
   services: TServiceMap
@@ -118,6 +137,26 @@ export function createSchema<
     readonly [K in keyof TServiceMap]: ExtractServiceWithName<TServiceMap[K], K & string>
   }
   return { services: serviceMap }
+}
+
+// Create a schema directly from a generated service contract map
+export function defineSchemaFor<
+  const TServiceDefs extends ServiceDefinitions<TServiceDefs>,
+>(): DefineSchemaFor<TServiceDefs> {
+  return (<const TServiceNames extends readonly (keyof TServiceDefs & string)[]>(config: {
+    services: TServiceNames
+  }) => {
+    const services = Object.fromEntries(
+      config.services.map(name => [
+        name,
+        { name } as ServiceFromDefinition<TServiceDefs[typeof name], typeof name>,
+      ]),
+    ) as unknown as ServiceMapFromDefinitions<TServiceDefs, TServiceNames[number]>
+
+    return defineSchema({ services }) as {
+      services: ServiceMapFromDefinitions<TServiceDefs, TServiceNames[number]>
+    }
+  }) as DefineSchemaFor<TServiceDefs>
 }
 
 // Type helpers to extract types from schema

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,7 +4,7 @@ export { Figbird } from './core/figbird.js'
 export type { EventType } from './core/figbird.js'
 
 // schema
-export { createSchema, service } from './core/schema.js'
+export { defineSchema, defineSchemaFor, defineService } from './core/schema.js'
 export type {
   AnySchema,
   Create,

--- a/test/figbird-instance.test.ts
+++ b/test/figbird-instance.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { FeathersAdapter } from '../lib/adapters/feathers'
 import { Figbird } from '../lib/core/figbird'
-import { createSchema, service } from '../lib/core/schema'
+import { defineSchema, defineService } from '../lib/core/schema'
 import { mockFeathers } from './helpers'
 
 interface Note {
@@ -18,10 +18,10 @@ interface Post {
   updatedAt?: number
 }
 
-const schema = createSchema({
+const schema = defineSchema({
   services: {
-    notes: service<{ item: Note }>(),
-    posts: service<{ item: Post }>(),
+    notes: defineService<{ item: Note }>(),
+    posts: defineService<{ item: Post }>(),
   },
 })
 

--- a/test/figbird.test.tsx
+++ b/test/figbird.test.tsx
@@ -3,11 +3,11 @@ import React, { StrictMode, useEffect, useState } from 'react'
 import type { FeathersClient, QueryResult, QueryStatus, UseMutationResult } from '../lib'
 import {
   createHooks,
-  createSchema,
+  defineSchema,
   FeathersAdapter,
   Figbird,
   FigbirdProvider,
-  service,
+  defineService,
   useFeathers,
 } from '../lib'
 import { dom, mockFeathers, queueTask } from './helpers'
@@ -29,9 +29,9 @@ interface NoteService {
 }
 
 // Create schema for typed hooks
-const schema = createSchema({
+const schema = defineSchema({
   services: {
-    notes: service<NoteService>(),
+    notes: defineService<NoteService>(),
   },
 })
 

--- a/test/fixtures/figbird-methods-inference.ts
+++ b/test/fixtures/figbird-methods-inference.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable @typescript-eslint/no-unused-vars */
 import type { FeathersClient } from '../../lib'
-import { FeathersAdapter, Figbird, createSchema, service } from '../../lib'
+import { FeathersAdapter, Figbird, defineSchema, defineService } from '../../lib'
 
 // Define a simple Person model
 interface Person {
@@ -14,9 +14,9 @@ interface PersonService {
 }
 
 // Build schema with a single service
-const schema = createSchema({
+const schema = defineSchema({
   services: {
-    'api/people': service<PersonService>(),
+    'api/people': defineService<PersonService>(),
   },
 })
 

--- a/test/fixtures/generated-schema-helpers.ts
+++ b/test/fixtures/generated-schema-helpers.ts
@@ -1,0 +1,78 @@
+import type { FeathersClient } from '../../lib'
+import {
+  createHooks,
+  defineSchemaFor,
+  FeathersAdapter,
+  Figbird,
+  type ServiceCreate,
+  type ServiceItem,
+  type ServicePatch,
+  type ServiceQuery,
+} from '../../lib'
+
+interface Person {
+  id: string
+  name: string
+  status: 'active' | 'inactive'
+}
+
+interface PersonCreate {
+  name: string
+}
+
+interface PersonPatch {
+  status?: Person['status']
+}
+
+interface PersonQuery {
+  status?: Person['status']
+  $search?: string
+}
+
+interface Task {
+  id: string
+  title: string
+  done: boolean
+}
+
+interface GeneratedApiSchemaTypes {
+  'api/people': {
+    item: Person
+    create: PersonCreate
+    patch: PersonPatch
+    query: PersonQuery
+  }
+  'api/tasks': {
+    item: Task
+  }
+}
+
+export const schemaFromNames = defineSchemaFor<GeneratedApiSchemaTypes>()({
+  services: ['api/people', 'api/tasks'],
+})
+
+type AppSchema = typeof schemaFromNames
+
+const feathers = {} as FeathersClient
+const adapter = new FeathersAdapter(feathers)
+const figbird = new Figbird({ schema: schemaFromNames, adapter })
+const { useFind, useMutation } = createHooks(figbird)
+
+export type PeopleItem = ServiceItem<AppSchema, 'api/people'>
+export type PeopleQuery = ServiceQuery<AppSchema, 'api/people'>
+export type PeopleCreate = ServiceCreate<AppSchema, 'api/people'>
+export type PeoplePatch = ServicePatch<AppSchema, 'api/people'>
+export type TaskCreate = ServiceCreate<AppSchema, 'api/tasks'>
+export type PeopleService = (typeof schemaFromNames.services)['api/people']
+
+export const people = useFind('api/people', {
+  query: {
+    status: 'active',
+    $search: 'Ada',
+  },
+})
+
+const { create, patch } = useMutation('api/people')
+
+export const createdPerson = create({ name: 'Ada' })
+export const patchedPerson = patch('person-1', { status: 'inactive' })

--- a/test/fixtures/inferred-meta-from-figbird.ts
+++ b/test/fixtures/inferred-meta-from-figbird.ts
@@ -4,7 +4,7 @@
  */
 
 import type { FeathersClient } from '../../lib'
-import { createHooks, createSchema, FeathersAdapter, Figbird, service } from '../../lib'
+import { createHooks, defineSchema, FeathersAdapter, Figbird, defineService } from '../../lib'
 
 // Define domain types
 interface Task {
@@ -30,10 +30,10 @@ interface ProjectService {
 }
 
 // Create schema
-const schema = createSchema({
+const schema = defineSchema({
   services: {
-    tasks: service<TaskService>(),
-    projects: service<ProjectService>(),
+    tasks: defineService<TaskService>(),
+    projects: defineService<ProjectService>(),
   },
 })
 

--- a/test/fixtures/multi-service-inference.ts
+++ b/test/fixtures/multi-service-inference.ts
@@ -1,10 +1,10 @@
 import type { FeathersClient } from '../../lib'
 import {
   createHooks,
-  createSchema,
+  defineSchema,
   FeathersAdapter,
   Figbird,
-  service,
+  defineService,
   type ServiceItem,
 } from '../../lib'
 
@@ -32,10 +32,10 @@ interface TaskService {
   item: Task
 }
 
-export const schema = createSchema({
+export const schema = defineSchema({
   services: {
-    'api/people': service<PersonService>(),
-    'api/tasks': service<TaskService>(),
+    'api/people': defineService<PersonService>(),
+    'api/tasks': defineService<TaskService>(),
   },
 })
 

--- a/test/fixtures/optional-query-inference.ts
+++ b/test/fixtures/optional-query-inference.ts
@@ -1,4 +1,4 @@
-import { createSchema, service } from '../../lib'
+import { defineSchema, defineService } from '../../lib'
 
 interface Task {
   id: string
@@ -16,9 +16,9 @@ interface TaskServiceDefinition {
   query?: TaskQuery
 }
 
-export const schema = createSchema({
+export const schema = defineSchema({
   services: {
-    tasks: service<TaskServiceDefinition>(),
+    tasks: defineService<TaskServiceDefinition>(),
   },
 })
 

--- a/test/fixtures/params-type-inference.ts
+++ b/test/fixtures/params-type-inference.ts
@@ -7,7 +7,7 @@
  */
 
 import type { FeathersClient } from '../../lib'
-import { createHooks, createSchema, FeathersAdapter, Figbird, service } from '../../lib'
+import { createHooks, defineSchema, FeathersAdapter, Figbird, defineService } from '../../lib'
 
 // Define a model
 interface Product {
@@ -24,9 +24,9 @@ interface ProductService {
 }
 
 // Create schema
-const schema = createSchema({
+const schema = defineSchema({
   services: {
-    products: service<ProductService>(),
+    products: defineService<ProductService>(),
   },
 })
 

--- a/test/fixtures/real-world-meta-usage.ts
+++ b/test/fixtures/real-world-meta-usage.ts
@@ -4,7 +4,7 @@
  */
 
 import type { FeathersClient } from '../../lib'
-import { createHooks, createSchema, FeathersAdapter, Figbird, service } from '../../lib'
+import { createHooks, defineSchema, FeathersAdapter, Figbird, defineService } from '../../lib'
 
 // Define domain models
 interface Article {
@@ -33,10 +33,10 @@ interface CommentService {
 }
 
 // Create schema with services
-const schema = createSchema({
+const schema = defineSchema({
   services: {
-    articles: service<ArticleService>(),
-    comments: service<CommentService>(),
+    articles: defineService<ArticleService>(),
+    comments: defineService<CommentService>(),
   },
 })
 

--- a/test/fixtures/typed-feathers-client.ts
+++ b/test/fixtures/typed-feathers-client.ts
@@ -1,5 +1,5 @@
 import type { FeathersClient } from '../../lib'
-import { createHooks, createSchema, FeathersAdapter, Figbird, service } from '../../lib'
+import { createHooks, defineSchema, FeathersAdapter, Figbird, defineService } from '../../lib'
 
 // Test typed Feathers client with CRUD methods
 interface Note {
@@ -45,10 +45,10 @@ interface TaskService {
   item: Task
 }
 
-export const schema = createSchema({
+export const schema = defineSchema({
   services: {
-    notes: service<NotesService>(),
-    tasks: service<TaskService>(),
+    notes: defineService<NotesService>(),
+    tasks: defineService<TaskService>(),
   },
 })
 

--- a/test/locked-query.test.tsx
+++ b/test/locked-query.test.tsx
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { FeathersAdapter } from '../lib/adapters/feathers.js'
 import { Figbird } from '../lib/core/figbird.js'
-import { createSchema, service } from '../lib/core/schema.js'
+import { defineSchema, defineService } from '../lib/core/schema.js'
 import { createHooks } from '../lib/react/createHooks.js'
 import { FigbirdProvider } from '../lib/react/react.js'
 import { dom, mockFeathers } from './helpers.js'
@@ -48,17 +48,17 @@ interface Note {
 }
 
 test('locked-down query types work correctly', async t => {
-  const schema = createSchema({
+  const schema = defineSchema({
     services: {
-      people: service<{
+      people: defineService<{
         item: Person
         query: StrictQuery
       }>(),
-      todos: service<{
+      todos: defineService<{
         item: Todo
         query: PaginatedQuery
       }>(),
-      notes: service<{
+      notes: defineService<{
         item: Note
         query: MinimalQuery
       }>(),
@@ -176,9 +176,9 @@ test('locked-down query types work correctly', async t => {
 // The server will reject invalid query fields if someone bypasses TypeScript
 
 test('allPages works correctly with proper pagination fields', async t => {
-  const schema = createSchema({
+  const schema = defineSchema({
     services: {
-      todos: service<{
+      todos: defineService<{
         item: Todo
         query: PaginatedQuery
       }>(),
@@ -236,9 +236,9 @@ test('allPages works correctly with proper pagination fields', async t => {
 test('React hooks work with locked-down query types', async t => {
   const { $all, render, unmount, flush } = dom()
 
-  const schema = createSchema({
+  const schema = defineSchema({
     services: {
-      people: service<{
+      people: defineService<{
         item: Person
         query: StrictQuery
       }>(),

--- a/test/matcher-types.test.tsx
+++ b/test/matcher-types.test.tsx
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { FeathersAdapter } from '../lib/adapters/feathers.js'
 import { Figbird } from '../lib/core/figbird.js'
-import { createSchema, service } from '../lib/core/schema.js'
+import { defineSchema, defineService } from '../lib/core/schema.js'
 import { createHooks } from '../lib/react/createHooks.js'
 import { FigbirdProvider } from '../lib/react/react.js'
 import { dom, mockFeathers } from './helpers.js'
@@ -38,13 +38,13 @@ interface User {
 }
 
 test('matcher receives properly typed query from schema', async t => {
-  const schema = createSchema({
+  const schema = defineSchema({
     services: {
-      todos: service<{
+      todos: defineService<{
         item: Todo
         query: TodoQuery
       }>(),
-      users: service<{
+      users: defineService<{
         item: User
         query: UserQuery
       }>(),
@@ -159,9 +159,9 @@ test('matcher receives properly typed query from schema', async t => {
 test('React hooks provide typed query in matcher', async t => {
   const { render, unmount, flush } = dom()
 
-  const schema = createSchema({
+  const schema = defineSchema({
     services: {
-      todos: service<{
+      todos: defineService<{
         item: Todo
         query: TodoQuery
       }>(),
@@ -250,9 +250,9 @@ test('React hooks provide typed query in matcher', async t => {
 })
 
 test('matcher with undefined query works correctly', async t => {
-  const schema = createSchema({
+  const schema = defineSchema({
     services: {
-      items: service<{
+      items: defineService<{
         item: { id: string; name: string }
         query: { search?: string }
       }>(),

--- a/test/schema.test.tsx
+++ b/test/schema.test.tsx
@@ -2,11 +2,11 @@ import test from 'ava'
 import { useEffect, useState } from 'react'
 import {
   createHooks,
-  createSchema,
+  defineSchema,
   FeathersAdapter,
   Figbird,
   FigbirdProvider,
-  service,
+  defineService,
   useFigbird,
   useFind as useUntypedFind,
   useGet as useUntypedGet,
@@ -63,11 +63,11 @@ interface ProjectService {
 }
 
 // Define schema with typed services
-const schema = createSchema({
+const schema = defineSchema({
   services: {
-    'api/people': service<PersonService>(),
-    'api/tasks': service<TaskService>(),
-    'api/projects': service<ProjectService>(),
+    'api/people': defineService<PersonService>(),
+    'api/tasks': defineService<TaskService>(),
+    'api/projects': defineService<ProjectService>(),
   },
 })
 
@@ -305,10 +305,10 @@ test('schema with array of services', t => {
   const { render, unmount, flush, $ } = dom()
 
   // Services are defined in an object map
-  const schema = createSchema({
+  const schema = defineSchema({
     services: {
-      'api/people': service<PersonService>(),
-      'api/tasks': service<TaskService>(),
+      'api/people': defineService<PersonService>(),
+      'api/tasks': defineService<TaskService>(),
     },
   })
 

--- a/test/type-inference.test.ts
+++ b/test/type-inference.test.ts
@@ -219,3 +219,28 @@ test('optional query definitions are inferred', t => {
 
   t.is(taskQueryType, 'TaskQuery')
 })
+
+test('generated schema helpers infer service contracts without intersections', t => {
+  const fixturePath = join(__dirname, 'fixtures', 'generated-schema-helpers.ts')
+
+  const peopleItemType = getTypeAtPosition(fixturePath, 'PeopleItem')
+  const peopleQueryType = getTypeAtPosition(fixturePath, 'PeopleQuery')
+  const peopleCreateType = getTypeAtPosition(fixturePath, 'PeopleCreate')
+  const peoplePatchType = getTypeAtPosition(fixturePath, 'PeoplePatch')
+  const taskCreateType = getTypeAtPosition(fixturePath, 'TaskCreate')
+  const peopleServiceType = getTypeAtPosition(fixturePath, 'PeopleService')
+  const peopleType = getTypeAtPosition(fixturePath, 'people')
+
+  t.is(peopleItemType, 'Person')
+  t.is(peopleQueryType, 'PersonQuery')
+  t.is(peopleCreateType, 'PersonCreate')
+  t.is(peoplePatchType, 'PersonPatch')
+  t.is(taskCreateType, 'Partial<Task>')
+  t.true(
+    peopleServiceType.startsWith(
+      'import("figbird").Service<Person, PersonQuery, "api/people", PersonCreate',
+    ),
+    `Expected defineSchemaFor to preserve the generated service contract, got: ${peopleServiceType}`,
+  )
+  t.is(peopleType, 'import("figbird").QueryResult<Person[], import("figbird").FeathersFindMeta>')
+})


### PR DESCRIPTION
## Summary
- replace the schema DSL exports with defineService, defineSchema, and defineSchemaFor
- add defineSchemaFor for deriving Figbird schemas from generated service contract maps
- document generated schema usage and add type inference coverage

## Tests
- npm run tsc
- npm run lint
- npm run ava
- npm run test