### PR TITLE
Refactor schema API around service maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Figbird Changelog
 
+## Unreleased
+
+- Breaking: replace `defineSchema`/`defineService` service-object schemas with a canonical service-definition map passed to `defineSchema<ServiceMap>()`.
+- Breaking: remove `defineSchemaFor`; generated and handwritten schemas now use the same `defineSchema` API.
+- Add optional `defineSchema<ServiceMap>({ services: { key: { path } } })` config for mapping typed service keys to transport service paths.
+
 ## 0.22.1
 
 - Rebuild package artifacts during `npm pack`/`npm publish` so `npm run release` publishes fresh `dist` entrypoints.

--- a/README.md
+++ b/README.md
@@ -67,18 +67,36 @@ includes typed CRUD methods plus any custom methods declared in the schema.
 - **Custom methods** - typed service method calls with `status`, `data`, `error`, and `reset`
 - **Full TypeScript** - define a schema once, get inference everywhere
 
-## Generated Schemas
+## Typed Schemas
 
-If your API contract is generated as a service map, use `defineSchemaFor` to create a typed schema from service names.
+Define a service map once, then bind it to a Figbird schema with `defineSchema`.
+The same shape works for handwritten schemas and generated API contracts.
 
 ```ts
-import { defineSchemaFor } from 'figbird'
-import type { ApiSchemaTypes } from './generated-api'
+import { defineSchema } from 'figbird'
 
-const schema = defineSchemaFor<ApiSchemaTypes>()({
-  services: ['api/people', 'api/tasks'],
+interface ApiSchemaTypes {
+  people: {
+    item: Person
+    create: PersonCreate
+    patch: PersonPatch
+    query: PersonQuery
+  }
+  tasks: {
+    item: Task
+  }
+}
+
+const schema = defineSchema<ApiSchemaTypes>({
+  services: {
+    people: { path: 'api/people' },
+    tasks: { path: 'api/tasks' },
+  },
 })
 ```
+
+The `services` config is optional. Omit it when your schema keys already match
+your Feathers service paths.
 
 ## Documentation
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -51,7 +51,6 @@ import {
   FeathersAdapter,
   FigbirdProvider,
   defineSchema,
-  defineService,
   createHooks
 } from 'figbird'
 import { feathersClient } from './feathers'
@@ -62,11 +61,13 @@ interface Note {
   content: string
 }
 
-const schema = defineSchema({
-  services: {
-    notes: defineService<{ item: Note }>(),
-  },
-})
+interface AppSchemaTypes {
+  notes: {
+    item: Note
+  }
+}
+
+const schema = defineSchema<AppSchemaTypes>()
 
 // Create figbird instance
 const figbird = new Figbird({
@@ -98,14 +99,14 @@ function Notes() {
 
 # TypeScript
 
-Figbird provides full TypeScript inference through a lightweight schema DSL. Define your services once, and get type safety across all hooks, mutations, and queries - no code generation required.
+Figbird provides full TypeScript inference through a plain service-definition map. Define your services once, or generate the map from your API contract, and get type safety across all hooks, mutations, and queries.
 
 ## Defining a Schema
 
-A schema declares your services and their types. Each service specifies an `item` shape, and optionally custom types for queries and mutation payloads.
+A schema declares your services and their types. Each service specifies an `item` shape, and optionally custom types for queries, mutation payloads, and custom methods.
 
 ```ts
-import { defineSchema, defineService } from 'figbird'
+import { defineSchema } from 'figbird'
 
 interface Task {
   id: string
@@ -122,29 +123,39 @@ interface TaskService {
   query?: TaskQuery
 }
 
-const schema = defineSchema({
-  services: {
-    tasks: defineService<TaskService>(),
-  },
-})
+const schema = defineSchema<{
+  tasks: TaskService
+}>()
 ```
 
 Service keys are preserved as literal types - so `'api/people'` and `'tasks'` remain distinct, and all APIs narrow correctly based on the service name you pass.
 
-## Generated Schema Maps
-
-If your API contract already exists as a generated map, you can derive Figbird services from it without manually wrapping every entry in `ServiceTypeDefinition`.
+If you want ergonomic schema keys that differ from the Feathers service path,
+configure the runtime path separately:
 
 ```ts
-import { defineSchemaFor } from 'figbird'
-import type { ApiSchemaTypes } from './generated-api'
-
-const schema = defineSchemaFor<ApiSchemaTypes>()({
-  services: ['api/people', 'api/tasks'],
+const schema = defineSchema<{
+  tasks: TaskService
+}>({
+  services: {
+    tasks: { path: 'api/tasks' },
+  },
 })
 ```
 
-Each generated service entry should follow Figbird's service contract shape: `item` is required, while `query`, `create`, `update`, `patch`, and `methods` are optional.
+The path config is optional. When it is omitted, Figbird uses the schema key as
+the service path.
+
+## Generated Schema Maps
+
+Generated schemas use the same shape as handwritten schemas. Emit a service-definition map where `item` is required, while `query`, `create`, `update`, `patch`, and `methods` are optional.
+
+```ts
+import { defineSchema } from 'figbird'
+import type { ApiSchemaTypes } from './generated-api'
+
+const schema = defineSchema<ApiSchemaTypes>()
+```
 
 ## Type-Safe Hooks
 
@@ -217,11 +228,9 @@ interface NotesService {
   }
 }
 
-const schema = defineSchema({
-  services: {
-    notes: defineService<NotesService>(),
-  },
-})
+const schema = defineSchema<{
+  notes: NotesService
+}>()
 ```
 
 Access custom methods through the typed Feathers client returned by `useFeathers`:

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -9,6 +9,7 @@ import type {
   ServiceQuery,
   ServiceUpdate,
 } from './schema.js'
+import { resolveServicePath } from './schema.js'
 import { QueryRef } from './queryRef.js'
 import { QueryStore } from './queryStore.js'
 import {
@@ -142,9 +143,14 @@ export class Figbird<
     config?: QueryConfig<unknown, unknown>,
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   ): any {
+    const resolvedDesc = {
+      ...desc,
+      serviceName: resolveServicePath(this.schema, desc.serviceName),
+    }
+
     return new QueryRef<unknown, unknown, S, AdapterParams<A>, AdapterFindMeta<A>, AdapterQuery<A>>(
       {
-        desc: desc as QueryDescriptor,
+        desc: resolvedDesc as QueryDescriptor,
         config: normalizeQueryConfig(config),
         queryStore: this.queryStore,
       },
@@ -198,7 +204,10 @@ export class Figbird<
   // Implementation
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   mutate(desc: MutationDescriptor): Promise<any> {
-    return this.queryStore.mutate(desc)
+    return this.queryStore.mutate({
+      ...desc,
+      serviceName: resolveServicePath(this.schema, desc.serviceName),
+    })
   }
 
   /** Subscribe to any state changes within Figbird (across all queries/services). */

--- a/lib/core/schema.ts
+++ b/lib/core/schema.ts
@@ -1,10 +1,13 @@
 /**
- * Schema types for Figbird
- * These types enable type-safe service definitions and query inference
+ * Schema types for Figbird.
+ *
+ * A schema is backed by a plain service-definition map:
+ * `{ serviceName: { item, create?, update?, patch?, query?, methods? } }`.
+ * Runtime configuration is optional and only describes service metadata that
+ * TypeScript cannot provide after type erasure, such as transport paths.
  */
 
-// Unique symbol for phantom types - keeps internal typing machinery hidden
-declare const $phantom: unique symbol
+declare const $schemaDefinitions: unique symbol
 
 // Arbitrary service methods must preserve their own argument and return types.
 // `any` is intentional here: `unknown[]` would reject concrete method signatures.
@@ -12,8 +15,7 @@ declare const $phantom: unique symbol
 export type ServiceMethod = (...args: any[]) => any
 export type ServiceMethodsMap = Record<string, ServiceMethod>
 
-// Base service type definition interface that users provide
-export interface ServiceTypeDefinition {
+export interface ServiceDefinition {
   item: unknown
   create?: unknown
   update?: unknown
@@ -22,197 +24,123 @@ export interface ServiceTypeDefinition {
   methods?: ServiceMethodsMap
 }
 
-// Internal service representation - matches expected type structure
-export interface Service<
-  TItem = Record<string, unknown>,
-  TQuery = Record<string, unknown>,
-  TName extends string = string,
-  TCreate = unknown,
-  TUpdate = unknown,
-  TPatch = unknown,
-  TMethods extends ServiceMethodsMap = ServiceMethodsMap,
-> {
-  readonly name: TName
-  readonly [$phantom]?: {
-    item: TItem
-    query: TQuery
-    create: TCreate
-    update: TUpdate
-    patch: TPatch
-    methods: TMethods
-  }
+export type ServiceDefinitionMap<TServiceDefs> = {
+  [K in keyof TServiceDefs]: ServiceDefinition
 }
 
-// Helper types to derive payload types from service definition
-type DeriveCreate<TServiceDef extends ServiceTypeDefinition> = 'create' extends keyof TServiceDef
+interface UntypedServiceDefinition extends ServiceDefinition {
+  item: Record<string, unknown>
+  create: Record<string, unknown>
+  update: Record<string, unknown>
+  patch: Record<string, unknown>
+  query: Record<string, unknown>
+  methods: Record<string, never>
+}
+
+export interface ServiceConfig {
+  /**
+   * Transport-level service name. When omitted, the schema key is used.
+   *
+   * This lets app code use ergonomic schema keys (`people`) while adapters still
+   * call the real backend service path (`api/people`).
+   */
+  readonly path?: string
+}
+
+export type SchemaServiceConfig<TServiceName extends string = string> = Partial<
+  Record<TServiceName, ServiceConfig>
+>
+
+export interface SchemaConfig<TServiceName extends string = string> {
+  readonly services?: SchemaServiceConfig<TServiceName>
+}
+
+export interface Schema {
+  readonly services?: SchemaServiceConfig
+  readonly [$schemaDefinitions]?: unknown
+}
+
+export interface TypedSchema<
+  TServiceDefs extends ServiceDefinitionMap<TServiceDefs>,
+> extends Schema {
+  readonly services?: SchemaServiceConfig<keyof TServiceDefs & string>
+  readonly [$schemaDefinitions]?: TServiceDefs
+}
+
+type DeriveCreate<TServiceDef extends ServiceDefinition> = 'create' extends keyof TServiceDef
   ? Exclude<TServiceDef['create'], undefined>
   : Partial<TServiceDef['item']>
 
-type DeriveUpdate<TServiceDef extends ServiceTypeDefinition> = 'update' extends keyof TServiceDef
+type DeriveUpdate<TServiceDef extends ServiceDefinition> = 'update' extends keyof TServiceDef
   ? Exclude<TServiceDef['update'], undefined>
   : TServiceDef['item']
 
-type DerivePatch<TServiceDef extends ServiceTypeDefinition> = 'patch' extends keyof TServiceDef
+type DerivePatch<TServiceDef extends ServiceDefinition> = 'patch' extends keyof TServiceDef
   ? Exclude<TServiceDef['patch'], undefined>
   : Partial<TServiceDef['item']>
 
-type DeriveMethods<TServiceDef extends ServiceTypeDefinition> = 'methods' extends keyof TServiceDef
-  ? Exclude<TServiceDef['methods'], undefined> extends infer M extends ServiceMethodsMap
-    ? M
+type DeriveMethods<TServiceDef extends ServiceDefinition> = 'methods' extends keyof TServiceDef
+  ? Exclude<TServiceDef['methods'], undefined> extends infer TMethods extends ServiceMethodsMap
+    ? TMethods
     : Record<never, never>
   : Record<never, never>
 
-type DeriveQuery<TServiceDef extends ServiceTypeDefinition> = 'query' extends keyof TServiceDef
+type DeriveQuery<TServiceDef extends ServiceDefinition> = 'query' extends keyof TServiceDef
   ? Exclude<TServiceDef['query'], undefined>
   : Record<string, unknown>
 
-type ServiceDefinitions<TServiceDefs> = {
-  [K in keyof TServiceDefs]: ServiceTypeDefinition
+export function defineSchema<const TServiceDefs extends ServiceDefinitionMap<TServiceDefs>>(
+  config: SchemaConfig<keyof TServiceDefs & string> = {},
+): TypedSchema<TServiceDefs> {
+  return config as TypedSchema<TServiceDefs>
 }
 
-type ServiceFromDefinition<
-  TServiceDef extends ServiceTypeDefinition,
-  TName extends string = string,
-> = Service<
-  TServiceDef['item'],
-  DeriveQuery<TServiceDef>,
-  TName,
-  DeriveCreate<TServiceDef>,
-  DeriveUpdate<TServiceDef>,
-  DerivePatch<TServiceDef>,
-  DeriveMethods<TServiceDef>
->
-
-type ServiceMapFromDefinitions<
-  TServiceDefs extends ServiceDefinitions<TServiceDefs>,
-  TServiceName extends keyof TServiceDefs & string,
-> = {
-  readonly [K in TServiceName]: ServiceFromDefinition<TServiceDefs[K], K>
-}
-
-type DefineSchemaFor<TServiceDefs extends ServiceDefinitions<TServiceDefs>> = <
-  const TServiceNames extends readonly (keyof TServiceDefs & string)[],
->(config: {
-  services: TServiceNames
-}) => {
-  services: ServiceMapFromDefinitions<TServiceDefs, TServiceNames[number]>
-}
-
-// Phase 1: Create a service definition (no name yet)
-export function defineService<
-  TServiceDef extends ServiceTypeDefinition,
->(): ServiceFromDefinition<TServiceDef> {
-  return { name: '' } as ServiceFromDefinition<TServiceDef>
-}
-
-// Base schema interface - flexible to preserve specific service types
-export interface Schema {
-  services: Record<string, Service<unknown, unknown, string>>
-}
-
-// Helper type to extract all service parameters and update name
-type ExtractServiceWithName<S, N extends string> =
-  S extends Service<
-    infer TItem,
-    infer TQuery,
-    string,
-    infer TCreate,
-    infer TUpdate,
-    infer TPatch,
-    infer TMethods extends ServiceMethodsMap
-  >
-    ? Service<TItem, TQuery, N, TCreate, TUpdate, TPatch, TMethods>
-    : never
-
-// Phase 2: Create a schema with services object map (preserves literal keys)
-export function defineSchema<
-  const TServiceMap extends Record<string, Service<unknown, unknown, string>>,
->(config: {
-  services: TServiceMap
-}): {
-  services: {
-    readonly [K in keyof TServiceMap]: ExtractServiceWithName<TServiceMap[K], K & string>
-  }
-} {
-  // Assign names to services based on their keys in the map
-  const serviceMap = Object.fromEntries(
-    Object.entries(config.services).map(([name, service]) => [name, { ...service, name }]),
-  ) as {
-    readonly [K in keyof TServiceMap]: ExtractServiceWithName<TServiceMap[K], K & string>
-  }
-  return { services: serviceMap }
-}
-
-// Create a schema directly from a generated service contract map
-export function defineSchemaFor<
-  const TServiceDefs extends ServiceDefinitions<TServiceDefs>,
->(): DefineSchemaFor<TServiceDefs> {
-  return (<const TServiceNames extends readonly (keyof TServiceDefs & string)[]>(config: {
-    services: TServiceNames
-  }) => {
-    const services = Object.fromEntries(
-      config.services.map(name => [
-        name,
-        { name } as ServiceFromDefinition<TServiceDefs[typeof name], typeof name>,
-      ]),
-    ) as unknown as ServiceMapFromDefinitions<TServiceDefs, TServiceNames[number]>
-
-    return defineSchema({ services }) as {
-      services: ServiceMapFromDefinitions<TServiceDefs, TServiceNames[number]>
-    }
-  }) as DefineSchemaFor<TServiceDefs>
-}
+export type SchemaDefinitions<S extends Schema> =
+  S extends TypedSchema<infer TServiceDefs> ? TServiceDefs : never
 
 // Type helpers to extract types from schema
-export type ServiceNames<S extends Schema> = keyof S['services'] & string
+export type ServiceNames<S extends Schema> =
+  S extends TypedSchema<infer TServiceDefs> ? keyof TServiceDefs & string : never
 
-export type ServiceByName<S extends Schema, N extends ServiceNames<S>> = S['services'][N]
+export type ServiceByName<S extends Schema, N extends ServiceNames<S>> = SchemaDefinitions<S>[N]
 
-export type ServiceItem<S extends Schema, N extends ServiceNames<S>> =
-  ServiceByName<S, N> extends { [$phantom]?: { item: infer I } } ? I : Record<string, unknown>
+export type ServiceItem<S extends Schema, N extends ServiceNames<S>> = ServiceByName<S, N>['item']
 
-export type ServiceCreate<S extends Schema, N extends ServiceNames<S>> =
-  ServiceByName<S, N> extends { [$phantom]?: { create: infer C } } ? C : Record<string, unknown>
+export type ServiceCreate<S extends Schema, N extends ServiceNames<S>> = DeriveCreate<
+  ServiceByName<S, N>
+>
 
-export type ServiceUpdate<S extends Schema, N extends ServiceNames<S>> =
-  ServiceByName<S, N> extends { [$phantom]?: { update: infer U } } ? U : Record<string, unknown>
+export type ServiceUpdate<S extends Schema, N extends ServiceNames<S>> = DeriveUpdate<
+  ServiceByName<S, N>
+>
 
-export type ServicePatch<S extends Schema, N extends ServiceNames<S>> =
-  ServiceByName<S, N> extends { [$phantom]?: { patch: infer P } } ? P : Record<string, unknown>
+export type ServicePatch<S extends Schema, N extends ServiceNames<S>> = DerivePatch<
+  ServiceByName<S, N>
+>
 
-export type ServiceQuery<S extends Schema, N extends ServiceNames<S>> =
-  ServiceByName<S, N> extends { [$phantom]?: { query: infer Q } } ? Q : Record<string, unknown>
+export type ServiceQuery<S extends Schema, N extends ServiceNames<S>> = DeriveQuery<
+  ServiceByName<S, N>
+>
 
-export type ServiceMethods<S extends Schema, N extends ServiceNames<S>> =
-  ServiceByName<S, N> extends { [$phantom]?: { methods: infer M extends ServiceMethodsMap } }
-    ? M
-    : Record<string, never>
+export type ServiceMethods<S extends Schema, N extends ServiceNames<S>> = DeriveMethods<
+  ServiceByName<S, N>
+>
 
-// Utility type to extract item type from a service
-export type Item<S> = S extends { [$phantom]?: { item: infer I } } ? I : Record<string, unknown>
+// Utility types to extract payloads from one service definition
+export type Item<TServiceDef extends ServiceDefinition> = TServiceDef['item']
 
-// Utility type to extract create type from a service
-export type Create<S> = S extends { [$phantom]?: { create: infer C } } ? C : Record<string, unknown>
+export type Create<TServiceDef extends ServiceDefinition> = DeriveCreate<TServiceDef>
 
-// Utility type to extract update type from a service
-export type Update<S> = S extends { [$phantom]?: { update: infer U } } ? U : Record<string, unknown>
+export type Update<TServiceDef extends ServiceDefinition> = DeriveUpdate<TServiceDef>
 
-// Utility type to extract patch type from a service
-export type Patch<S> = S extends { [$phantom]?: { patch: infer P } } ? P : Record<string, unknown>
+export type Patch<TServiceDef extends ServiceDefinition> = DerivePatch<TServiceDef>
 
-// Utility type to extract query type from a service
-export type Query<S> = S extends { [$phantom]?: { query: infer Q } } ? Q : Record<string, unknown>
+export type Query<TServiceDef extends ServiceDefinition> = DeriveQuery<TServiceDef>
 
-// Utility type to extract methods from a service
-export type Methods<S> = S extends { [$phantom]?: { methods: infer M } } ? M : Record<string, never>
+export type Methods<TServiceDef extends ServiceDefinition> = DeriveMethods<TServiceDef>
 
-// Helper to find service by name string (for runtime lookup)
-export function findServiceByName<S extends Schema>(
-  schema: S | undefined,
-  name: string,
-): Service<unknown, unknown, string> | undefined {
-  if (!schema) return undefined
-  return schema.services[name]
+export function resolveServicePath<S extends Schema>(schema: S | undefined, name: string): string {
+  return schema?.services?.[name]?.path ?? name
 }
 
 // Type guard to check if schema is defined
@@ -223,9 +151,9 @@ export function hasSchema<S extends Schema>(schema: S | undefined): schema is S 
 // Default schema type when no schema is provided
 // Use a branded subtype of Schema so we can detect "untyped schema" in conditional types
 declare const $anySchemaBrand: unique symbol
-export interface AnySchema extends Schema {
+export interface AnySchema extends TypedSchema<Record<string, UntypedServiceDefinition>> {
   readonly [$anySchemaBrand]: 'AnySchema'
 }
 
 // Type for untyped services (fallback for services not in schema)
-export type UntypedService = Service<Record<string, unknown>, unknown, string>
+export type UntypedService = { readonly name: string }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,7 +2,7 @@
 export { Figbird, isFetching, isIdle, isLoading, isPending } from './core/figbird.js'
 
 // schema
-export { defineSchema, defineSchemaFor, defineService } from './core/schema.js'
+export { defineSchema } from './core/schema.js'
 export type {
   AnySchema,
   Create,
@@ -11,9 +11,14 @@ export type {
   Patch,
   Query,
   Schema,
-  Service,
+  SchemaConfig,
+  SchemaDefinitions,
+  SchemaServiceConfig,
   ServiceByName,
+  ServiceConfig,
   ServiceCreate,
+  ServiceDefinition,
+  ServiceDefinitionMap,
   ServiceItem,
   ServiceMethod,
   ServiceMethods,
@@ -21,8 +26,8 @@ export type {
   ServiceNames,
   ServicePatch,
   ServiceQuery,
-  ServiceTypeDefinition,
   ServiceUpdate,
+  TypedSchema,
   UntypedService,
   Update,
 } from './core/schema.js'

--- a/lib/react/createHooks.ts
+++ b/lib/react/createHooks.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import type { AdapterFindMeta, AdapterParams } from '../adapters/adapter.js'
 import type {
   FeathersClient,
@@ -16,7 +17,7 @@ import type {
   ServiceQuery,
   ServiceUpdate,
 } from '../core/schema.js'
-import { findServiceByName } from '../core/schema.js'
+import { resolveServicePath } from '../core/schema.js'
 import { useMethod as useBaseMethod, type UseMethodResult } from './useMethod.js'
 import { useMutation as useBaseMutation, type UseMutationResult } from './useMutation.js'
 import { useQuery, type QueryResult } from './useQuery.js'
@@ -112,8 +113,8 @@ type InferMeta<F> = AdapterFindMeta<InferAdapter<F>>
  * import { useFind } from './hooks'
  *
  * function MyComponent() {
- *   const people = useFind('api/people') // Fully typed to QueryResult<Person[], FeathersFindMeta>
- *   const peopleService = useService('api/people') // Fully typed Feathers service
+ *   const people = useFind('people') // Fully typed to QueryResult<Person[], FeathersFindMeta>
+ *   const peopleService = useService('people') // Fully typed Feathers service
  * }
  * ```
  */
@@ -143,10 +144,8 @@ export function createHooks<F extends Figbird<any, any>>(
     params?: WithServiceQuery<S, N, TParams> &
       Partial<QueryConfig<ServiceItem<S, N>, ServiceQuery<S, N>>>,
   ) {
-    const service = findServiceByName(figbird.schema, serviceName)
-    const actualServiceName = service?.name ?? serviceName
     const combinedConfig = Object.assign(
-      { serviceName: actualServiceName, method: 'get' as const, resourceId },
+      { serviceName, method: 'get' as const, resourceId },
       params || {},
     )
     const { desc, config } = splitConfig<ServiceItem<S, N>, ServiceQuery<S, N>>(combinedConfig)
@@ -162,20 +161,13 @@ export function createHooks<F extends Figbird<any, any>>(
     params?: WithServiceQuery<S, N, TParams> &
       Partial<QueryConfig<ServiceItem<S, N>[], ServiceQuery<S, N>>>,
   ) {
-    const service = findServiceByName(figbird.schema, serviceName)
-    const actualServiceName = service?.name ?? serviceName
-    const combinedConfig = Object.assign(
-      { serviceName: actualServiceName, method: 'find' as const },
-      params || {},
-    )
+    const combinedConfig = Object.assign({ serviceName, method: 'find' as const }, params || {})
     const { desc, config } = splitConfig<ServiceItem<S, N>[], ServiceQuery<S, N>>(combinedConfig)
     return useQuery<ServiceItem<S, N>[], TMeta, ServiceQuery<S, N>>(desc, config)
   }
 
   function useTypedMutation<N extends ServiceNames<S>>(serviceName: N) {
-    const service = findServiceByName(figbird.schema, serviceName)
-    const actualServiceName = service?.name ?? serviceName
-    return useBaseMutation(actualServiceName) as UseMutationResult<
+    return useBaseMutation(serviceName) as UseMutationResult<
       ServiceItem<S, N>,
       ServiceCreate<S, N>,
       ServiceUpdate<S, N>,
@@ -184,19 +176,22 @@ export function createHooks<F extends Figbird<any, any>>(
   }
 
   function useTypedService<N extends ServiceNames<S>>(serviceName: N) {
-    const service = findServiceByName(figbird.schema, serviceName)
-    const actualServiceName = service?.name ?? serviceName
-    return useTypedFeathers().service(actualServiceName as N)
+    const adapter = figbird.adapter as { feathers?: FeathersClient }
+    if (!adapter?.feathers) {
+      throw new Error('useService must be used with a Feathers adapter')
+    }
+
+    return adapter.feathers.service(
+      resolveServicePath(figbird.schema, serviceName),
+    ) as unknown as TypedServiceForSchema<S, N>
   }
 
   function useTypedMethod<N extends ServiceNames<S>, M extends keyof ServiceMethods<S, N> & string>(
     serviceName: N,
     methodName: M,
   ) {
-    const service = findServiceByName(figbird.schema, serviceName)
-    const actualServiceName = service?.name ?? serviceName
     return useBaseMethod<MethodArgs<ServiceMethods<S, N>[M]>, MethodData<ServiceMethods<S, N>[M]>>(
-      actualServiceName,
+      serviceName,
       methodName,
     )
   }
@@ -206,9 +201,25 @@ export function createHooks<F extends Figbird<any, any>>(
     if (!adapter?.feathers) {
       throw new Error('useFeathers must be used with a Feathers adapter')
     }
-    // Cast through unknown: FeathersClient has the same runtime shape as TypedFeathersClient,
-    // we're just adding type information based on the schema
-    return adapter.feathers as unknown as TypedFeathersClient<S>
+    const { feathers } = adapter
+
+    return useMemo(
+      () =>
+        new Proxy(feathers, {
+          get(target, prop, receiver) {
+            if (prop === 'service') {
+              return <N extends ServiceNames<S>>(serviceName: N) =>
+                target.service(
+                  resolveServicePath(figbird.schema, serviceName),
+                ) as unknown as TypedServiceForSchema<S, N>
+            }
+
+            const value = Reflect.get(target, prop, receiver)
+            return typeof value === 'function' ? value.bind(target) : value
+          },
+        }) as unknown as TypedFeathersClient<S>,
+      [feathers],
+    )
   }
 
   return {

--- a/lib/react/useMethod.ts
+++ b/lib/react/useMethod.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
-import { findServiceByName } from '../core/schema.js'
+import { resolveServicePath } from '../core/schema.js'
 import { useFigbird } from './react.js'
 
 export type UseMethodStatus = 'idle' | 'loading' | 'success' | 'error'
@@ -48,8 +48,7 @@ export function useMethod<TArgs extends unknown[] = unknown[], TResult = unknown
   methodName: string,
 ): UseMethodResult<TArgs, TResult> {
   const figbird = useFigbird()
-  const service = findServiceByName(figbird.schema, serviceName)
-  const actualServiceName = service?.name ?? serviceName
+  const servicePath = resolveServicePath(figbird.schema, serviceName)
 
   const [state, dispatch] = useReducer(methodReducer<TResult>, initialMethodState)
 
@@ -65,11 +64,7 @@ export function useMethod<TArgs extends unknown[] = unknown[], TResult = unknown
     async (...args: TArgs): Promise<TResult> => {
       dispatch({ type: 'calling' })
       try {
-        const result = (await figbird.adapter.mutate(
-          actualServiceName,
-          methodName,
-          args,
-        )) as TResult
+        const result = (await figbird.adapter.mutate(servicePath, methodName, args)) as TResult
         if (mountedRef.current) {
           dispatch({ type: 'success', payload: result })
         }
@@ -82,7 +77,7 @@ export function useMethod<TArgs extends unknown[] = unknown[], TResult = unknown
         throw error
       }
     },
-    [actualServiceName, figbird.adapter, methodName],
+    [figbird.adapter, methodName, servicePath],
   )
 
   const reset = useCallback(() => {

--- a/lib/react/useMutation.ts
+++ b/lib/react/useMutation.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
-import { findServiceByName } from '../core/schema.js'
 import { useFigbird } from './react.js'
 
 interface MutationState<T> {
@@ -50,8 +49,6 @@ export function useMutation(
   serviceName: string,
 ): UseMutationResult<UntypedData, UntypedData, UntypedData, UntypedData> {
   const figbird = useFigbird()
-  const service = findServiceByName(figbird.schema, serviceName)
-  const actualServiceName = service?.name ?? serviceName
 
   const [state, dispatch] = useReducer(mutationReducer<UntypedData | UntypedData[]>, {
     status: 'idle',
@@ -91,51 +88,51 @@ export function useMutation(
     (data: UntypedData | UntypedData[], params?: unknown) =>
       executeMutation(
         figbird.mutate({
-          serviceName: actualServiceName,
+          serviceName,
           method: 'create' as const,
           data,
           params,
         }) as Promise<UntypedData | UntypedData[]>,
       ),
-    [executeMutation, figbird, actualServiceName],
+    [executeMutation, figbird, serviceName],
   ) as UseMutationResult<UntypedData, UntypedData, UntypedData, UntypedData>['create']
   const update = useCallback(
     (id: string | number, data: UntypedData, params?: unknown) =>
       executeMutation(
         figbird.mutate({
-          serviceName: actualServiceName,
+          serviceName,
           method: 'update' as const,
           id,
           data,
           params,
         }) as Promise<UntypedData>,
       ),
-    [executeMutation, figbird, actualServiceName],
+    [executeMutation, figbird, serviceName],
   ) as UseMutationResult<UntypedData, UntypedData, UntypedData, UntypedData>['update']
   const patch = useCallback(
     (id: string | number, data: UntypedData, params?: unknown) =>
       executeMutation(
         figbird.mutate({
-          serviceName: actualServiceName,
+          serviceName,
           method: 'patch' as const,
           id,
           data,
           params,
         }) as Promise<UntypedData>,
       ),
-    [executeMutation, figbird, actualServiceName],
+    [executeMutation, figbird, serviceName],
   ) as UseMutationResult<UntypedData, UntypedData, UntypedData, UntypedData>['patch']
   const remove = useCallback(
     (id: string | number, params?: unknown) =>
       executeMutation(
         figbird.mutate({
-          serviceName: actualServiceName,
+          serviceName,
           method: 'remove' as const,
           id,
           params,
         }) as Promise<UntypedData>,
       ),
-    [executeMutation, figbird, actualServiceName],
+    [executeMutation, figbird, serviceName],
   ) as UseMutationResult<UntypedData, UntypedData, UntypedData, UntypedData>['remove']
 
   return useMemo(

--- a/lib/react/useQuery.ts
+++ b/lib/react/useQuery.ts
@@ -1,6 +1,5 @@
 import { useCallback, useId, useMemo, useRef, useSyncExternalStore } from 'react'
 import { queryIdentityKey, type QueryIdentityConfig } from '../core/queryIdentity.js'
-import { findServiceByName } from '../core/schema.js'
 import {
   splitConfig,
   type QueryConfig,
@@ -37,11 +36,8 @@ export function useGet(
   resourceId: string | number,
   params: Record<string, unknown> = {},
 ): QueryResult<UntypedData> {
-  const figbird = useFigbird()
-  const service = findServiceByName(figbird.schema, serviceName)
-  const actualServiceName = service?.name ?? serviceName
   const { desc, config } = splitConfig<UntypedData, Record<string, unknown>>({
-    serviceName: actualServiceName,
+    serviceName,
     method: 'get' as const,
     resourceId,
     ...params,
@@ -60,11 +56,8 @@ export function useFind(
   serviceName: string,
   params: Record<string, unknown> = {},
 ): QueryResult<UntypedData[], Record<string, unknown>> {
-  const figbird = useFigbird()
-  const service = findServiceByName(figbird.schema, serviceName)
-  const actualServiceName = service?.name ?? serviceName
   const { desc, config } = splitConfig<UntypedData[], Record<string, unknown>>({
-    serviceName: actualServiceName,
+    serviceName,
     method: 'find' as const,
     ...params,
   })

--- a/lib/react/useService.ts
+++ b/lib/react/useService.ts
@@ -1,5 +1,5 @@
 import type { FeathersClient, FeathersService } from '../adapters/feathers.js'
-import { findServiceByName } from '../core/schema.js'
+import { resolveServicePath } from '../core/schema.js'
 import { useFigbird } from './react.js'
 
 /**
@@ -14,6 +14,5 @@ export function useService(serviceName: string): FeathersService {
     throw new Error('useService must be used with a Feathers adapter')
   }
 
-  const service = findServiceByName(figbird.schema, serviceName)
-  return adapter.feathers.service(service?.name ?? serviceName)
+  return adapter.feathers.service(resolveServicePath(figbird.schema, serviceName))
 }

--- a/test/figbird-instance.test.ts
+++ b/test/figbird-instance.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { FeathersAdapter } from '../lib/adapters/feathers'
 import { Figbird } from '../lib/core/figbird'
-import { defineSchema, defineService } from '../lib/core/schema'
+import { defineSchema } from '../lib/core/schema'
 import { mockFeathers } from './helpers'
 
 interface Note {
@@ -18,12 +18,12 @@ interface Post {
   updatedAt?: number
 }
 
-const schema = defineSchema({
-  services: {
-    notes: defineService<{ item: Note }>(),
-    posts: defineService<{ item: Post }>(),
-  },
-})
+interface AppSchemaTypes {
+  notes: { item: Note }
+  posts: { item: Post }
+}
+
+const schema = defineSchema<AppSchemaTypes>()
 
 function wait(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))

--- a/test/figbird.test.tsx
+++ b/test/figbird.test.tsx
@@ -1,8 +1,7 @@
 import test from 'ava'
-import React, { StrictMode, useEffect, useState } from 'react'
+import React, { StrictMode, useEffect, useRef, useState } from 'react'
 import type {
   FeathersClient,
-  FeathersService,
   QueryResult,
   QueryStatus,
   UseMethodResult,
@@ -14,7 +13,6 @@ import {
   FeathersAdapter,
   Figbird,
   FigbirdProvider,
-  defineService,
   useFeathers,
   useService as useGlobalService,
 } from '../lib'
@@ -44,12 +42,12 @@ interface NoteService {
   }
 }
 
+interface AppSchemaTypes {
+  notes: NoteService
+}
+
 // Create schema for typed hooks
-const schema = defineSchema({
-  services: {
-    notes: defineService<NoteService>(),
-  },
-})
+const schema = defineSchema<AppSchemaTypes>()
 
 type AppSchema = typeof schema
 
@@ -234,10 +232,12 @@ test('useGet updates after realtime patch', async t => {
 test('useService returns a Feathers service with CRUD and custom methods', async t => {
   const { render, flush, unmount } = dom()
   const { App, useService, feathers } = app()
-  type ArchiveService = FeathersService & { archive: NoteService['methods']['archive'] }
+  type ArchiveService = ReturnType<typeof feathers.service> & {
+    archive: NoteService['methods']['archive']
+  }
   const notesService = feathers.service('notes') as unknown as ArchiveService
   notesService.archive = async id => {
-    const note = (await notesService.patch(id, { archived: true })) as Note
+    const note = (await notesService.patch(id, { archived: true })) as unknown as Note
     return { id: note.id, archived: note.archived === true }
   }
 
@@ -271,6 +271,97 @@ test('useService returns a Feathers service with CRUD and custom methods', async
   t.is(typedGetResult!.content, 'hello')
   t.deepEqual(typedArchiveResult, { id: 1, archived: true })
   t.true(globalGetResult!.archived)
+
+  unmount()
+})
+
+test('schema service path config maps service keys to adapter paths', async t => {
+  const { render, flush, unmount, $ } = dom()
+  const pathSchema = defineSchema<AppSchemaTypes>({
+    services: {
+      notes: { path: 'api/notes' },
+    },
+  })
+  const feathers = mockFeathers({
+    'api/notes': {
+      data: {
+        1: {
+          id: 1,
+          content: 'hello',
+          updatedAt: new Date('2024-02-02').getTime(),
+        },
+      },
+    },
+  })
+  type ArchiveService = ReturnType<typeof feathers.service> & {
+    archive: NoteService['methods']['archive']
+  }
+  const notesService = feathers.service('api/notes') as unknown as ArchiveService
+  notesService.archive = async id => {
+    const note = (await notesService.patch(id, { archived: true })) as unknown as Note
+    return { id: note.id, archived: note.archived === true }
+  }
+  const adapter = new FeathersAdapter(feathers)
+  const figbird = new Figbird({ schema: pathSchema, adapter, eventBatchProcessingInterval: 0 })
+  const { useFind, useMutation, useService, useMethod, useFeathers } = createHooks(figbird)
+
+  let resolveOperations: (value: {
+    serviceGet: Note
+    feathersGet: Note
+    archived: { id: number; archived: boolean }
+    created: Note
+  }) => void = () => {}
+  const operations = new Promise<{
+    serviceGet: Note
+    feathersGet: Note
+    archived: { id: number; archived: boolean }
+    created: Note
+  }>(resolve => {
+    resolveOperations = resolve
+  })
+
+  function PathMappedNotes() {
+    const notes = useFind('notes')
+    const typedNotes = useService('notes')
+    const typedFeathers = useFeathers()
+    const { create } = useMutation('notes')
+    const [archive] = useMethod('notes', 'archive')
+    const ran = useRef(false)
+
+    useEffect(() => {
+      if (ran.current) return
+      ran.current = true
+      ;(async () => {
+        const serviceGet = await typedNotes.get(1)
+        const feathersGet = await typedFeathers.service('notes').get(1)
+        const archived = await archive(1)
+        const created = await create({ id: 2, content: 'created' })
+        resolveOperations({ serviceGet, feathersGet, archived, created })
+      })()
+    }, [archive, create, typedFeathers, typedNotes])
+
+    return <div className='path-note'>{notes.data?.[0]?.content ?? ''}</div>
+  }
+
+  render(
+    <FigbirdProvider figbird={figbird}>
+      <PathMappedNotes />
+    </FigbirdProvider>,
+  )
+
+  await flush()
+  const result = await operations
+  await flush()
+
+  t.is($('.path-note')!.innerHTML, 'hello')
+  t.is(notesService.counts.find, 1)
+  t.is(notesService.counts.get, 2)
+  t.is(notesService.counts.patch, 1)
+  t.is(notesService.counts.create, 1)
+  t.is(result.serviceGet.content, 'hello')
+  t.is(result.feathersGet.content, 'hello')
+  t.deepEqual(result.archived, { id: 1, archived: true })
+  t.is(result.created.content, 'created')
 
   unmount()
 })

--- a/test/fixtures/figbird-methods-inference.ts
+++ b/test/fixtures/figbird-methods-inference.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable @typescript-eslint/no-unused-vars */
 import type { FeathersClient } from '../../lib'
-import { FeathersAdapter, Figbird, defineSchema, defineService } from '../../lib'
+import { FeathersAdapter, Figbird, defineSchema } from '../../lib'
 
 // Define a simple Person model
 interface Person {
@@ -13,12 +13,12 @@ interface PersonService {
   item: Person
 }
 
+interface AppSchemaTypes {
+  'api/people': PersonService
+}
+
 // Build schema with a single service
-const schema = defineSchema({
-  services: {
-    'api/people': defineService<PersonService>(),
-  },
-})
+const schema = defineSchema<AppSchemaTypes>()
 
 // Figbird instance with Feathers adapter (meta inferred as FeathersFindMeta)
 const feathers = {} as FeathersClient

--- a/test/fixtures/generated-schema-helpers.ts
+++ b/test/fixtures/generated-schema-helpers.ts
@@ -1,9 +1,10 @@
 import type { FeathersClient } from '../../lib'
 import {
   createHooks,
-  defineSchemaFor,
+  defineSchema,
   FeathersAdapter,
   Figbird,
+  type ServiceByName,
   type ServiceCreate,
   type ServiceItem,
   type ServicePatch,
@@ -47,9 +48,7 @@ interface GeneratedApiSchemaTypes {
   }
 }
 
-export const schemaFromNames = defineSchemaFor<GeneratedApiSchemaTypes>()({
-  services: ['api/people', 'api/tasks'],
-})
+export const schemaFromNames = defineSchema<GeneratedApiSchemaTypes>()
 
 type AppSchema = typeof schemaFromNames
 
@@ -63,7 +62,7 @@ export type PeopleQuery = ServiceQuery<AppSchema, 'api/people'>
 export type PeopleCreate = ServiceCreate<AppSchema, 'api/people'>
 export type PeoplePatch = ServicePatch<AppSchema, 'api/people'>
 export type TaskCreate = ServiceCreate<AppSchema, 'api/tasks'>
-export type PeopleService = (typeof schemaFromNames.services)['api/people']
+export type PeopleService = ServiceByName<AppSchema, 'api/people'>
 
 export const people = useFind('api/people', {
   query: {

--- a/test/fixtures/inferred-meta-from-figbird.ts
+++ b/test/fixtures/inferred-meta-from-figbird.ts
@@ -4,7 +4,7 @@
  */
 
 import type { FeathersClient } from '../../lib'
-import { createHooks, defineSchema, FeathersAdapter, Figbird, defineService } from '../../lib'
+import { createHooks, defineSchema, FeathersAdapter, Figbird } from '../../lib'
 
 // Define domain types
 interface Task {
@@ -29,13 +29,13 @@ interface ProjectService {
   item: Project
 }
 
+interface AppSchemaTypes {
+  tasks: TaskService
+  projects: ProjectService
+}
+
 // Create schema
-const schema = defineSchema({
-  services: {
-    tasks: defineService<TaskService>(),
-    projects: defineService<ProjectService>(),
-  },
-})
+const schema = defineSchema<AppSchemaTypes>()
 
 // Mock Feathers client
 const feathersClient = {} as FeathersClient

--- a/test/fixtures/multi-service-inference.ts
+++ b/test/fixtures/multi-service-inference.ts
@@ -4,7 +4,7 @@ import {
   defineSchema,
   FeathersAdapter,
   Figbird,
-  defineService,
+  type ServiceByName,
   type ServiceItem,
 } from '../../lib'
 
@@ -32,12 +32,12 @@ interface TaskService {
   item: Task
 }
 
-export const schema = defineSchema({
-  services: {
-    'api/people': defineService<PersonService>(),
-    'api/tasks': defineService<TaskService>(),
-  },
-})
+interface AppSchemaTypes {
+  'api/people': PersonService
+  'api/tasks': TaskService
+}
+
+export const schema = defineSchema<AppSchemaTypes>()
 
 type AppSchema = typeof schema
 
@@ -50,8 +50,8 @@ const figbird = new Figbird({ schema, adapter })
 const { useFind } = createHooks(figbird)
 
 // Debug types - these will be inspected by the test
-export type PersonServiceByName = AppSchema['services']['api/people']
-export type TaskServiceByName = AppSchema['services']['api/tasks']
+export type PersonServiceByName = ServiceByName<AppSchema, 'api/people'>
+export type TaskServiceByName = ServiceByName<AppSchema, 'api/tasks'>
 export type PersonServiceItem = ServiceItem<AppSchema, 'api/people'>
 export type TaskServiceItem = ServiceItem<AppSchema, 'api/tasks'>
 

--- a/test/fixtures/optional-query-inference.ts
+++ b/test/fixtures/optional-query-inference.ts
@@ -1,4 +1,4 @@
-import { defineSchema, defineService } from '../../lib'
+import { defineSchema } from '../../lib'
 
 interface Task {
   id: string
@@ -16,14 +16,14 @@ interface TaskServiceDefinition {
   query?: TaskQuery
 }
 
-export const schema = defineSchema({
-  services: {
-    tasks: defineService<TaskServiceDefinition>(),
-  },
-})
+interface AppSchemaTypes {
+  tasks: TaskServiceDefinition
+}
 
-export const taskService = schema.services.tasks
+export const schema = defineSchema<AppSchemaTypes>()
 
-type TaskService = (typeof schema.services)['tasks']
+type AppSchema = typeof schema
+
+export type TaskService = import('../../lib').ServiceByName<AppSchema, 'tasks'>
 
 export type TaskQueryType = import('../../lib').Query<TaskService>

--- a/test/fixtures/params-type-inference.ts
+++ b/test/fixtures/params-type-inference.ts
@@ -7,7 +7,7 @@
  */
 
 import type { FeathersClient } from '../../lib'
-import { createHooks, defineSchema, FeathersAdapter, Figbird, defineService } from '../../lib'
+import { createHooks, defineSchema, FeathersAdapter, Figbird } from '../../lib'
 
 // Define a model
 interface Product {
@@ -23,12 +23,12 @@ interface ProductService {
   item: Product
 }
 
+interface AppSchemaTypes {
+  products: ProductService
+}
+
 // Create schema
-const schema = defineSchema({
-  services: {
-    products: defineService<ProductService>(),
-  },
-})
+const schema = defineSchema<AppSchemaTypes>()
 
 // Setup Figbird with FeathersAdapter
 const feathersClient = {} as FeathersClient

--- a/test/fixtures/real-world-meta-usage.ts
+++ b/test/fixtures/real-world-meta-usage.ts
@@ -4,7 +4,7 @@
  */
 
 import type { FeathersClient } from '../../lib'
-import { createHooks, defineSchema, FeathersAdapter, Figbird, defineService } from '../../lib'
+import { createHooks, defineSchema, FeathersAdapter, Figbird } from '../../lib'
 
 // Define domain models
 interface Article {
@@ -32,13 +32,13 @@ interface CommentService {
   item: Comment
 }
 
+interface AppSchemaTypes {
+  articles: ArticleService
+  comments: CommentService
+}
+
 // Create schema with services
-const schema = defineSchema({
-  services: {
-    articles: defineService<ArticleService>(),
-    comments: defineService<CommentService>(),
-  },
-})
+const schema = defineSchema<AppSchemaTypes>()
 
 // Create Figbird instance with FeathersAdapter
 const feathers = {} as FeathersClient

--- a/test/fixtures/typed-feathers-client.ts
+++ b/test/fixtures/typed-feathers-client.ts
@@ -1,5 +1,5 @@
 import type { FeathersClient } from '../../lib'
-import { createHooks, defineSchema, FeathersAdapter, Figbird, defineService } from '../../lib'
+import { createHooks, defineSchema, FeathersAdapter, Figbird } from '../../lib'
 
 // Test typed Feathers client with CRUD methods
 interface Note {
@@ -45,12 +45,12 @@ interface TaskService {
   item: Task
 }
 
-export const schema = defineSchema({
-  services: {
-    notes: defineService<NotesService>(),
-    tasks: defineService<TaskService>(),
-  },
-})
+interface AppSchemaTypes {
+  notes: NotesService
+  tasks: TaskService
+}
+
+export const schema = defineSchema<AppSchemaTypes>()
 
 // Create Figbird instance
 const feathers = {} as FeathersClient

--- a/test/fixtures/use-method-inference.ts
+++ b/test/fixtures/use-method-inference.ts
@@ -1,5 +1,5 @@
 import type { FeathersClient } from '../../lib'
-import { createHooks, defineSchema, defineService, FeathersAdapter, Figbird } from '../../lib'
+import { createHooks, defineSchema, FeathersAdapter, Figbird } from '../../lib'
 
 interface EsignInstance {
   id: string
@@ -31,12 +31,12 @@ interface MessageService {
   }
 }
 
-const schema = defineSchema({
-  services: {
-    'api/esign-instances': defineService<EsignInstanceService>(),
-    'api/messages': defineService<MessageService>(),
-  },
-})
+interface AppSchemaTypes {
+  'api/esign-instances': EsignInstanceService
+  'api/messages': MessageService
+}
+
+const schema = defineSchema<AppSchemaTypes>()
 
 const feathers = {} as FeathersClient
 const adapter = new FeathersAdapter(feathers)

--- a/test/locked-query.test.tsx
+++ b/test/locked-query.test.tsx
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { FeathersAdapter } from '../lib/adapters/feathers.js'
 import { Figbird } from '../lib/core/figbird.js'
-import { defineSchema, defineService } from '../lib/core/schema.js'
+import { defineSchema } from '../lib/core/schema.js'
 import { createHooks } from '../lib/react/createHooks.js'
 import { FigbirdProvider } from '../lib/react/react.js'
 import { dom, mockFeathers } from './helpers.js'
@@ -48,22 +48,20 @@ interface Note {
 }
 
 test('locked-down query types work correctly', async t => {
-  const schema = defineSchema({
-    services: {
-      people: defineService<{
-        item: Person
-        query: StrictQuery
-      }>(),
-      todos: defineService<{
-        item: Todo
-        query: PaginatedQuery
-      }>(),
-      notes: defineService<{
-        item: Note
-        query: MinimalQuery
-      }>(),
-    },
-  })
+  const schema = defineSchema<{
+    people: {
+      item: Person
+      query: StrictQuery
+    }
+    todos: {
+      item: Todo
+      query: PaginatedQuery
+    }
+    notes: {
+      item: Note
+      query: MinimalQuery
+    }
+  }>()
 
   const feathers = mockFeathers({
     people: {
@@ -176,14 +174,12 @@ test('locked-down query types work correctly', async t => {
 // The server will reject invalid query fields if someone bypasses TypeScript
 
 test('allPages works correctly with proper pagination fields', async t => {
-  const schema = defineSchema({
-    services: {
-      todos: defineService<{
-        item: Todo
-        query: PaginatedQuery
-      }>(),
-    },
-  })
+  const schema = defineSchema<{
+    todos: {
+      item: Todo
+      query: PaginatedQuery
+    }
+  }>()
 
   // Create 10 items for pagination testing
   const data: Record<string, Todo> = {}
@@ -236,14 +232,12 @@ test('allPages works correctly with proper pagination fields', async t => {
 test('React hooks work with locked-down query types', async t => {
   const { $all, render, unmount, flush } = dom()
 
-  const schema = defineSchema({
-    services: {
-      people: defineService<{
-        item: Person
-        query: StrictQuery
-      }>(),
-    },
-  })
+  const schema = defineSchema<{
+    people: {
+      item: Person
+      query: StrictQuery
+    }
+  }>()
 
   const feathers = mockFeathers({
     people: {

--- a/test/matcher-types.test.tsx
+++ b/test/matcher-types.test.tsx
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { FeathersAdapter } from '../lib/adapters/feathers.js'
 import { Figbird } from '../lib/core/figbird.js'
-import { defineSchema, defineService } from '../lib/core/schema.js'
+import { defineSchema } from '../lib/core/schema.js'
 import { createHooks } from '../lib/react/createHooks.js'
 import { FigbirdProvider } from '../lib/react/react.js'
 import { dom, mockFeathers } from './helpers.js'
@@ -38,18 +38,16 @@ interface User {
 }
 
 test('matcher receives properly typed query from schema', async t => {
-  const schema = defineSchema({
-    services: {
-      todos: defineService<{
-        item: Todo
-        query: TodoQuery
-      }>(),
-      users: defineService<{
-        item: User
-        query: UserQuery
-      }>(),
-    },
-  })
+  const schema = defineSchema<{
+    todos: {
+      item: Todo
+      query: TodoQuery
+    }
+    users: {
+      item: User
+      query: UserQuery
+    }
+  }>()
 
   const feathers = mockFeathers({
     todos: {
@@ -159,14 +157,12 @@ test('matcher receives properly typed query from schema', async t => {
 test('React hooks provide typed query in matcher', async t => {
   const { render, unmount, flush } = dom()
 
-  const schema = defineSchema({
-    services: {
-      todos: defineService<{
-        item: Todo
-        query: TodoQuery
-      }>(),
-    },
-  })
+  const schema = defineSchema<{
+    todos: {
+      item: Todo
+      query: TodoQuery
+    }
+  }>()
 
   const feathers = mockFeathers({
     todos: {
@@ -250,14 +246,12 @@ test('React hooks provide typed query in matcher', async t => {
 })
 
 test('matcher with undefined query works correctly', async t => {
-  const schema = defineSchema({
-    services: {
-      items: defineService<{
-        item: { id: string; name: string }
-        query: { search?: string }
-      }>(),
-    },
-  })
+  const schema = defineSchema<{
+    items: {
+      item: { id: string; name: string }
+      query: { search?: string }
+    }
+  }>()
 
   const feathers = mockFeathers({
     items: {

--- a/test/schema.test.tsx
+++ b/test/schema.test.tsx
@@ -6,7 +6,6 @@ import {
   FeathersAdapter,
   Figbird,
   FigbirdProvider,
-  defineService,
   useFigbird,
   useFind as useUntypedFind,
   useGet as useUntypedGet,
@@ -62,14 +61,14 @@ interface ProjectService {
   item: Project
 }
 
+interface AppSchemaTypes {
+  'api/people': PersonService
+  'api/tasks': TaskService
+  'api/projects': ProjectService
+}
+
 // Define schema with typed services
-const schema = defineSchema({
-  services: {
-    'api/people': defineService<PersonService>(),
-    'api/tasks': defineService<TaskService>(),
-    'api/projects': defineService<ProjectService>(),
-  },
-})
+const schema = defineSchema<AppSchemaTypes>()
 
 type AppSchema = typeof schema
 
@@ -301,16 +300,10 @@ test('schema-based type inference', t => {
   })
 })
 
-test('schema with array of services', t => {
+test('schema type map works across multiple services', t => {
   const { render, unmount, flush, $ } = dom()
 
-  // Services are defined in an object map
-  const schema = defineSchema({
-    services: {
-      'api/people': defineService<PersonService>(),
-      'api/tasks': defineService<TaskService>(),
-    },
-  })
+  const schema = defineSchema<AppSchemaTypes>()
 
   const feathers = mockFeathers({
     'api/people': {
@@ -417,8 +410,8 @@ test('backward compatibility - untyped usage still works', t => {
 
 test('type extraction utilities', t => {
   // Test that type extraction utilities work correctly
-  type PersonService = (typeof schema.services)['api/people']
-  type PersonItem = import('../lib').Item<PersonService>
+  type PersonServiceDef = import('../lib').ServiceByName<AppSchema, 'api/people'>
+  type PersonItem = import('../lib').Item<PersonServiceDef>
 
   // These assertions are compile-time only, but we can test runtime behavior
   const person: PersonItem = {
@@ -432,8 +425,8 @@ test('type extraction utilities', t => {
   t.is(person.role, 'user')
 
   // Query type includes custom extensions
-  type TaskService = (typeof schema.services)['api/tasks']
-  type TaskQueryType = import('../lib').Query<TaskService>
+  type TaskServiceDef = import('../lib').ServiceByName<AppSchema, 'api/tasks'>
+  type TaskQueryType = import('../lib').Query<TaskServiceDef>
 
   const query: TaskQueryType = {
     $search: 'test',

--- a/test/type-inference.test.ts
+++ b/test/type-inference.test.ts
@@ -104,19 +104,9 @@ test('type narrowing works correctly with multiple services', t => {
   const taskItemType = getTypeAtPosition(fixturePath, 'TaskServiceItem')
   const tasksType = getTypeAtPosition(fixturePath, 'tasks')
 
-  // Test that the key types are working correctly (Service has more type parameters now)
-  t.true(
-    personServiceType.startsWith(
-      'import("figbird").Service<Person, Record<string, unknown>, "api/people"',
-    ),
-    `Expected personServiceType to start with Service<Person, ...>, got: ${personServiceType}`,
-  )
-  t.true(
-    taskServiceType.startsWith(
-      'import("figbird").Service<Task, Record<string, unknown>, "api/tasks"',
-    ),
-    `Expected taskServiceType to start with Service<Task, ...>, got: ${taskServiceType}`,
-  )
+  // Test that the canonical service-definition map is preserved
+  t.is(personServiceType, 'PersonService')
+  t.is(taskServiceType, 'TaskService')
 
   // Test that ServiceItem extraction is working
   t.is(personItemType, 'Person')
@@ -228,7 +218,7 @@ test('optional query definitions are inferred', t => {
   t.is(taskQueryType, 'TaskQuery')
 })
 
-test('generated schema helpers infer service contracts without intersections', t => {
+test('generated schema maps infer service contracts without intersections', t => {
   const fixturePath = join(__dirname, 'fixtures', 'generated-schema-helpers.ts')
 
   const peopleItemType = getTypeAtPosition(fixturePath, 'PeopleItem')
@@ -244,11 +234,9 @@ test('generated schema helpers infer service contracts without intersections', t
   t.is(peopleCreateType, 'PersonCreate')
   t.is(peoplePatchType, 'PersonPatch')
   t.is(taskCreateType, 'Partial<Task>')
-  t.true(
-    peopleServiceType.startsWith(
-      'import("figbird").Service<Person, PersonQuery, "api/people", PersonCreate',
-    ),
-    `Expected defineSchemaFor to preserve the generated service contract, got: ${peopleServiceType}`,
+  t.is(
+    peopleServiceType,
+    '{ item: Person; create: PersonCreate; patch: PersonPatch; query: PersonQuery; }',
   )
   t.is(peopleType, 'import("figbird").QueryResult<Person[], import("figbird").FeathersFindMeta>')
 })


### PR DESCRIPTION
Summary
- Replace service-object schemas with canonical service-definition maps via defineSchema<ServiceMap>()({ services })
- Remove defineSchemaFor and defineService from public exports
- Update docs, fixtures, and type inference tests for the new schema model

Verification
- npm run tsc
- npm run lint
- npm run ava
- npm run test