### PR TITLE
Fix matcher query cache identity

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -161,8 +161,8 @@ const figbird = new Figbird({
 const { useFind, useGet, useMutation } = createHooks(figbird)
 
 // Types flow automatically
-const tasks = useFind('tasks')       // QueryResult<Task[], FindMeta>
-const task = useGet('tasks', '123')  // QueryResult<Task>
+const tasks = useFind('tasks') // QueryResult<Task[], FindMeta>
+const task = useGet('tasks', '123') // QueryResult<Task>
 ```
 
 ## Query Parameters
@@ -172,8 +172,8 @@ Query parameters combine your domain filters with adapter controls. You define t
 ```ts
 useFind('tasks', {
   query: {
-    completed: true,  // domain filter (from TaskQuery)
-    $limit: 10,       // adapter control (from Feathers)
+    completed: true, // domain filter (from TaskQuery)
+    $limit: 10, // adapter control (from Feathers)
     $sort: { title: 1 },
   },
 })
@@ -199,9 +199,9 @@ If you omit payload types, Figbird uses sensible defaults: `Partial<item>` for c
 ```ts
 const { create, patch, remove } = useMutation('tasks')
 
-const newTask = await create({ title: 'Ship it' })  // typed payload, returns Task
-await patch('id-1', { completed: true })            // typed patch payload
-await remove('id-1')                                // returns removed Task
+const newTask = await create({ title: 'Ship it' }) // typed payload, returns Task
+await patch('id-1', { completed: true }) // typed patch payload
+await remove('id-1') // returns removed Task
 ```
 
 ## Custom Service Methods
@@ -230,8 +230,8 @@ Access custom methods through the typed Feathers client returned by `useFeathers
 const { useFeathers } = createHooks(figbird)
 const feathers = useFeathers()
 
-await feathers.service('notes').archive(['1', '2'])  // { count: number }
-await feathers.service('notes').search('hello')      // Note[]
+await feathers.service('notes').archive(['1', '2']) // { count: number }
+await feathers.service('notes').search('hello') // Note[]
 ```
 
 # API Reference
@@ -295,7 +295,9 @@ const notes = useFind('notes') // QueryResult<Note[], FindMeta>
 - `realtime` - one of `merge` (default), `refetch` or `disabled`
 - `fetchPolicy` - one of `swr` (default), `cache-first` or `network-only`
 - `allPages` - fetch all pages
-- `matcher` - custom matcher function of signature `(query) => (item) => bool`, used when merging realtime events into local query cache
+- `parallel` - when used in combination with `allPages` will fetch all pages in parallel
+- `parallelLimit` - when used in combination with `parallel` limits how many parallel requests to make at once (default: 4)
+- `matcher` - custom matcher function of signature `(query) => (item) => bool`, used when merging realtime events into local query cache. Queries with custom matchers use isolated cache identity because matcher functions cannot be serialized into a stable shared cache key.
 
 #### Returns
 
@@ -420,7 +422,7 @@ function TaskView({ id }: { id: string }) {
 
 #### Arguments
 
-* `figbird` - figbird instance
+- `figbird` - figbird instance
 
 # Advanced Usage
 
@@ -477,11 +479,7 @@ const adapter = new FeathersAdapter(feathers)
 const figbird = new Figbird({ adapter })
 
 export function App({ children }) {
-  return (
-    <FigbirdProvider figbird={figbird}>
-      {children}
-    </FigbirdProvider>
-  )
+  return <FigbirdProvider figbird={figbird}>{children}</FigbirdProvider>
 }
 
 // inspect the state of all of the queries in figbird
@@ -506,7 +504,7 @@ const query = figbird.query({
 
 // Subscribe to get data and updates
 const unsub = query.subscribe(state => {
-  console.log(state.data)  // Task[] | null
+  console.log(state.data) // Task[] | null
   console.log(state.status) // 'loading' | 'success' | 'error'
 })
 

--- a/lib/core/queryIdentity.ts
+++ b/lib/core/queryIdentity.ts
@@ -1,0 +1,62 @@
+import { hashObject } from './hash.js'
+import type { QueryConfig, QueryDescriptor } from './queryTypes.js'
+
+export const queryIdentityKey: unique symbol = Symbol('figbird.queryIdentity')
+
+export type QueryIdentityConfig = {
+  [queryIdentityKey]?: string
+}
+
+let nextIsolatedQueryIdentity = 0
+
+export function createQueryId<TItem, TQuery>(
+  desc: QueryDescriptor,
+  config: QueryConfig<TItem, TQuery>,
+): string {
+  return `q/${hashObject(getQueryIdentity(desc, config))}`
+}
+
+function getQueryIdentity<TItem, TQuery>(
+  desc: QueryDescriptor,
+  config: QueryConfig<TItem, TQuery>,
+): unknown {
+  const scope = getQueryIdentityScope(config)
+
+  return {
+    desc,
+    config: getHashableConfig(config),
+    ...(scope !== undefined && { scope }),
+  }
+}
+
+function getQueryIdentityScope<TItem, TQuery>(
+  config: QueryConfig<TItem, TQuery>,
+): string | undefined {
+  const internalScope = (config as QueryConfig<TItem, TQuery> & QueryIdentityConfig)[
+    queryIdentityKey
+  ]
+  if (internalScope !== undefined) {
+    return internalScope
+  }
+
+  if (config.matcher) {
+    return `matcher/${++nextIsolatedQueryIdentity}`
+  }
+
+  return undefined
+}
+
+function getHashableConfig<TItem, TQuery>(config: QueryConfig<TItem, TQuery>): unknown {
+  if (!config.matcher) {
+    return config
+  }
+
+  const hashableConfig: Record<PropertyKey, unknown> = { ...config }
+  delete hashableConfig.matcher
+  delete hashableConfig[queryIdentityKey]
+
+  return {
+    ...hashableConfig,
+    matcher: 'custom',
+  }
+}

--- a/lib/core/queryRef.ts
+++ b/lib/core/queryRef.ts
@@ -1,4 +1,4 @@
-import { hashObject } from './hash.js'
+import { createQueryId } from './queryIdentity.js'
 import type { AnySchema, Schema } from './schema.js'
 import type { QueryStore } from './queryStore.js'
 import type { QueryConfig, QueryDescriptor, QueryState } from './queryTypes.js'
@@ -33,7 +33,7 @@ export class QueryRef<
     config: QueryConfig<T, TQueryType>
     queryStore: QueryStore<S, TParams, TMeta, TQuery>
   }) {
-    this.#queryId = `q/${hashObject({ desc, config })}`
+    this.#queryId = createQueryId(desc, config)
     this.#desc = desc
     this.#config = config
     this.#queryStore = queryStore

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -117,7 +117,8 @@ export class QueryStore<
 
     this.#subscribeToRealtime(queryId)
 
-    const shouldVacuumByDefault = q.config.fetchPolicy === 'network-only'
+    const shouldVacuumByDefault =
+      q.config.fetchPolicy === 'network-only' || Boolean(q.config.matcher)
     return ({ vacuum = shouldVacuumByDefault }: { vacuum?: boolean } = {}) => {
       removeListener()
       if (vacuum && this.#listenerCount(queryId) === 0) {

--- a/lib/core/queryTypes.ts
+++ b/lib/core/queryTypes.ts
@@ -158,6 +158,8 @@ interface BaseQueryConfig<TItem = unknown, TQuery = unknown> {
    * Receives the prepared query object; returns a predicate for items.
    * Provide this if your adapter needs custom client-side matching logic.
    * Note: For find queries, the matcher works with individual items, not arrays.
+   * Queries with a matcher use isolated cache identity because functions cannot
+   * be serialized into a stable shared cache key.
    */
   matcher?: (query: TQuery | undefined) => (item: ElementType<TItem>) => boolean
 }

--- a/lib/react/useQuery.ts
+++ b/lib/react/useQuery.ts
@@ -1,4 +1,5 @@
 import { useCallback, useId, useMemo, useRef, useSyncExternalStore } from 'react'
+import { queryIdentityKey, type QueryIdentityConfig } from '../core/queryIdentity.js'
 import { findServiceByName } from '../core/schema.js'
 import {
   splitConfig,
@@ -99,8 +100,8 @@ export function useQuery<
 >(desc: QueryDescriptor, config: QueryConfig<T, TQuery>): QueryResult<T, TMeta> {
   const figbird = useFigbird()
 
-  // For network-only queries, we need a unique ID for each hook instance
-  // to ensure that queries are not shared between components.
+  // For network-only and custom matcher queries, we need a unique ID for each hook
+  // instance to ensure that queries are not shared between components.
   // useId provides a stable, unique ID for the lifetime of the component.
   const uniqueId = useId()
 
@@ -109,10 +110,14 @@ export function useQuery<
   // the q.subscribe and q.getSnapshot stable and avoid unsubbing and resubbing
   // you don't need to do this outside React where you can more easily create a
   // stable reference to a query and use it for as long as you want
-  const _q = figbird.query(desc, {
-    ...config,
-    ...(config.fetchPolicy === 'network-only' ? { uid: uniqueId } : {}),
-  } as QueryConfig<unknown, unknown>)
+  const shouldScopeToHook = config.fetchPolicy === 'network-only' || config.matcher
+  const queryConfig = shouldScopeToHook
+    ? ({
+        ...config,
+        [queryIdentityKey]: uniqueId,
+      } as QueryConfig<unknown, unknown> & QueryIdentityConfig)
+    : (config as QueryConfig<unknown, unknown>)
+  const _q = figbird.query(desc, queryConfig)
 
   // a bit of React foo to create stable fn references
   const hash = _q.hash()

--- a/test/figbird.test.tsx
+++ b/test/figbird.test.tsx
@@ -1828,6 +1828,65 @@ test('useFind - with custom matcher', async t => {
   unmount()
 })
 
+test('useFind - queries with different custom matchers do not share cache identity', async t => {
+  const { render, flush, unmount, $all } = dom()
+  const { App, useFind, feathers } = app()
+
+  function FooNotes() {
+    const notes = useFind('notes', {
+      query: { tag: 'post' },
+      matcher: _query => item => item.foo === true,
+    })
+    return (
+      <div className='foo-notes'>
+        <NoteList notes={notes} />
+      </div>
+    )
+  }
+
+  function ArchivedNotes() {
+    const notes = useFind('notes', {
+      query: { tag: 'post' },
+      matcher: _query => item => item.archived === true,
+    })
+    return (
+      <div className='archived-notes'>
+        <NoteList notes={notes} />
+      </div>
+    )
+  }
+
+  render(
+    <App>
+      <FooNotes />
+      <ArchivedNotes />
+    </App>,
+  )
+
+  await flush()
+
+  await flush(async () => {
+    await feathers.service('notes').create({ id: 2, tag: 'post', content: 'foo', foo: true })
+    await feathers.service('notes').create({
+      id: 3,
+      tag: 'post',
+      content: 'archived',
+      archived: true,
+    })
+  })
+
+  t.deepEqual(
+    $all('.foo-notes .note').map(n => n.innerHTML),
+    ['hello', 'foo'],
+  )
+  t.deepEqual(
+    $all('.archived-notes .note').map(n => n.innerHTML),
+    ['hello', 'archived'],
+  )
+
+  unmount()
+})
+
 test('items get updated in cache even if not currently relevant to any query', async t => {
   const { render, flush, unmount, $, $all } = dom()
   const { App, useFind, feathers, figbird } = app({ config: { noUpdatedAt: true } })


### PR DESCRIPTION
## Summary
- isolate query cache identity for custom matcher queries so function-valued config cannot be dropped by JSON hashing
- keep React matcher queries stable per hook instance while preventing cross-component cache/filter reuse
- document the matcher cache identity contract and add a regression test for two same-descriptor queries with different matchers

## Verification
- npm run tsc
- npm run lint
- npm run ava
- npm run test