### PR TITLE
Retry failed query fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Figbird Changelog
 
+## Unreleased
+
+- Retry failed query fetches up to three times with exponential backoff before exposing
+  the error. Configure the instance with `retry` and `retryDelay`; descriptor queries can
+  override both or disable retries with `retry: false`.
+
 ## 0.24.0
 
 The relational rewrite.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ function NoteRow({ note }: { note: Note & { author?: User } }) {
 ```
 
 No provider needed — the hooks are bound to the instance. Cold reads suspend into your `<Suspense>` boundary; warm reads render synchronously.
+Failed fetches retry up to three times with exponential backoff before Figbird exposes the error.
 
 ## Features
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -777,6 +777,40 @@ useQuery(q.currencies, { staleTime: Infinity }) // cache-first
 It is a read-site option, not query identity: readers with different tolerances share one cache
 entry, and the most demanding one keeps it freshest. `prepare()` and `prefetch()` accept it too.
 
+### Fetch retries
+
+Figbird retries a failed fetch up to three times before exposing the error. The default
+delay uses exponential backoff: 1s, 2s, then 4s, capped at 30s if you allow more retries.
+The query stays in its fetching state between attempts, so a cold query keeps suspending
+and a background refetch keeps showing its cached data. Only the final failure enters the
+error state.
+
+Configure the policy on the instance:
+
+```ts
+const figbird = new Figbird({
+  adapter,
+  schema,
+  retry: 5, // retries after the initial request
+  retryDelay: (attempt, error) => Math.min(500 * 2 ** (attempt - 1), 10_000),
+})
+```
+
+`attempt` is one-based: `1` is the first retry. Pass a number for a fixed delay, or
+`retry: false` to disable automatic retries. A manual `refetch()` after the final error
+starts a new retry budget.
+
+Descriptor queries can override the instance policy with numeric `retry` and
+`retryDelay` options:
+
+```ts
+useFind('audit-log', { retry: false })
+figbird.queryDesc(desc, { retry: 1, retryDelay: 250 })
+```
+
+Each network attempt emits its own fetch lifecycle events and contributes to the query's
+fetch and error counts in `inspect()`.
+
 ### Freezing a query: .snapshot()
 
 `.snapshot()` fetches once and then ignores realtime entirely, for the root and every
@@ -1318,7 +1352,14 @@ order.
 The core instance holding the adapter, schema, and shared query state.
 
 ```ts
-const figbird = new Figbird({ adapter, schema, eventBatchInterval?, reconnectJitter? })
+const figbird = new Figbird({
+  adapter,
+  schema,
+  eventBatchInterval?,
+  retry?,
+  retryDelay?,
+  reconnectJitter?,
+})
 ```
 
 | Member                                            | Description                                                                                                                                                 |
@@ -1522,6 +1563,8 @@ automatically, via `swr` + classification-driven realtime):
 - `fetchPolicy` — cache vs network: `swr` (default — show cached, revalidate in background),
   `cache-first` (fetch only when nothing is cached), or `network-only` (always fetch;
   hook-scoped results)
+- `retry` — failed fetches to retry before exposing the error; `false` disables retries
+- `retryDelay` — fixed delay in milliseconds between retries
 - `allPages` — fetch all pages (`parallel` + `parallelLimit` control concurrency)
 - `matcher` — custom `(query) => (item) => boolean` for realtime merging
 - `matcherKey` — opt into sharing equivalent custom-matcher queries across hooks;

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -25,9 +25,14 @@ import {
 import { explainQuery, type ExplainReport, type QueryNodeClass } from './queryClassification.js'
 export type { ExplainNode, ExplainReport } from './queryClassification.js'
 import { QueryRef } from './queryRef.js'
-import { QueryStore, type ReconnectJitter, type VisibilitySource } from './queryStore.js'
+import {
+  QueryStore,
+  type ReconnectJitter,
+  type RetryDelay,
+  type VisibilitySource,
+} from './queryStore.js'
 
-export type { ReconnectJitter, VisibilitySource } from './queryStore.js'
+export type { ReconnectJitter, RetryDelay, VisibilitySource } from './queryStore.js'
 export { DevtoolsControl } from './devtoolsControl.js'
 export type { DevtoolsPreference } from './devtoolsControl.js'
 import {
@@ -148,6 +153,10 @@ export class Figbird<
    * @param reconcileCooldown Burst safety: minimum interval (ms) between event-driven
    *   refetches of one query. First event refetches immediately; further events within
    *   the window coalesce into one guaranteed trailing refetch. Default 2000; 0 disables.
+   * @param retry Failed fetches to retry before exposing the error. Defaults to 3;
+   *   `false` disables automatic retry.
+   * @param retryDelay Fixed or computed delay before each retry. Defaults to exponential
+   *   backoff (1s, 2s, 4s, capped at 30s).
    * @param reconnectJitter Random delay before a reconnect sweep, which staggers visible
    *   clients after a server restart. Defaults to [0, 3000]; 0 restores immediate sweeps.
    * @param visibility Visibility source for hidden-tab gating (defaults to `document`).
@@ -164,6 +173,8 @@ export class Figbird<
     eventBatchInterval,
     schema,
     reconcileCooldown,
+    retry,
+    retryDelay,
     reconnectJitter,
     visibility,
     defaultSort,
@@ -172,6 +183,8 @@ export class Figbird<
     eventBatchInterval?: number
     schema?: S
     reconcileCooldown?: number
+    retry?: number | false
+    retryDelay?: RetryDelay
     reconnectJitter?: ReconnectJitter
     visibility?: VisibilitySource
     defaultSort?: Record<string, 1 | -1>
@@ -182,6 +195,8 @@ export class Figbird<
       adapter,
       eventBatchInterval,
       ...(reconcileCooldown !== undefined ? { reconcileCooldown } : {}),
+      ...(retry !== undefined ? { retry } : {}),
+      ...(retryDelay !== undefined ? { retryDelay } : {}),
       ...(reconnectJitter !== undefined ? { reconnectJitter } : {}),
       ...(visibility !== undefined ? { visibility } : {}),
       ...(defaultSort !== undefined ? { defaultSort } : {}),

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -54,6 +54,16 @@ export interface VisibilitySource {
 /** Random reconnect delay in ms. A number means `[0, number]`; `0` disables jitter. */
 export type ReconnectJitter = number | readonly [number, number]
 
+/** Delay before a retry. `attempt` is one-based: 1 is the first retry. */
+export type RetryDelay = number | ((attempt: number, error: Error) => number)
+
+const DEFAULT_RETRIES = 3
+const MAX_RETRY_DELAY = 30_000
+
+function defaultRetryDelay(attempt: number): number {
+  return Math.min(1000 * 2 ** (attempt - 1), MAX_RETRY_DELAY)
+}
+
 type ItemId = string | number
 
 /** The realtime event type a mutation verb produces. */
@@ -119,8 +129,11 @@ export class QueryStore<
   #deferredWhileHidden: Set<string> = new Set()
 
   #defaultSort: Record<string, number> | undefined
+  #retry: number | false
+  #retryDelay: RetryDelay
   #reconnectJitter: readonly [number, number]
   #reconnectSweepTimer: ReturnType<typeof setTimeout> | null = null
+  #retryTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
   #warnedMissingIdServices: Set<string> = new Set()
 
   #eventQueue: QueuedEvent[] = []
@@ -135,6 +148,8 @@ export class QueryStore<
     adapter,
     eventBatchInterval = 100,
     reconcileCooldown = 2000,
+    retry = DEFAULT_RETRIES,
+    retryDelay = defaultRetryDelay,
     reconnectJitter = [0, 3000],
     visibility,
     defaultSort,
@@ -148,6 +163,10 @@ export class QueryStore<
      * window coalesce into one guaranteed trailing refetch. `0` disables.
      */
     reconcileCooldown?: number
+    /** Failed fetches to retry. Defaults to 3; `false` disables retries. */
+    retry?: number | false
+    /** Fixed or computed delay before each retry. Defaults to 1s, 2s, 4s, capped at 30s. */
+    retryDelay?: RetryDelay
     /** Random delay before reconnect sweeps. A number means `[0, number]`; `0` disables. */
     reconnectJitter?: ReconnectJitter
     /** Visibility source for hidden-tab gating. Defaults to `document`. */
@@ -167,6 +186,8 @@ export class QueryStore<
     this.#events = new FigbirdEventEmitter()
     this.#mutations = new MutationTracker()
     this.#reconcileCooldown = reconcileCooldown
+    this.#retry = this.#normalizeRetry(retry)
+    this.#retryDelay = retryDelay
     this.#reconnectJitter = this.#normalizeReconnectJitter(reconnectJitter)
     this.#visibility = visibility ?? documentVisibility()
     this.#visibility.onChange(() => this.#drainDeferredReconciles())
@@ -505,8 +526,24 @@ export class QueryStore<
   }
 
   // Query lifecycle
-  async #queue(queryId: string): Promise<void> {
-    this.#fetching({ queryId })
+  async #queue(
+    queryId: string,
+    {
+      retryAttempt = 0,
+      expectedGeneration,
+    }: { retryAttempt?: number; expectedGeneration?: number } = {},
+  ): Promise<void> {
+    if (
+      expectedGeneration !== undefined &&
+      this.#queryGenerations.get(queryId) !== expectedGeneration
+    ) {
+      return
+    }
+
+    if (retryAttempt === 0) {
+      this.#clearRetryTimer(queryId)
+      this.#fetching({ queryId })
+    }
     const query = this.#getQuery(queryId)
     const generation = this.#queryGenerations.get(queryId)
     const startedAt = query ? Date.now() : undefined
@@ -575,7 +612,6 @@ export class QueryStore<
         current &&
         this.#queryGenerations.get(queryId) === trace.generation
       ) {
-        this.#fetchFailed({ queryId, error })
         this.#recordFetchStats(queryId, { ok: false, durationMs })
       }
       if (trace && durationMs !== undefined) {
@@ -589,10 +625,88 @@ export class QueryStore<
           error,
         })
       }
+
+      if (
+        trace &&
+        current &&
+        this.#queryGenerations.get(queryId) === trace.generation &&
+        this.#hasRetryOwner(queryId) &&
+        this.#shouldRetry(current, retryAttempt)
+      ) {
+        this.#scheduleRetry({
+          queryId,
+          generation: trace.generation,
+          retryAttempt: retryAttempt + 1,
+          error,
+        })
+      } else if (trace && current && this.#queryGenerations.get(queryId) === trace.generation) {
+        this.#fetchFailed({ queryId, error })
+      }
     } finally {
       if (journalCursor) {
         this.#fetchEventJournal.end(journalCursor)
       }
+    }
+  }
+
+  #shouldRetry(query: Query<unknown, TMeta, unknown>, retryAttempt: number): boolean {
+    const retry = this.#normalizeRetry(query.config.retry ?? this.#retry)
+    return retry !== false && retryAttempt < retry
+  }
+
+  #scheduleRetry({
+    queryId,
+    generation,
+    retryAttempt,
+    error,
+  }: {
+    queryId: string
+    generation: number
+    retryAttempt: number
+    error: Error
+  }): void {
+    this.#clearRetryTimer(queryId)
+    const configuredDelay = this.#getQuery(queryId)?.config.retryDelay ?? this.#retryDelay
+    const delay = this.#resolveRetryDelay(configuredDelay, retryAttempt, error)
+    const timer = setTimeout(() => {
+      this.#retryTimers.delete(queryId)
+      if (this.#queryGenerations.get(queryId) === generation && !this.#hasRetryOwner(queryId)) {
+        this.#fetchFailed({ queryId, error })
+        return
+      }
+      void this.#queue(queryId, { retryAttempt, expectedGeneration: generation })
+    }, delay)
+    this.#retryTimers.set(queryId, timer)
+  }
+
+  #clearRetryTimer(queryId: string): void {
+    const timer = this.#retryTimers.get(queryId)
+    if (timer === undefined) return
+    clearTimeout(timer)
+    this.#retryTimers.delete(queryId)
+  }
+
+  #normalizeRetry(retry: number | false): number | false {
+    if (retry === false || !Number.isFinite(retry) || retry <= 0) return false
+    return Math.floor(retry)
+  }
+
+  #hasRetryOwner(queryId: string): boolean {
+    if (this.#listenerCount(queryId) > 0) return true
+    const serviceName = this.#serviceNamesByQueryId.get(queryId)
+    return (
+      serviceName !== undefined && this.#state.get(serviceName)?.materialized?.queryId === queryId
+    )
+  }
+
+  #resolveRetryDelay(delay: RetryDelay, attempt: number, error: Error): number {
+    try {
+      const value = typeof delay === 'function' ? delay(attempt, error) : delay
+      return Number.isFinite(value) ? Math.max(0, value) : 0
+    } catch {
+      // A timing hook must not turn a handled fetch failure into an unhandled
+      // rejection. Fall back to the built-in cadence for this attempt.
+      return defaultRetryDelay(attempt)
     }
   }
 
@@ -1556,6 +1670,7 @@ export class QueryStore<
   }
 
   #vacuum({ queryId }: { queryId: string }): void {
+    this.#clearRetryTimer(queryId)
     this.#clearReconcileState(queryId)
     this.#transactOverService(queryId, (service, query) => {
       if (query) {

--- a/lib/core/queryTypes.ts
+++ b/lib/core/queryTypes.ts
@@ -194,6 +194,15 @@ interface BaseQueryConfig<TItem = unknown, TQuery = unknown> {
   fetchPolicy?: 'swr' | 'cache-first' | 'network-only'
 
   /**
+   * Failed fetches to retry before exposing the error. Inherits the Figbird
+   * instance setting when omitted. `false` disables retries for this query.
+   */
+  retry?: number | false
+
+  /** Fixed delay in milliseconds before each retry for this query. */
+  retryDelay?: number
+
+  /**
    * Optional custom matcher factory. Only used in realtime 'merge' mode.
    * Receives the prepared query object; returns a predicate for items.
    * Provide this if your adapter needs custom client-side matching logic.
@@ -373,8 +382,19 @@ export function splitConfig<TItem = unknown, TQuery = unknown>(
   config: QueryConfig<TItem, TQuery>
 } {
   // Extract common properties
-  const { serviceName, method, skip, realtime, fetchPolicy, matcher, matcherKey, server, ...rest } =
-    combinedConfig
+  const {
+    serviceName,
+    method,
+    skip,
+    realtime,
+    fetchPolicy,
+    retry,
+    retryDelay,
+    matcher,
+    matcherKey,
+    server,
+    ...rest
+  } = combinedConfig
 
   if (method === 'get') {
     const { resourceId, ...params } = rest as CombinedGetConfig<TItem, TQuery>
@@ -390,6 +410,8 @@ export function splitConfig<TItem = unknown, TQuery = unknown>(
       ...(skip !== undefined && { skip }),
       ...(realtime !== undefined && { realtime }),
       ...(fetchPolicy !== undefined && { fetchPolicy }),
+      ...(retry !== undefined && { retry }),
+      ...(retryDelay !== undefined && { retryDelay }),
       ...(matcher !== undefined && { matcher }),
       ...(matcherKey !== undefined && { matcherKey }),
       ...(server !== undefined && { server }),
@@ -409,6 +431,8 @@ export function splitConfig<TItem = unknown, TQuery = unknown>(
       ...(skip !== undefined && { skip }),
       ...(realtime !== undefined && { realtime }),
       ...(fetchPolicy !== undefined && { fetchPolicy }),
+      ...(retry !== undefined && { retry }),
+      ...(retryDelay !== undefined && { retryDelay }),
       ...(matcher !== undefined && { matcher }),
       ...(matcherKey !== undefined && { matcherKey }),
       ...(allPages !== undefined && { allPages }),

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -28,6 +28,7 @@ export type {
   PreparedQuery,
   QueryDefinition,
   ReconnectJitter,
+  RetryDelay,
   StandardSchemaV1,
   VisibilitySource,
 } from './core/figbird.js'

--- a/test/fetch-races.test.ts
+++ b/test/fetch-races.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { FeathersAdapter, Figbird, createSchema, service } from '../lib'
+import { FeathersAdapter, Figbird, createSchema, service, type RetryDelay } from '../lib'
 import { FetchEventJournal, MAX_FETCH_JOURNAL_EVENTS } from '../lib/core/fetchRebase'
 import type { ProcessedRealtimeEvent } from '../lib/core/queryTypes'
 import { mockFeathers, type TestItem } from './helpers'
@@ -29,7 +29,15 @@ async function waitFor(predicate: () => boolean, message: string): Promise<void>
 
 function createApp(
   data: Record<string, Note>,
-  { eventBatchInterval = 0 }: { eventBatchInterval?: number } = {},
+  {
+    eventBatchInterval = 0,
+    retry,
+    retryDelay,
+  }: {
+    eventBatchInterval?: number
+    retry?: number | false
+    retryDelay?: RetryDelay
+  } = {},
 ) {
   const feathers = mockFeathers({ notes: { data } }, { queryAwareFind: true })
   const figbird = new Figbird({
@@ -38,9 +46,92 @@ function createApp(
     eventBatchInterval,
     reconcileCooldown: 0,
     reconnectJitter: 0,
+    ...(retry !== undefined ? { retry } : {}),
+    ...(retryDelay !== undefined ? { retryDelay } : {}),
   })
   return { figbird, notes: feathers.service('notes') }
 }
+
+test('failed fetches retry with backoff before exposing an error', async t => {
+  const delays: Array<{ attempt: number; message: string }> = []
+  const { figbird, notes } = createApp(
+    { 1: { id: 1, content: 'one', rank: 1 } },
+    {
+      retryDelay: (attempt, error) => {
+        delays.push({ attempt, message: error.message })
+        return 0
+      },
+    },
+  )
+  const find = notes.find.bind(notes)
+  let failuresRemaining = 2
+  notes.find = async params => {
+    if (failuresRemaining-- > 0) {
+      notes.counts.find++
+      throw new Error('network down')
+    }
+    return find(params)
+  }
+
+  const ref = figbird.queryDesc({ serviceName: 'notes', method: 'find' })
+  const observedStatuses: string[] = []
+  const unsub = ref.subscribe(state => observedStatuses.push(state.status))
+
+  await waitFor(() => ref.getSnapshot()?.status === 'success', 'the retried find')
+
+  t.is(notes.counts.find, 3, 'the initial request plus two retries ran')
+  t.deepEqual(delays, [
+    { attempt: 1, message: 'network down' },
+    { attempt: 2, message: 'network down' },
+  ])
+  t.false(observedStatuses.includes('error'), 'retryable failures stay internal')
+  const stats = figbird.queryStore.getQueryStats(ref.hash())
+  t.is(stats?.fetchCount, 3)
+  t.is(stats?.errorCount, 2)
+  unsub()
+})
+
+test('retry exhaustion exposes the final error and per-query retry false opts out', async t => {
+  const { figbird, notes } = createApp({}, { retry: 2, retryDelay: 0 })
+  notes.find = async () => {
+    notes.counts.find++
+    throw new Error('still offline')
+  }
+
+  const retried = figbird.queryDesc({ serviceName: 'notes', method: 'find' })
+  const unsubRetried = retried.subscribe(() => {})
+  await waitFor(() => retried.getSnapshot()?.status === 'error', 'retry exhaustion')
+  t.is(notes.counts.find, 3)
+  t.is(retried.getSnapshot()?.error?.message, 'still offline')
+  unsubRetried()
+
+  notes.counts.find = 0
+  const noRetry = figbird.queryDesc(
+    { serviceName: 'notes', method: 'find', params: { query: { disabled: true } } },
+    { retry: false },
+  )
+  const unsubNoRetry = noRetry.subscribe(() => {})
+  await waitFor(() => noRetry.getSnapshot()?.status === 'error', 'the opted-out failure')
+  t.is(notes.counts.find, 1)
+  unsubNoRetry()
+})
+
+test('a pending retry stops when the query loses its last subscriber', async t => {
+  const { figbird, notes } = createApp({}, { retry: 3, retryDelay: 20 })
+  notes.find = async () => {
+    notes.counts.find++
+    throw new Error('offline')
+  }
+
+  const ref = figbird.queryDesc({ serviceName: 'notes', method: 'find' })
+  const unsub = ref.subscribe(() => {})
+  await waitFor(() => notes.counts.find === 1, 'the first failed request')
+  unsub()
+  await sleep(40)
+
+  t.is(notes.counts.find, 1)
+  t.is(ref.getSnapshot()?.status, 'error')
+})
 
 function ids(data: unknown): number[] {
   return (data as Note[]).map(note => note.id)

--- a/test/figbird.test.tsx
+++ b/test/figbird.test.tsx
@@ -71,7 +71,7 @@ function app({ feathers, figbird, config }: AppOptions = {}) {
   const adapter = new FeathersAdapter(feathers, config)
   // Create a properly typed figbird instance
   const figbirdInstance: Figbird<AppSchema, typeof adapter> =
-    figbird || new Figbird({ schema, adapter, eventBatchInterval: 0 })
+    figbird || new Figbird({ schema, adapter, eventBatchInterval: 0, retry: false })
 
   // Create typed hooks from the figbird instance
   const { useGet, useFind, useMutation } = createHooks(figbirdInstance)

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -185,6 +185,9 @@ export function createTestApp<S extends Schema>(
     // Keep existing tests deterministic: no reconcile cooldown unless a test
     // opts in with its own instance.
     reconcileCooldown: 0,
+    // Error-path tests opt into retry explicitly so they do not wait through
+    // production backoff or change their expected request counts.
+    retry: false,
   })
 
   // Pin the provider's generics — createElement can't infer them from the figbird prop.


### PR DESCRIPTION
## Summary

- retry failed query fetches three times by default
- use exponential backoff (1s, 2s, 4s, capped at 30s)
- keep cold queries suspended and cached data visible until the retry budget is exhausted
- stop scheduled retries when a query loses its last subscriber
- support instance-level `retry` and `retryDelay`, plus numeric descriptor-query overrides
- count and emit lifecycle events for every network attempt

This replaces the retry portion of #66. `staleTime` is already on `master`; refetch-on-focus remains out of scope.

## Validation

- `npm run tsc`
- `npm run lint`
- `npm run ava` — 289 tests passed
- `npm run test` — typecheck, lint, formatting, 289 tests, and coverage passed
