### PR TITLE
Fix release package build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,9 @@
 docs
+demo
 test
 tasks
 coverage
 .nyc_output
+.claude
 .git
 node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Figbird Changelog
 
+## 0.22.1
+
+- Rebuild package artifacts during `npm pack`/`npm publish` so `npm run release` publishes fresh `dist` entrypoints.
+- Limit the published npm package to the library source, built artifacts, and public project metadata.
+
 ## 0.22.0
 
 - Add `useService` and `useMethod` hooks, including typed versions from `createHooks`.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "types": "./dist/esm/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
-    "./package-lock.json": "./package-lock.json",
     "./tsconfig.json": "./tsconfig.json",
     ".": {
       "types": "./dist/esm/index.d.ts",
@@ -19,6 +18,14 @@
       "import": "./dist/esm/*.js"
     }
   },
+  "files": [
+    "dist",
+    "lib",
+    "CHANGELOG.md",
+    "README.md",
+    "LICENSE.md",
+    "tsconfig.json"
+  ],
   "scripts": {
     "test": "tsc --noEmit && oxlint -c oxlintrc.json && prettier --check '**/*.{ts,tsx,js,jsx,css,yml}' && c8 ava",
     "lint": "oxlint -c oxlintrc.json",
@@ -27,6 +34,7 @@
     "format": "prettier --write '**/*.{ts,tsx,js,jsx,css,yml}'",
     "coverage": "c8 -r html -r text ava",
     "build": "node ./tasks/build.js",
+    "prepack": "npm run build",
     "watch": "node ./tasks/build.js -w",
     "release": "np",
     "release:beta": "np --tag=beta",


### PR DESCRIPTION
## Summary
- rebuild dist during npm pack/publish via prepack so npm run release publishes fresh entrypoints
- whitelist npm package contents and explicitly ignore demo/.claude artifacts
- add a 0.22.1 changelog entry for the packaging fix

## Verification
- npm --cache /private/tmp/codex-npm-cache pack --dry-run
- npm run tsc
- npm run lint
- npm run ava
- npm run test