### PR TITLE
Fix realtime batch event drain

### DIFF
--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -37,6 +37,7 @@ export class QueryStore<
   #eventQueue: QueuedEvent[] = []
   #eventBatchProcessingTimer: ReturnType<typeof setTimeout> | null = null
   #eventBatchProcessingInterval: number | undefined = 100
+  #processingEventQueue = false
 
   constructor({
     adapter,
@@ -382,12 +383,12 @@ export class QueryStore<
       items: Array.isArray(event.item) ? event.item : [event.item],
     })
 
-    if (!this.#eventBatchProcessingTimer) {
+    if (!this.#eventBatchProcessingTimer && !this.#processingEventQueue) {
       // process all events in a short interval as a batch later
       if (this.#eventBatchProcessingInterval) {
         this.#eventBatchProcessingTimer = setTimeout(() => {
-          this.#processQueuedEvents()
           this.#eventBatchProcessingTimer = null
+          this.#processQueuedEvents()
         }, this.#eventBatchProcessingInterval)
       } else {
         // batching is disabled, process each event immediately
@@ -397,41 +398,48 @@ export class QueryStore<
   }
 
   #processQueuedEvents(): void {
-    if (this.#eventQueue.length === 0) {
+    if (this.#processingEventQueue || this.#eventQueue.length === 0) {
       return
     }
 
-    const eventsByService = groupQueuedEvents(this.#eventQueue)
-    const getId = (item: unknown) => this.#adapter.getId(item)
-    const isItemStale = (curr: unknown, next: unknown) => this.#adapter.isItemStale(curr, next)
+    this.#processingEventQueue = true
+    try {
+      const getId = (item: unknown) => this.#adapter.getId(item)
+      const isItemStale = (curr: unknown, next: unknown) => this.#adapter.isItemStale(curr, next)
 
-    for (const [serviceName, events] of Object.entries(eventsByService)) {
-      this.#transactOverServiceByName(serviceName, (service, touch) => {
-        const appliedEvents = applyEventsToService({
-          service,
-          events,
-          getId,
-          isItemStale,
-        })
+      while (this.#eventQueue.length > 0) {
+        const eventsByService = groupQueuedEvents(this.#eventQueue)
+        this.#eventQueue = []
 
-        // Update queries only for non-stale items
-        if (appliedEvents.length > 0) {
-          updateQueriesFromEvents({
-            service,
-            appliedEvents,
-            touch,
-            getId,
-            itemAdded: meta => this.#adapter.itemAdded(meta),
-            itemRemoved: meta => this.#adapter.itemRemoved(meta),
+        for (const [serviceName, events] of Object.entries(eventsByService)) {
+          this.#transactOverServiceByName(serviceName, (service, touch) => {
+            const appliedEvents = applyEventsToService({
+              service,
+              events,
+              getId,
+              isItemStale,
+            })
+
+            // Update queries only for non-stale items
+            if (appliedEvents.length > 0) {
+              updateQueriesFromEvents({
+                service,
+                appliedEvents,
+                touch,
+                getId,
+                itemAdded: meta => this.#adapter.itemAdded(meta),
+                itemRemoved: meta => this.#adapter.itemRemoved(meta),
+              })
+            }
           })
+
+          // Refetch refetchable queries if needed
+          this.#refetchRefetchableQueries(serviceName)
         }
-      })
-
-      // Refetch refetchable queries if needed
-      this.#refetchRefetchableQueries(serviceName)
+      }
+    } finally {
+      this.#processingEventQueue = false
     }
-
-    this.#eventQueue = []
   }
 
   #refetchRefetchableQueries(serviceName: string): void {

--- a/test/figbird-instance.test.ts
+++ b/test/figbird-instance.test.ts
@@ -25,6 +25,10 @@ const schema = defineSchema({
   },
 })
 
+function wait(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
 test('Figbird instance can be created', t => {
   const feathers = mockFeathers({
     notes: {
@@ -252,6 +256,55 @@ test('figbird.query defaults to realtime merge updates', async t => {
   }
 
   t.like(updated, { id: 1, content: 'realtime' })
+})
+
+test('realtime events queued while a batch flushes are not dropped', async t => {
+  const feathers = mockFeathers({
+    notes: {
+      data: {
+        1: { id: 1, content: 'initial' },
+      },
+    },
+  })
+  const adapter = new FeathersAdapter(feathers, { updatedAtField: () => undefined })
+  const figbird = new Figbird({ schema, adapter, eventBatchProcessingInterval: 10 })
+  const query = figbird.query({ serviceName: 'notes', method: 'find' })
+  const service = feathers.service('notes')
+
+  let resolveInitial: () => void = () => {}
+  const initial = new Promise<void>(resolve => {
+    resolveInitial = resolve
+  })
+  let sawInitial = false
+  let emittedSecond = false
+  const unsubscribe = query.subscribe(state => {
+    if (state.status !== 'success') return
+
+    const content = state.data[0]?.content
+    if (!sawInitial) {
+      sawInitial = true
+      resolveInitial()
+      return
+    }
+
+    if (content === 'first' && !emittedSecond) {
+      emittedSecond = true
+      service.emit('patched', { id: 1, content: 'second' })
+    }
+  })
+
+  await initial
+
+  service.emit('patched', { id: 1, content: 'first' })
+  await wait(30)
+
+  unsubscribe()
+
+  const snapshot = query.getSnapshot()
+  t.is(snapshot?.status, 'success')
+  if (snapshot?.status !== 'success') return
+
+  t.is(snapshot.data[0]?.content, 'second')
 })
 
 test('figbird.mutate with create', async t => {


### PR DESCRIPTION
## Summary
- Drain realtime event batches in snapshots so events queued during listener notification are processed instead of cleared
- Avoid scheduling redundant batch timers while the event queue is already being processed
- Add a regression test for events emitted while a batch flushes

## Tests
- npm run tsc
- npm run lint
- npx ava test/figbird-instance.test.ts
- npm run ava
- npm run test