### PR TITLE
Fix query index sync after refetch

### DIFF
--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -866,6 +866,7 @@ class QueryStore<
       const data = result.data
       const meta = (result as { meta?: TMeta }).meta
       const getId = (item: unknown) => this.#adapter.getId(item)
+      const nextItemIds = new Set<string | number>()
       const getFreshItem = (item: unknown) => {
         const itemId = getId(item)
         if (itemId === undefined) {
@@ -897,11 +898,18 @@ class QueryStore<
       for (const item of freshItems) {
         const itemId = getId(item)
         if (itemId !== undefined) {
+          nextItemIds.add(itemId)
           service.entities.set(itemId, item)
           if (!service.itemQueryIndex.has(itemId)) {
             service.itemQueryIndex.set(itemId, new Set())
           }
           service.itemQueryIndex.get(itemId)!.add(queryId)
+        }
+      }
+
+      for (const [itemId, queryIds] of service.itemQueryIndex) {
+        if (!nextItemIds.has(itemId)) {
+          queryIds.delete(queryId)
         }
       }
 

--- a/test/figbird.test.tsx
+++ b/test/figbird.test.tsx
@@ -918,7 +918,7 @@ test('useFind with skip', async t => {
 
 test('useFind with refetch', async t => {
   const { render, flush, unmount, $ } = dom()
-  const { App, useFind, feathers } = app()
+  const { App, useFind, feathers, figbird } = app()
   let refetch: () => void
 
   function Note() {
@@ -926,7 +926,12 @@ test('useFind with refetch', async t => {
 
     refetch = notes.refetch
 
-    return <div className='data'>{notes.status === 'success' ? notes.data[0]?.id : null}</div>
+    return (
+      <>
+        <div className='data'>{notes.status === 'success' ? notes.data[0]?.id : null}</div>
+        <div className='total'>{notes.status === 'success' ? notes.meta.total : null}</div>
+      </>
+    )
   }
 
   const results = [
@@ -961,6 +966,19 @@ test('useFind with refetch', async t => {
   })
 
   t.is($('.data')!.innerHTML, '2')
+  t.is($('.total')!.innerHTML, '1')
+
+  const notesState = figbird.getState().get('notes')!
+  const queryId = Array.from(notesState.queries.keys())[0]!
+  t.false(notesState.itemQueryIndex.get(1)?.has(queryId) ?? false)
+  t.true(notesState.itemQueryIndex.get(2)?.has(queryId) ?? false)
+
+  await flush(async () => {
+    await feathers.service('notes').remove(1)
+  })
+
+  t.is($('.data')!.innerHTML, '2')
+  t.is($('.total')!.innerHTML, '1')
 
   unmount()
 


### PR DESCRIPTION
## Summary
- sync itemQueryIndex membership to the exact latest successful fetch result
- cover refetch removing stale index membership before later realtime remove events

## Test plan
- npm run tsc
- npm run lint
- npm run ava
- npm run test