### PR TITLE
Normalize core query config defaults

### DIFF
--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -438,7 +438,7 @@ export class Figbird<
     return new QueryRef<unknown, unknown, S, AdapterParams<A>, AdapterFindMeta<A>, AdapterQuery<A>>(
       {
         desc: desc as QueryDescriptor,
-        config: (config || {}) as QueryConfig<unknown, unknown>,
+        config: normalizeQueryConfig(config),
         queryStore: this.queryStore,
       },
     )
@@ -512,16 +512,8 @@ export function splitConfig<TItem = unknown, TQuery = unknown>(
   desc: QueryDescriptor
   config: QueryConfig<TItem, TQuery>
 } {
-  // Extract common properties with defaults
-  const {
-    serviceName,
-    method,
-    skip,
-    realtime = 'merge',
-    fetchPolicy = 'swr',
-    matcher,
-    ...rest
-  } = combinedConfig
+  // Extract common properties
+  const { serviceName, method, skip, realtime, fetchPolicy, matcher, ...rest } = combinedConfig
 
   if (method === 'get') {
     const { resourceId, ...params } = rest as CombinedGetConfig<TItem, TQuery>
@@ -535,12 +527,12 @@ export function splitConfig<TItem = unknown, TQuery = unknown>(
 
     const config: GetQueryConfig<TItem, TQuery> = {
       ...(skip !== undefined && { skip }),
-      realtime,
-      fetchPolicy,
+      ...(realtime !== undefined && { realtime }),
+      ...(fetchPolicy !== undefined && { fetchPolicy }),
       ...(matcher !== undefined && { matcher }),
     }
 
-    return { desc, config }
+    return { desc, config: normalizeQueryConfig(config) }
   } else {
     const { allPages, ...params } = rest as CombinedFindConfig<TItem, TQuery>
 
@@ -552,13 +544,23 @@ export function splitConfig<TItem = unknown, TQuery = unknown>(
 
     const config: FindQueryConfig<TItem, TQuery> = {
       ...(skip !== undefined && { skip }),
-      realtime,
-      fetchPolicy,
+      ...(realtime !== undefined && { realtime }),
+      ...(fetchPolicy !== undefined && { fetchPolicy }),
       ...(matcher !== undefined && { matcher }),
       ...(allPages !== undefined && { allPages }),
     }
 
-    return { desc, config }
+    return { desc, config: normalizeQueryConfig(config) }
+  }
+}
+
+function normalizeQueryConfig<TItem = unknown, TQuery = unknown>(
+  config: QueryConfig<TItem, TQuery> = {},
+): QueryConfig<TItem, TQuery> {
+  return {
+    realtime: 'merge',
+    fetchPolicy: 'swr',
+    ...config,
   }
 }
 

--- a/test/figbird-instance.test.ts
+++ b/test/figbird-instance.test.ts
@@ -202,6 +202,58 @@ test('figbird.query with find returns any data when no schema is provided', asyn
   t.deepEqual(result, [{ id: 1, content: 'hello' }])
 })
 
+test('figbird.query defaults to realtime merge updates', async t => {
+  const feathers = mockFeathers({
+    notes: {
+      data: {
+        1: { id: 1, content: 'hello' },
+      },
+    },
+  })
+  const adapter = new FeathersAdapter(feathers)
+  const figbird = new Figbird({ schema, adapter, eventBatchProcessingInterval: 0 })
+
+  const query = figbird.query({ serviceName: 'notes', method: 'get', resourceId: 1 })
+  let resolveInitial: (note: Note) => void = () => {}
+  let resolveUpdated: (note: Note) => void = () => {}
+  const initialState = new Promise<Note>(resolve => {
+    resolveInitial = resolve
+  })
+  const updatedState = new Promise<Note>(resolve => {
+    resolveUpdated = resolve
+  })
+
+  const unsubscribe = query.subscribe(state => {
+    if (state.status !== 'success') return
+
+    if (state.data.content === 'hello') {
+      resolveInitial(state.data)
+    } else if (state.data.content === 'realtime') {
+      resolveUpdated(state.data)
+    }
+  })
+
+  t.deepEqual(await initialState, { id: 1, content: 'hello' })
+
+  await feathers.service('notes').patch(1, { content: 'realtime' })
+
+  const updated = await Promise.race([
+    updatedState,
+    new Promise<null>(resolve => {
+      setTimeout(() => resolve(null), 100)
+    }),
+  ])
+
+  unsubscribe()
+
+  if (!updated) {
+    t.fail('Expected direct query to receive realtime update')
+    return
+  }
+
+  t.like(updated, { id: 1, content: 'realtime' })
+})
+
 test('figbird.mutate with create', async t => {
   const feathers = mockFeathers({
     notes: {


### PR DESCRIPTION
## Summary
- centralize query config defaults in the core layer
- apply the same realtime and fetch policy defaults to direct Figbird.query calls
- add a direct API regression test for default realtime merge updates

## Verification
- npm run tsc
- npm run lint
- npm run ava
- npm run test