### PR TITLE
Add typed useMethod hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ const figbird = new Figbird({
   adapter: new FeathersAdapter(feathersClient),
 })
 
-export const { useFind, useGet, useMutation, useService } = createHooks(figbird)
+export const { useFind, useGet, useMutation, useService, useMethod } = createHooks(figbird)
 
 function App() {
   return (
@@ -39,6 +39,19 @@ function Notes() {
     </div>
   ))
 }
+
+function SendDocumentButton({ id }: { id: string }) {
+  const [requestSendDocument, { status, data, error }] = useMethod(
+    'api/esign-instances',
+    'requestSendDocument',
+  )
+
+  return (
+    <button disabled={status === 'loading'} onClick={() => requestSendDocument(id)}>
+      {data ? 'Sent' : error ? `Retry: ${error.message}` : 'Send'}
+    </button>
+  )
+}
 ```
 
 `useService('notes')` returns the Feathers service for that schema service. When you create hooks
@@ -51,6 +64,7 @@ includes typed CRUD methods plus any custom methods declared in the schema.
 - **Shared cache** - same data across components, always consistent
 - **Realtime built-in** - Feathers websocket events update your UI automatically
 - **Fetch policies** - `swr`, `cache-first`, or `network-only` per query
+- **Custom methods** - typed service method calls with `status`, `data`, `error`, and `reset`
 - **Full TypeScript** - define a schema once, get inference everywhere
 
 ## Generated Schemas

--- a/lib/core/schema.ts
+++ b/lib/core/schema.ts
@@ -55,8 +55,10 @@ type DerivePatch<TServiceDef extends ServiceTypeDefinition> = 'patch' extends ke
   : Partial<TServiceDef['item']>
 
 type DeriveMethods<TServiceDef extends ServiceTypeDefinition> = 'methods' extends keyof TServiceDef
-  ? Exclude<TServiceDef['methods'], undefined> & AnyMethodsType
-  : Record<string, never>
+  ? Exclude<TServiceDef['methods'], undefined> extends infer M extends AnyMethodsType
+    ? M
+    : Record<never, never>
+  : Record<never, never>
 
 type DeriveQuery<TServiceDef extends ServiceTypeDefinition> = 'query' extends keyof TServiceDef
   ? Exclude<TServiceDef['query'], undefined>

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -44,6 +44,7 @@ export type {
 export { createHooks } from './react/createHooks.js'
 export { FigbirdProvider, useFigbird } from './react/react.js'
 export { useFeathers } from './react/useFeathers.js'
+export { useMethod } from './react/useMethod.js'
 export { useMutation } from './react/useMutation.js'
 export { useFind, useGet } from './react/useQuery.js'
 export { useService } from './react/useService.js'
@@ -58,6 +59,12 @@ export type {
 } from './core/figbird.js'
 
 // React hook result types (already exported but let's be complete)
+export type {
+  UseMethodCall,
+  UseMethodResult,
+  UseMethodState,
+  UseMethodStatus,
+} from './react/useMethod.js'
 export type { UseMutationResult } from './react/useMutation.js'
 export type { QueryResult } from './react/useQuery.js'
 

--- a/lib/react/createHooks.ts
+++ b/lib/react/createHooks.ts
@@ -16,6 +16,7 @@ import type {
   ServiceUpdate,
 } from '../core/schema.js'
 import { findServiceByName } from '../core/schema.js'
+import { useMethod as useBaseMethod, type UseMethodResult } from './useMethod.js'
 import { useMutation as useBaseMutation, type UseMutationResult } from './useMutation.js'
 import { useQuery, type QueryResult } from './useQuery.js'
 
@@ -69,6 +70,24 @@ type UseServiceForSchema<S extends Schema> = <N extends ServiceNames<S>>(
   serviceName: N,
 ) => TypedServiceForSchema<S, N>
 
+type MethodArgs<TMethod> = TMethod extends (...args: infer TArgs extends unknown[]) => unknown
+  ? TArgs
+  : never
+
+type MethodData<TMethod> = TMethod extends (...args: infer TArgs extends unknown[]) => infer TResult
+  ? TArgs extends unknown[]
+    ? Awaited<TResult>
+    : never
+  : never
+
+type UseMethodForSchema<S extends Schema> = <
+  N extends ServiceNames<S>,
+  M extends keyof ServiceMethods<S, N> & string,
+>(
+  serviceName: N,
+  methodName: M,
+) => UseMethodResult<MethodArgs<ServiceMethods<S, N>[M]>, MethodData<ServiceMethods<S, N>[M]>>
+
 type UseFeathersForSchema<S extends Schema> = () => TypedFeathersClient<S>
 
 // Type helper to extract schema and adapter types from a Figbird instance
@@ -106,6 +125,7 @@ export function createHooks<F extends Figbird<any, any>>(
   useFind: UseFindForSchema<InferSchema<F>, InferParams<F>, InferMeta<F>>
   useMutation: UseMutationForSchema<InferSchema<F>>
   useService: UseServiceForSchema<InferSchema<F>>
+  useMethod: UseMethodForSchema<InferSchema<F>>
   useFeathers: UseFeathersForSchema<InferSchema<F>>
 } {
   type S = InferSchema<F>
@@ -168,6 +188,18 @@ export function createHooks<F extends Figbird<any, any>>(
     return useTypedFeathers().service(actualServiceName as N)
   }
 
+  function useTypedMethod<N extends ServiceNames<S>, M extends keyof ServiceMethods<S, N> & string>(
+    serviceName: N,
+    methodName: M,
+  ) {
+    const service = findServiceByName(figbird.schema, serviceName)
+    const actualServiceName = service?.name ?? serviceName
+    return useBaseMethod<MethodArgs<ServiceMethods<S, N>[M]>, MethodData<ServiceMethods<S, N>[M]>>(
+      actualServiceName,
+      methodName,
+    )
+  }
+
   function useTypedFeathers() {
     const adapter = figbird.adapter as { feathers?: FeathersClient }
     if (!adapter?.feathers) {
@@ -183,6 +215,7 @@ export function createHooks<F extends Figbird<any, any>>(
     useFind: useTypedFind as UseFindForSchema<S, TParams, TMeta>,
     useMutation: useTypedMutation as UseMutationForSchema<S>,
     useService: useTypedService as UseServiceForSchema<S>,
+    useMethod: useTypedMethod as UseMethodForSchema<S>,
     useFeathers: useTypedFeathers as UseFeathersForSchema<S>,
   }
 }

--- a/lib/react/useMethod.ts
+++ b/lib/react/useMethod.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
+import { findServiceByName } from '../core/schema.js'
+import { useFigbird } from './react.js'
+
+export type UseMethodStatus = 'idle' | 'loading' | 'success' | 'error'
+
+export interface UseMethodState<TResult = unknown> {
+  status: UseMethodStatus
+  data: TResult | null
+  error: Error | null
+  reset: () => void
+}
+
+interface MethodState<TResult> {
+  status: UseMethodStatus
+  data: TResult | null
+  error: Error | null
+}
+
+type MethodAction<TResult> =
+  | { type: 'calling' }
+  | { type: 'success'; payload: TResult }
+  | { type: 'error'; payload: Error }
+  | { type: 'reset' }
+
+export type UseMethodCall<TArgs extends unknown[] = unknown[], TResult = unknown> = (
+  ...args: TArgs
+) => Promise<TResult>
+
+export type UseMethodResult<TArgs extends unknown[] = unknown[], TResult = unknown> = readonly [
+  UseMethodCall<TArgs, TResult>,
+  UseMethodState<TResult>,
+]
+
+const initialMethodState = {
+  status: 'idle',
+  data: null,
+  error: null,
+} satisfies MethodState<unknown>
+
+/**
+ * Calls an arbitrary service method and tracks local UI lifecycle state.
+ * This does not apply CRUD cache updates. For typed custom methods, prefer
+ * the `useMethod` returned by `createHooks(figbird)`.
+ */
+export function useMethod<TArgs extends unknown[] = unknown[], TResult = unknown>(
+  serviceName: string,
+  methodName: string,
+): UseMethodResult<TArgs, TResult> {
+  const figbird = useFigbird()
+  const service = findServiceByName(figbird.schema, serviceName)
+  const actualServiceName = service?.name ?? serviceName
+
+  const [state, dispatch] = useReducer(methodReducer<TResult>, initialMethodState)
+
+  const mountedRef = useRef(false)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  const call = useCallback(
+    async (...args: TArgs): Promise<TResult> => {
+      dispatch({ type: 'calling' })
+      try {
+        const result = (await figbird.adapter.mutate(
+          actualServiceName,
+          methodName,
+          args,
+        )) as TResult
+        if (mountedRef.current) {
+          dispatch({ type: 'success', payload: result })
+        }
+        return result
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err))
+        if (mountedRef.current) {
+          dispatch({ type: 'error', payload: error })
+        }
+        throw error
+      }
+    },
+    [actualServiceName, figbird.adapter, methodName],
+  )
+
+  const reset = useCallback(() => {
+    dispatch({ type: 'reset' })
+  }, [])
+
+  return useMemo(
+    () =>
+      [
+        call,
+        {
+          status: state.status,
+          data: state.data,
+          error: state.error,
+          reset,
+        },
+      ] as const,
+    [call, reset, state],
+  )
+}
+
+function methodReducer<TResult>(
+  state: MethodState<TResult>,
+  action: MethodAction<TResult>,
+): MethodState<TResult> {
+  switch (action.type) {
+    case 'calling':
+      return { ...state, status: 'loading', data: null, error: null }
+    case 'success':
+      return { ...state, status: 'success', data: action.payload, error: null }
+    case 'error':
+      return { ...state, status: 'error', data: null, error: action.payload }
+    case 'reset':
+      return { status: 'idle', data: null, error: null }
+    default:
+      return state
+  }
+}

--- a/test/figbird.test.tsx
+++ b/test/figbird.test.tsx
@@ -5,6 +5,7 @@ import type {
   FeathersService,
   QueryResult,
   QueryStatus,
+  UseMethodResult,
   UseMutationResult,
 } from '../lib'
 import {
@@ -36,6 +37,10 @@ interface NoteService {
   item: Note
   methods: {
     archive: (id: number) => Promise<{ id: number; archived: boolean }>
+    requestSendDocument: (
+      id: number,
+      payload: { message: string },
+    ) => Promise<{ id: number; message: string; queued: boolean }>
   }
 }
 
@@ -81,7 +86,7 @@ function app({ feathers, figbird, config }: AppOptions = {}) {
     figbird || new Figbird({ schema, adapter, eventBatchProcessingInterval: 0 })
 
   // Create typed hooks from the figbird instance
-  const { useGet, useFind, useMutation, useService } = createHooks(figbirdInstance)
+  const { useGet, useFind, useMutation, useService, useMethod } = createHooks(figbirdInstance)
 
   function App({ children }: { children?: React.ReactNode }) {
     return (
@@ -93,7 +98,16 @@ function app({ feathers, figbird, config }: AppOptions = {}) {
     )
   }
 
-  return { App, useGet, useFind, useMutation, useService, figbird: figbirdInstance, feathers }
+  return {
+    App,
+    useGet,
+    useFind,
+    useMutation,
+    useService,
+    useMethod,
+    figbird: figbirdInstance,
+    feathers,
+  }
 }
 
 interface ErrorHandlerState {
@@ -635,6 +649,89 @@ test('useMutation handles errors', async t => {
   t.is($('.error')!.innerHTML, 'unexpected')
 
   t.is(handled, 'unexpected')
+
+  unmount()
+})
+
+test('useMethod tracks status, data, error, and reset without cache updates', async t => {
+  const { render, flush, unmount, $ } = dom()
+  const { App, useMethod, figbird, feathers } = app()
+  const notesService = feathers.service('notes') as ReturnType<typeof feathers.service> & {
+    requestSendDocument: (
+      id: number,
+      payload: { message: string },
+    ) => Promise<{ id: number; message: string; queued: boolean }>
+  }
+
+  let resolveRequest: (value: { id: number; message: string; queued: boolean }) => void = () => {}
+  notesService.requestSendDocument = (id, payload) => {
+    if (payload.message === 'fail') {
+      return Promise.reject(new Error('request failed'))
+    }
+    return new Promise(resolve => {
+      resolveRequest = resolve
+    }).then(() => ({ id, message: payload.message, queued: true }))
+  }
+
+  let call: UseMethodResult<
+    [number, { message: string }],
+    { id: number; message: string; queued: boolean }
+  >[0]
+  let reset: UseMethodResult[1]['reset']
+
+  function NoteMethod() {
+    const [requestSendDocument, request] = useMethod('notes', 'requestSendDocument')
+    call = requestSendDocument
+    reset = request.reset
+
+    return (
+      <>
+        <div className='status'>{request.status}</div>
+        <div className='data'>{request.data?.message ?? ''}</div>
+        <div className='error'>{request.error?.message ?? ''}</div>
+      </>
+    )
+  }
+
+  render(
+    <App>
+      <NoteMethod />
+    </App>,
+  )
+
+  t.is($('.status')!.innerHTML, 'idle')
+  t.is(figbird.getState().get('notes')?.entities.get(1), undefined)
+
+  let result: Promise<{ id: number; message: string; queued: boolean }>
+  await flush(async () => {
+    result = call(1, { message: 'please sign' })
+    await Promise.resolve()
+  })
+
+  t.is($('.status')!.innerHTML, 'loading')
+  t.is($('.data')!.innerHTML, '')
+
+  await flush(async () => {
+    resolveRequest({ id: 1, message: 'please sign', queued: true })
+    await result
+  })
+
+  t.is($('.status')!.innerHTML, 'success')
+  t.is($('.data')!.innerHTML, 'please sign')
+  t.is(figbird.getState().get('notes')?.entities.get(1), undefined)
+
+  await flush(() => reset())
+  t.is($('.status')!.innerHTML, 'idle')
+  t.is($('.data')!.innerHTML, '')
+  t.is($('.error')!.innerHTML, '')
+
+  await flush(async () => {
+    await call(1, { message: 'fail' }).catch(() => {})
+  })
+
+  t.is($('.status')!.innerHTML, 'error')
+  t.is($('.data')!.innerHTML, '')
+  t.is($('.error')!.innerHTML, 'request failed')
 
   unmount()
 })

--- a/test/fixtures/use-method-inference.ts
+++ b/test/fixtures/use-method-inference.ts
@@ -1,0 +1,68 @@
+import type { FeathersClient } from '../../lib'
+import { createHooks, defineSchema, defineService, FeathersAdapter, Figbird } from '../../lib'
+
+interface EsignInstance {
+  id: string
+  status: 'draft' | 'sent'
+}
+
+interface SendDocumentOptions {
+  notifySigner?: boolean
+}
+
+interface SendDocumentResult {
+  id: string
+  status: 'sent'
+  sentAt: string
+}
+
+interface EsignInstanceService {
+  item: EsignInstance
+  methods: {
+    requestSendDocument: (id: string, options?: SendDocumentOptions) => Promise<SendDocumentResult>
+    voidDocument: (id: string, reason: string) => Promise<{ id: string; voided: true }>
+  }
+}
+
+interface MessageService {
+  item: { id: string; body: string }
+  methods: {
+    sendMessage: (body: string) => Promise<{ id: string }>
+  }
+}
+
+const schema = defineSchema({
+  services: {
+    'api/esign-instances': defineService<EsignInstanceService>(),
+    'api/messages': defineService<MessageService>(),
+  },
+})
+
+const feathers = {} as FeathersClient
+const adapter = new FeathersAdapter(feathers)
+const figbird = new Figbird({ schema, adapter })
+const { useMethod } = createHooks(figbird)
+
+const [requestSendDocument, requestSendDocumentState] = useMethod(
+  'api/esign-instances',
+  'requestSendDocument',
+)
+const requestPromise = requestSendDocument('esign_1', { notifySigner: true })
+
+export type RequestSendArgs = Parameters<typeof requestSendDocument>
+export type RequestSendResult = Awaited<ReturnType<typeof requestSendDocument>>
+export type RequestSendPromiseResult = Awaited<typeof requestPromise>
+export type RequestSendData = typeof requestSendDocumentState.data
+
+// @ts-expect-error - method names are scoped to the selected service
+useMethod('api/esign-instances', 'sendMessage')
+
+// @ts-expect-error - unknown custom methods are rejected
+useMethod('api/esign-instances', 'missingMethod')
+
+// @ts-expect-error - custom method args are inferred
+requestSendDocument(123, { notifySigner: true })
+
+// @ts-expect-error - custom method return type is preserved
+export const invalidResult: Promise<{ id: string; status: 'draft' }> =
+  requestSendDocument('esign_1')

--- a/test/type-inference.test.ts
+++ b/test/type-inference.test.ts
@@ -83,6 +83,14 @@ function getTypeAtPosition(
   return raw.replace(/import\("[^"]+"\)/g, 'import("figbird")')
 }
 
+function getDiagnostics(filePath: string, tsConfigOptions: ts.CompilerOptions = {}): string[] {
+  const { program, sourceFile } = getProgramAndChecker(filePath, tsConfigOptions)
+  return [
+    ...program.getSyntacticDiagnostics(sourceFile),
+    ...program.getSemanticDiagnostics(sourceFile),
+  ].map(diagnostic => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
+}
+
 test('type narrowing works correctly with multiple services', t => {
   const fixturePath = join(__dirname, 'fixtures', 'multi-service-inference.ts')
 
@@ -243,4 +251,20 @@ test('generated schema helpers infer service contracts without intersections', t
     `Expected defineSchemaFor to preserve the generated service contract, got: ${peopleServiceType}`,
   )
   t.is(peopleType, 'import("figbird").QueryResult<Person[], import("figbird").FeathersFindMeta>')
+})
+
+test('useMethod infers custom method args and result types', t => {
+  const fixturePath = join(__dirname, 'fixtures', 'use-method-inference.ts')
+
+  const requestSendArgs = getTypeAtPosition(fixturePath, 'RequestSendArgs')
+  const requestSendResult = getTypeAtPosition(fixturePath, 'RequestSendResult')
+  const requestSendPromiseResult = getTypeAtPosition(fixturePath, 'RequestSendPromiseResult')
+  const requestSendData = getTypeAtPosition(fixturePath, 'RequestSendData')
+  const diagnostics = getDiagnostics(fixturePath)
+
+  t.is(requestSendArgs, '[id: string, options?: SendDocumentOptions | undefined]')
+  t.is(requestSendResult, 'SendDocumentResult')
+  t.is(requestSendPromiseResult, 'SendDocumentResult')
+  t.is(requestSendData, 'SendDocumentResult | null')
+  t.deepEqual(diagnostics, [])
 })


### PR DESCRIPTION
## Summary
- add a generic useMethod hook for arbitrary service methods with a tuple API: [call, { status, data, error, reset }]
- expose typed useMethod from createHooks using schema ServiceMethods args and return types
- preserve custom method key narrowing and document the new API

## Validation
- npm test