### PR TITLE
Add query state helper exports

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -293,6 +293,8 @@ const notes = useFind('notes') // QueryResult<Note[], FindMeta>
 - `error` - error object if request failed
 - `refetch` - function to refetch data
 
+Use `isPending(query)`, `isFetching(query)`, `isLoading(query)`, and `isIdle(query)` to make the two-axis state model explicit. `status` tells you whether a usable result exists (`loading`, `success`, or `error`); `isFetching` tells you whether a request is currently in flight. A skipped query is `loading` with `isFetching: false`.
+
 ## useMutation
 
 Provides methods to create, update, patch, and remove resources. Mutations automatically update the cache, so all components using related queries re-render with fresh data.

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -39,7 +39,28 @@ export interface QueuedEvent {
   items: unknown[]
 }
 
-export type QueryStatus = 'idle' | 'loading' | 'success' | 'error'
+export type QueryStatus = 'loading' | 'success' | 'error'
+
+type QueryStatusState = {
+  status: QueryStatus
+  isFetching: boolean
+}
+
+export function isPending(query: QueryStatusState): boolean {
+  return query.status === 'loading'
+}
+
+export function isFetching(query: QueryStatusState): boolean {
+  return query.isFetching
+}
+
+export function isLoading(query: QueryStatusState): boolean {
+  return query.status === 'loading' && query.isFetching
+}
+
+export function isIdle(query: QueryStatusState): boolean {
+  return query.status === 'loading' && !query.isFetching
+}
 
 /**
  * Query state representation - discriminated union for better type safety

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 // core
-export { Figbird } from './core/figbird.js'
+export { Figbird, isFetching, isIdle, isLoading, isPending } from './core/figbird.js'
 
 export type { EventType } from './core/figbird.js'
 

--- a/test/query-state-helpers.test.ts
+++ b/test/query-state-helpers.test.ts
@@ -1,0 +1,61 @@
+import test from 'ava'
+import { isFetching, isIdle, isLoading, isPending } from '../lib'
+import type { QueryResult, QueryState } from '../lib'
+
+test('query state helpers identify pending active loading state', t => {
+  const query = {
+    status: 'loading' as const,
+    isFetching: true,
+  }
+
+  t.true(isPending(query))
+  t.true(isFetching(query))
+  t.true(isLoading(query))
+  t.false(isIdle(query))
+})
+
+test('query state helpers identify pending idle state', t => {
+  const query = {
+    status: 'loading' as const,
+    isFetching: false,
+  }
+
+  t.true(isPending(query))
+  t.false(isFetching(query))
+  t.false(isLoading(query))
+  t.true(isIdle(query))
+})
+
+test('query state helpers identify successful background fetch state', t => {
+  const query = {
+    status: 'success' as const,
+    isFetching: true,
+  }
+
+  t.false(isPending(query))
+  t.true(isFetching(query))
+  t.false(isLoading(query))
+  t.false(isIdle(query))
+})
+
+test('query state helpers accept QueryState and QueryResult shapes', t => {
+  const state: QueryState<string[]> = {
+    status: 'success',
+    data: ['hello'],
+    meta: {},
+    isFetching: false,
+    error: null,
+  }
+  const result: QueryResult<string[]> = {
+    status: 'error',
+    data: null,
+    isFetching: false,
+    error: new Error('boom'),
+    refetch: () => {},
+  }
+
+  t.false(isPending(state))
+  t.false(isFetching(state))
+  t.false(isLoading(result))
+  t.false(isIdle(result))
+})


### PR DESCRIPTION
## Summary
- add public isPending, isFetching, isLoading, and isIdle helpers for query states
- keep query statuses to loading/success/error and make skipped queries explicit as pending idle
- add focused helper tests and concise docs note

## Validation
- npm run tsc
- npm run lint
- npm run ava
- npm run test