### PR TITLE
Prevent stale fetch results overwriting cache

### DIFF
--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -863,10 +863,36 @@ class QueryStore<
 
       const data = result.data
       const meta = (result as { meta?: TMeta }).meta
-      const items = Array.isArray(data) ? data : [data]
       const getId = (item: unknown) => this.#adapter.getId(item)
+      const getFreshItem = (item: unknown) => {
+        const itemId = getId(item)
+        if (itemId === undefined) {
+          return item
+        }
 
-      for (const item of items) {
+        const currItem = service.entities.get(itemId)
+        if (!currItem || !this.#adapter.isItemStale(currItem, item)) {
+          return item
+        }
+
+        if (query.desc.method === 'find' && !query.filterItem(currItem)) {
+          return undefined
+        }
+
+        return currItem
+      }
+      const freshData = Array.isArray(data)
+        ? data.reduce<unknown[]>((acc, item) => {
+            const freshItem = getFreshItem(item)
+            if (freshItem !== undefined) {
+              acc.push(freshItem)
+            }
+            return acc
+          }, [])
+        : getFreshItem(data)
+      const freshItems = Array.isArray(freshData) ? freshData : [freshData]
+
+      for (const item of freshItems) {
         const itemId = getId(item)
         if (itemId !== undefined) {
           service.entities.set(itemId, item)
@@ -883,7 +909,7 @@ class QueryStore<
         ...query,
         state: {
           status: 'success' as const,
-          data,
+          data: freshData,
           meta: meta || this.#adapter.emptyMeta(),
           isFetching: false,
           error: null,

--- a/test/figbird.test.tsx
+++ b/test/figbird.test.tsx
@@ -2214,6 +2214,86 @@ test('useFind - stale realtime event is ignored', async t => {
   unmount()
 })
 
+test('useFind - stale fetch result does not overwrite newer realtime item', async t => {
+  const { render, flush, unmount, $ } = dom()
+
+  function Note() {
+    const notes = useFind('notes')
+    return <NoteList notes={notes} />
+  }
+
+  const { App, useFind, feathers, figbird } = app()
+  feathers.service('notes').setDelay(50)
+
+  render(
+    <App>
+      <Note />
+    </App>,
+  )
+
+  await flush(async () => {
+    await new Promise(resolve => setTimeout(resolve, 5))
+    await feathers.service('notes').patch(1, {
+      content: 'newer update',
+      updatedAt: new Date('2024-03-01').getTime(),
+    })
+    await new Promise(resolve => setTimeout(resolve, 80))
+  })
+
+  t.is($('.note')!.innerHTML, 'newer update')
+  t.is((figbird.getState().get('notes')?.entities.get(1) as Note)?.content, 'newer update')
+
+  unmount()
+})
+
+test('useFind - stale fetch result omits newer realtime item that no longer matches', async t => {
+  const { render, flush, unmount, $all } = dom()
+  const feathers = mockFeathers({
+    notes: {
+      data: {
+        1: {
+          id: 1,
+          content: 'hello',
+          tag: 'post',
+          updatedAt: new Date('2024-02-02').getTime(),
+        },
+      },
+    },
+  })
+
+  function Note() {
+    const notes = useFind('notes', { query: { tag: 'post' } })
+    return <NoteList notes={notes} />
+  }
+
+  const { App, useFind, figbird } = app({ feathers })
+  feathers.service('notes').setDelay(50)
+
+  render(
+    <App>
+      <Note />
+    </App>,
+  )
+
+  await flush(async () => {
+    await new Promise(resolve => setTimeout(resolve, 5))
+    await feathers.service('notes').patch(1, {
+      content: 'draft update',
+      tag: 'draft',
+      updatedAt: new Date('2024-03-01').getTime(),
+    })
+    await new Promise(resolve => setTimeout(resolve, 80))
+  })
+
+  t.deepEqual(
+    $all('.note').map(n => n.innerHTML),
+    [],
+  )
+  t.is((figbird.getState().get('notes')?.entities.get(1) as Note)?.content, 'draft update')
+
+  unmount()
+})
+
 test('recursive serializer for maps and sets', async t => {
   t.deepEqual(
     serialize(


### PR DESCRIPTION
## Summary
- apply the adapter stale-item policy while ingesting fetch results
- keep newer cached items in entity and query state when a slower fetch returns older data
- for find results, omit a stale fetched row when the newer cached item no longer matches the query filter
- add focused regression tests for delayed fetches racing newer realtime patches

## Validation
- npm run tsc
- npm run lint
- npm run ava
- npm run test