### PR TITLE
Add native cursor pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ return `ItemRemovedError`; use `isItemRemovedError()` to handle this case.
 
 Also included:
 
+- Native cursor pagination for `.paginate()` and `.all()`, configured per Feathers
+  service without adding cursor controls to logical queries.
 - Devtools for inspecting queries, fetches, realtime events, and writes, plus richer
   lifecycle and payload details through `figbird.events`.
 - `matcherKey` for explicitly sharing queries that use equivalent custom matchers.

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1570,6 +1570,11 @@ the newest Figbird instance on the inspected page and starts debug collection. C
 panel drops the connection; without a connection, Figbird does not retain devtools history
 or subscribe to its event stream.
 
+Paginated queries appear as one operation rather than one row per fetched page. Query
+details show whether the operation uses offset or cursor pagination. Cursor details show
+the loaded page chain, each opaque `after` and next cursor, completion state, total when
+requested, and whether realtime updates merge when stable or reconcile from the server.
+
 Run `npm run devtools:package` to produce Chrome and Firefox zip archives under
 `extensions/build/` for store upload or direct distribution. See `extensions/README.md`
 for QA and packaging details.
@@ -1592,7 +1597,7 @@ No fetching happens, so it's callable anywhere and assertable in tests. See
 ```ts
 figbird.inspect()
 // → [{ queryId, serviceName, method, query, classification,
-//      status, isFetching, itemCount, fetchedAt, subscriberCount }]
+//      page?, status, isFetching, itemCount, fetchedAt, subscriberCount }]
 ```
 
 Read-only snapshot of every query currently in the store: the stable projection to build

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -426,8 +426,14 @@ cursorPagination({
     const result = response as {
       page: { more: boolean; next?: string; count?: number }
     }
+    if (!result.page.more) {
+      return { hasMore: false, total: result.page.count }
+    }
+    if (!result.page.next) {
+      throw new Error('Missing cursor for the next page')
+    }
     return {
-      hasMore: result.page.more,
+      hasMore: true,
       endCursor: result.page.next,
       total: result.page.count,
     }

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -373,13 +373,30 @@ Pagination uses `$limit` and `$skip` by default. Configure cursor-backed Feather
 services once on the adapter; query builders and hook results stay the same:
 
 ```ts
-import { cursorPagination, FeathersAdapter } from 'figbird'
+import {
+  cursorPagination,
+  FeathersAdapter,
+  offsetPagination,
+} from 'figbird'
+
+const cursor100 = cursorPagination({ maxPageSize: 100 })
 
 const adapter = new FeathersAdapter(feathers, {
+  defaultPagination: cursor100,
   pagination: {
-    'api/documents': cursorPagination(),
-    'api/identity-documents': cursorPagination(),
-    'api/ai-companion-threads': cursorPagination(),
+    'api/legacy-reports': offsetPagination(),
+  },
+})
+```
+
+Without `defaultPagination`, services use offset pagination. List cursor services in
+`pagination` when cursor support is the exception:
+
+```ts
+const adapter = new FeathersAdapter(feathers, {
+  pagination: {
+    'api/documents': cursor100,
+    'api/identity-documents': cursor100,
   },
 })
 ```
@@ -389,29 +406,31 @@ The default mapping matches this protocol:
 ```ts
 // request query
 {
-  cursorLimit: 25,
-  returnCursor: true,
-  cursor: 'opaque-token', // omitted on page one
-  returnTotal: true, // requested on page one only
+  $limit: 25,
+  $after: null, // an opaque endCursor on later pages
+  $total: true, // page one of paginate({ returnTotal: true }) only
 }
 
 // response
 {
   data: [...],
-  pageInfo: {
-    hasNextPage: true,
-    endCursor: 'next-opaque-token',
-    total: 123, // optional; normally returned on page one
-  },
+  total: 123, // optional; normally returned on page one
+  limit: 25,
+  hasPreviousPage: false,
+  hasNextPage: true,
+  startCursor: 'first-opaque-token',
+  endCursor: 'last-opaque-token',
 }
 ```
 
 Figbird treats the cursor as opaque and chains pages sequentially. `hasNextPage` is
 authoritative, so a full-sized final page still stops correctly. `.all()` drains the
-same cursor chain. For `.paginate()`, realtime changes rebuild the currently loaded
-prefix with fresh cursors while the old rows remain visible, then replace the prefix
-in one update. An explicit `refetch()` keeps the usual behavior: discard later pages
-and restart at page one.
+same cursor chain without requesting a server count; once complete, the row count is
+exact. `maxPageSize` caps `.all()` batches and rejects larger explicit `.paginate()`
+page sizes before a request reaches Feathers. For `.paginate()`, realtime changes
+rebuild the currently loaded prefix with fresh cursors while the old rows remain
+visible, then replace the prefix in one update. An explicit `refetch()` keeps the
+usual behavior: discard later pages and restart at page one.
 
 For a different server protocol, override the two mappings:
 
@@ -444,6 +463,11 @@ cursorPagination({
 Cursor controls live outside the logical Figbird query. They therefore never become
 filters, never need custom matcher support, and do not affect realtime query
 classification.
+
+Custom adapters choose pagination directly; they do not use these Feathers options.
+Implement `pageSource(serviceName)` for services with adapter-native sequential
+pagination, or return `undefined` to keep the query engine's `$limit`/`$skip` path.
+The adapter's `findAll` implementation owns exhaustive reads in either case.
 
 ## Mutations
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -350,11 +350,11 @@ avoid: multiple `{ suspense: false }` `useQuery` calls already run in parallel.
 `.paginate()` turns a query into an infinite-scroll accumulator. Each loaded page is its own window on the server, and `data` is the concatenation of all loaded pages:
 
 ```tsx
-const { data, loadMore, hasMore, isLoadingMore, loadMoreError, totalCount } = useQuery(
+const { data, loadMore, hasMore, isLoadingMore, loadMoreError, total } = useQuery(
   q.issues
     .where({ status: 'open' })
     .orderBy('updatedAt', 'desc')
-    .paginate({ pageSize: 25, returnTotal: true })
+    .paginate({ pageSize: 25, includeTotal: true })
     .related('creator'),
 )
 ```
@@ -362,10 +362,11 @@ const { data, loadMore, hasMore, isLoadingMore, loadMoreError, totalCount } = us
 - `loadMore()` appends the next page (no-op while one is in flight or when done)
 - `hasMore` is sticky during loads so the button doesn't flicker
 - `loadMoreError` reports a failed page load; calling `loadMore()` again retries the same page
-- `totalCount` comes from the first page's meta when `returnTotal: true`
+- `total` comes from the first page's metadata when `includeTotal: true`
 - `refetch()` re-fetches page 0 in place and drops follow-up pages (the dataset may have shifted)
 
-Realtime events on a paginated query refetch the affected pages rather than merging locally. An inserted row may displace a page boundary invisibly, so the server stays the source of truth.
+The server owns page boundaries. Figbird merges a realtime event locally only when it
+can prove that the event leaves the current window unchanged; otherwise it refetches.
 
 ### Cursor pagination
 
@@ -373,13 +374,12 @@ Pagination uses `$limit` and `$skip` by default. Configure cursor-backed Feather
 services once on the adapter; query builders and hook results stay the same:
 
 ```ts
-import {
-  cursorPagination,
-  FeathersAdapter,
-  offsetPagination,
-} from 'figbird'
+import { cursorPagination, FeathersAdapter, offsetPagination } from 'figbird'
 
-const cursor100 = cursorPagination({ maxPageSize: 100 })
+const cursor100 = cursorPagination({
+  maxPageSize: 100,
+  cursorStability: 'ordering',
+})
 
 const adapter = new FeathersAdapter(feathers, {
   defaultPagination: cursor100,
@@ -408,7 +408,7 @@ The default mapping matches this protocol:
 {
   $limit: 25,
   $after: null, // an opaque endCursor on later pages
-  $total: true, // page one of paginate({ returnTotal: true }) only
+  $total: true, // page one of paginate({ includeTotal: true }) only
 }
 
 // response
@@ -428,18 +428,30 @@ authoritative, so a full-sized final page still stops correctly. `.all()` drains
 same cursor chain without requesting a server count; once complete, the row count is
 exact. `maxPageSize` caps `.all()` batches and rejects larger explicit `.paginate()`
 page sizes before a request reaches Feathers. For `.paginate()`, realtime changes
-rebuild the currently loaded prefix with fresh cursors while the old rows remain
-visible, then replace the prefix in one update. An explicit `refetch()` keeps the
-usual behavior: discard later pages and restart at page one.
+normally rebuild the currently loaded prefix with fresh cursors while the old rows
+remain visible, then replace the prefix in one update.
+
+`cursorStability: 'ordering'` opts a service into a narrower local fast path. It
+promises that cursors remain valid when result-set membership and ordering inputs
+are unchanged, as they do for ordinary keyset cursors. An updated or patched row is
+then replaced locally across the loaded prefix when every explicit filter and sort
+field is present and unchanged. An explicit `$sort` is required for that proof.
+Creates, removals, changed inputs, implicit ordering, `.server()`, unknown query
+controls, and unavailable virtual fields still rebuild from page one. Omit
+`cursorStability` for snapshot/version cursors or any protocol invalidated by
+arbitrary row changes.
+
+An explicit `refetch()` keeps the usual behavior: discard later pages and restart at
+page one.
 
 For a different server protocol, override the two mappings:
 
 ```ts
 cursorPagination({
-  query: ({ limit, after, returnTotal }) => ({
+  query: ({ limit, after, includeTotal }) => ({
     first: limit,
     ...(after !== undefined ? { after } : {}),
-    ...(returnTotal ? { includeCount: true } : {}),
+    ...(includeTotal ? { includeCount: true } : {}),
   }),
   pageInfo: response => {
     const result = response as {
@@ -1221,17 +1233,17 @@ q('issues') // dynamic service name
 
 The full builder surface:
 
-| Method                                  | Meaning                                                                                                           |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `.where(filters)`                       | Merge filter conditions (deep-merged across calls); typed against the item, admits dotted paths and `$` operators |
-| `.orderBy(field, dir?)`                 | Add a sort clause; calls accumulate                                                                               |
-| `.limit(n)` / `.skip(n)`                | Window the result (`$limit` / `$skip`)                                                                            |
-| `.get(id)`                              | Resource fetch by pk (`GET /:service/:id`); `.where()` after it rides along as `params.query`                     |
-| `.related(name, refine?)`               | Attach a schema relation; the refine callback filters/windows/nests the related query                             |
-| `.paginate({ pageSize, returnTotal? })` | Infinite-scroll accumulator — the hook result widens with `loadMore`/`hasMore`/`totalCount`                       |
-| `.server()`                             | Mark server-maintained: realtime events refetch instead of merging locally                                        |
-| `.snapshot()`                           | Freeze as point-in-time: realtime is ignored; only `refetch()` moves it                                           |
-| `.all()`                                | Preload the complete set; later reads against the service answer locally                                          |
+| Method                                   | Meaning                                                                                                           |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `.where(filters)`                        | Merge filter conditions (deep-merged across calls); typed against the item, admits dotted paths and `$` operators |
+| `.orderBy(field, dir?)`                  | Add a sort clause; calls accumulate                                                                               |
+| `.limit(n)` / `.skip(n)`                 | Window the result (`$limit` / `$skip`)                                                                            |
+| `.get(id)`                               | Resource fetch by pk (`GET /:service/:id`); `.where()` after it rides along as `params.query`                     |
+| `.related(name, refine?)`                | Attach a schema relation; the refine callback filters/windows/nests the related query                             |
+| `.paginate({ pageSize, includeTotal? })` | Infinite-scroll accumulator — the hook result widens with `loadMore`/`hasMore`/`total`                            |
+| `.server()`                              | Mark server-maintained: realtime events refetch instead of merging locally                                        |
+| `.snapshot()`                            | Freeze as point-in-time: realtime is ignored; only `refetch()` moves it                                           |
+| `.all()`                                 | Preload the complete set; later reads against the service answer locally                                          |
 
 Builders are immutable values identified by a stable content hash, so constructing them
 inline in render needs no dependency arrays. Also available as `figbird.q`.
@@ -1244,8 +1256,8 @@ const { data, error, isFetching, refetch } = useQuery(builder)
 const { data } = useQuery(definition, args)
 
 // Paginated builders widen the result
-const { data, loadMore, hasMore, isLoadingMore, loadMoreError, totalCount } = useQuery(
-  q.issues.paginate({ pageSize: 25, returnTotal: true }),
+const { data, loadMore, hasMore, isLoadingMore, loadMoreError, total } = useQuery(
+  q.issues.paginate({ pageSize: 25, includeTotal: true }),
 )
 
 // Tagged union, never suspends or throws

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -367,6 +367,78 @@ const { data, loadMore, hasMore, isLoadingMore, loadMoreError, totalCount } = us
 
 Realtime events on a paginated query refetch the affected pages rather than merging locally. An inserted row may displace a page boundary invisibly, so the server stays the source of truth.
 
+### Cursor pagination
+
+Pagination uses `$limit` and `$skip` by default. Configure cursor-backed Feathers
+services once on the adapter; query builders and hook results stay the same:
+
+```ts
+import { cursorPagination, FeathersAdapter } from 'figbird'
+
+const adapter = new FeathersAdapter(feathers, {
+  pagination: {
+    'api/documents': cursorPagination(),
+    'api/identity-documents': cursorPagination(),
+    'api/ai-companion-threads': cursorPagination(),
+  },
+})
+```
+
+The default mapping matches this protocol:
+
+```ts
+// request query
+{
+  cursorLimit: 25,
+  returnCursor: true,
+  cursor: 'opaque-token', // omitted on page one
+  returnTotal: true, // requested on page one only
+}
+
+// response
+{
+  data: [...],
+  pageInfo: {
+    hasNextPage: true,
+    endCursor: 'next-opaque-token',
+    total: 123, // optional; normally returned on page one
+  },
+}
+```
+
+Figbird treats the cursor as opaque and chains pages sequentially. `hasNextPage` is
+authoritative, so a full-sized final page still stops correctly. `.all()` drains the
+same cursor chain. For `.paginate()`, realtime changes rebuild the currently loaded
+prefix with fresh cursors while the old rows remain visible, then replace the prefix
+in one update. An explicit `refetch()` keeps the usual behavior: discard later pages
+and restart at page one.
+
+For a different server protocol, override the two mappings:
+
+```ts
+cursorPagination({
+  query: ({ limit, after, returnTotal }) => ({
+    first: limit,
+    ...(after !== undefined ? { after } : {}),
+    ...(returnTotal ? { includeCount: true } : {}),
+  }),
+  pageInfo: response => {
+    const result = response as {
+      page: { more: boolean; next?: string; count?: number }
+    }
+    return {
+      hasMore: result.page.more,
+      endCursor: result.page.next,
+      total: result.page.count,
+    }
+  },
+})
+```
+
+Cursor controls live outside the logical Figbird query. They therefore never become
+filters, never need custom matcher support, and do not affect realtime query
+classification.
+
 ## Mutations
 
 The write side is three pieces, each owning a different granularity:
@@ -1397,6 +1469,7 @@ const adapter = new FeathersAdapter(feathers, options)
   - `updatedAtField` — string or function, defaults to `item => item.updatedAt || item.updated_at`; used to avoid overwriting newer cached data with older data when requests race
   - `defaultPageSize` — default `query.$limit` when fetching, unset by default so the server decides
   - `defaultPageSizeWhenFetchingAll` — default `query.$limit` when fetching with `allPages`
+  - `pagination` — cursor strategies keyed by service path; see [Cursor pagination](#cursor-pagination)
   - `operators` — custom query operators the client can evaluate (`{ $asOf: asOf => item => boolean }`); queries using them stay realtime-mergeable. See [Teaching the client custom operators](#teaching-the-client-custom-operators)
 
 Meta behavior: `find` returns `{ data, meta }` (`FindMeta`: `{ total, limit, skip }`); `get` returns only the item.

--- a/lib/adapters/adapter.ts
+++ b/lib/adapters/adapter.ts
@@ -21,7 +21,7 @@ export interface PageRequest {
   /** Adapter-issued continuation from the preceding page. */
   after?: PageCursor
   /** Only the first page asks the server to calculate a total. */
-  returnTotal: boolean
+  includeTotal: boolean
 }
 
 /** Adapter-neutral page information consumed by the query engine. */
@@ -41,6 +41,13 @@ export type PageInfo = (
  * continuations, so later pages must be rebuilt after an earlier page changes.
  */
 export interface PageSource<TParams, TMeta> {
+  /**
+   * `ordering` promises that a cursor remains valid when every explicit filter
+   * and ordering input is unchanged. This enables visible, non-window-changing
+   * updates to merge locally; omit it for conservative reconciliation on every
+   * realtime event.
+   */
+  cursorStability?: 'ordering'
   find(params: TParams | undefined, page: PageRequest): Promise<PageResponse<unknown[], TMeta>>
 }
 

--- a/lib/adapters/adapter.ts
+++ b/lib/adapters/adapter.ts
@@ -3,9 +3,40 @@
  * - For find-like operations, include meta (e.g. pagination info)
  * - For get-like operations, adapters may omit meta entirely
  */
-export type QueryResponse<TData, TMeta = undefined> = { data: TData } & (TMeta extends undefined
-  ? Record<never, never>
-  : { meta: TMeta })
+export type QueryResponse<TData, TMeta = undefined> = {
+  data: TData
+} & (TMeta extends undefined ? Record<never, never> : { meta: TMeta })
+
+/** A native page response always carries normalized continuation information. */
+export type PageResponse<TData, TMeta> = QueryResponse<TData, TMeta> & {
+  pageInfo: PageInfo
+}
+
+/** Opaque page request passed to adapters that support native pagination. */
+export interface PageRequest {
+  limit: number
+  /** Adapter-issued continuation from the preceding page. */
+  after?: unknown
+  /** Only the first page asks the server to calculate a total. */
+  returnTotal: boolean
+}
+
+/** Adapter-neutral page information consumed by the query engine. */
+export interface PageInfo {
+  hasMore: boolean
+  /** Opaque continuation to pass to the next page request. */
+  endCursor?: unknown
+  total?: number
+}
+
+/**
+ * Service-level native pagination capability. Sequential sources issue opaque
+ * continuations, so later pages must be rebuilt after an earlier page changes.
+ */
+export interface PageSource<TParams, TMeta> {
+  dependency: 'sequential'
+  find(params: TParams | undefined, page: PageRequest): Promise<PageResponse<unknown[], TMeta>>
+}
 
 /**
  * Event handlers for real-time updates
@@ -40,6 +71,9 @@ export interface Adapter<
   ): Promise<QueryResponse<unknown, TMeta | undefined>>
 
   find(serviceName: string, params?: TParams): Promise<QueryResponse<unknown[], TMeta>>
+
+  /** Return the native pagination capability for a service, if configured. */
+  pageSource?(serviceName: string): PageSource<TParams, TMeta> | undefined
 
   findAll(serviceName: string, params?: TParams): Promise<QueryResponse<unknown[], TMeta>>
 

--- a/lib/adapters/adapter.ts
+++ b/lib/adapters/adapter.ts
@@ -12,20 +12,27 @@ export type PageResponse<TData, TMeta> = QueryResponse<TData, TMeta> & {
   pageInfo: PageInfo
 }
 
+/** A stable, serializable token suitable for transport and query-cache identity. */
+export type PageCursor = string | number
+
 /** Opaque page request passed to adapters that support native pagination. */
 export interface PageRequest {
   limit: number
   /** Adapter-issued continuation from the preceding page. */
-  after?: unknown
+  after?: PageCursor
   /** Only the first page asks the server to calculate a total. */
   returnTotal: boolean
 }
 
 /** Adapter-neutral page information consumed by the query engine. */
-export interface PageInfo {
-  hasMore: boolean
-  /** Opaque continuation to pass to the next page request. */
-  endCursor?: unknown
+export type PageInfo = (
+  | { hasMore: false }
+  | {
+      hasMore: true
+      /** Opaque continuation to pass to the next page request. */
+      endCursor: PageCursor
+    }
+) & {
   total?: number
 }
 
@@ -34,7 +41,6 @@ export interface PageInfo {
  * continuations, so later pages must be rebuilt after an earlier page changes.
  */
 export interface PageSource<TParams, TMeta> {
-  dependency: 'sequential'
   find(params: TParams | undefined, page: PageRequest): Promise<PageResponse<unknown[], TMeta>>
 }
 

--- a/lib/adapters/feathers.ts
+++ b/lib/adapters/feathers.ts
@@ -109,6 +109,8 @@ export interface FeathersCursorPagination {
   pageInfo(response: unknown): PageInfo
   /** Largest page the cursor service accepts. */
   maxPageSize?: number
+  /** See `PageSource.cursorStability`. */
+  cursorStability?: 'ordering'
 }
 
 /** Select the built-in `$limit`/`$skip` behavior for a Feathers service. */
@@ -124,6 +126,12 @@ export interface CursorPaginationOptions {
    * this value, and larger explicit `.paginate()` page sizes fail locally.
    */
   maxPageSize?: number
+  /**
+   * Opt into local updates when explicit filter and sort inputs are unchanged.
+   * Use `ordering` only when cursors depend on result-set position rather than
+   * arbitrary row values or a mutable server snapshot.
+   */
+  cursorStability?: 'ordering'
   /**
    * Map Figbird's adapter-neutral request to Feathers query controls. Defaults
    * to `$limit`/`$after` and optional `$total`.
@@ -150,10 +158,11 @@ function isPageCursor(value: unknown): value is PageCursor {
  */
 export function cursorPagination({
   maxPageSize,
+  cursorStability,
   query = page => ({
     $limit: page.limit,
     $after: page.after ?? null,
-    ...(page.returnTotal ? { $total: true } : {}),
+    ...(page.includeTotal ? { $total: true } : {}),
   }),
   pageInfo = response => {
     const value = response as Record<string, unknown> | null
@@ -178,6 +187,7 @@ export function cursorPagination({
     query,
     pageInfo,
     ...(maxPageSize !== undefined ? { maxPageSize } : {}),
+    ...(cursorStability !== undefined ? { cursorStability } : {}),
   }
 }
 
@@ -448,6 +458,9 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
     const pagination = this.#paginationFor(serviceName)
     if (!pagination || pagination.kind === 'offset') return undefined
     return {
+      ...(pagination.cursorStability !== undefined
+        ? { cursorStability: pagination.cursorStability }
+        : {}),
       find: (params, page) => this.#findPage(serviceName, pagination, params, page),
     }
   }
@@ -568,7 +581,7 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
       const page = await this.#findPage(serviceName, pagination, params, {
         limit,
         ...(after !== undefined ? { after } : {}),
-        returnTotal: false,
+        includeTotal: false,
       })
       result.data.push(...page.data)
       const knownTotal = result.meta.total >= 0 ? result.meta.total : page.meta.total

--- a/lib/adapters/feathers.ts
+++ b/lib/adapters/feathers.ts
@@ -106,9 +106,17 @@ type FeathersFindResult =
 export interface FeathersCursorPagination {
   query(page: PageRequest): Record<string, unknown>
   pageInfo(response: unknown): PageInfo
+  /** Page size used when `.all()` drains this cursor service. */
+  pageSizeWhenFetchingAll?: number
 }
 
 export interface CursorPaginationOptions {
+  /**
+   * Page size used when `.all()` drains this cursor service. Overrides the
+   * adapter-wide `defaultPageSizeWhenFetchingAll` for services with a lower
+   * cursor limit.
+   */
+  pageSizeWhenFetchingAll?: number
   /**
    * Map Figbird's adapter-neutral request to Feathers query controls. Defaults
    * to Humaans' `cursor`/`cursorLimit`/`returnCursor` protocol.
@@ -134,6 +142,7 @@ function isPageCursor(value: unknown): value is PageCursor {
  * })
  */
 export function cursorPagination({
+  pageSizeWhenFetchingAll,
   query = page => ({
     cursorLimit: page.limit,
     returnCursor: true,
@@ -153,7 +162,19 @@ export function cursorPagination({
     return { hasMore: true, endCursor: value.endCursor, ...total }
   },
 }: CursorPaginationOptions = {}): FeathersCursorPagination {
-  return { query, pageInfo }
+  if (
+    pageSizeWhenFetchingAll !== undefined &&
+    (!Number.isFinite(pageSizeWhenFetchingAll) || pageSizeWhenFetchingAll <= 0)
+  ) {
+    throw new Error(
+      `cursorPagination(): pageSizeWhenFetchingAll must be a positive number, got ${pageSizeWhenFetchingAll}`,
+    )
+  }
+  return {
+    query,
+    pageInfo,
+    ...(pageSizeWhenFetchingAll !== undefined ? { pageSizeWhenFetchingAll } : {}),
+  }
 }
 
 /**
@@ -502,7 +523,11 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
     pagination: FeathersCursorPagination,
     params?: FeathersParams<TQuery>,
   ): Promise<QueryResponse<unknown[], FeathersFindMeta>> {
-    const limit = this.#defaultPageSizeWhenFetchingAll || this.#defaultPageSize || 50
+    const limit =
+      pagination.pageSizeWhenFetchingAll ||
+      this.#defaultPageSizeWhenFetchingAll ||
+      this.#defaultPageSize ||
+      50
     const result: QueryResponse<unknown[], FeathersFindMeta> = {
       data: [],
       meta: { total: -1, limit, skip: 0 },

--- a/lib/adapters/feathers.ts
+++ b/lib/adapters/feathers.ts
@@ -1,4 +1,13 @@
-import type { Adapter, EventHandlers, MatcherContext, QueryResponse } from './adapter.js'
+import type {
+  Adapter,
+  EventHandlers,
+  MatcherContext,
+  PageInfo,
+  PageRequest,
+  PageResponse,
+  PageSource,
+  QueryResponse,
+} from './adapter.js'
 import { matcher, type PrepareQueryOptions, type Query } from './matcher.js'
 import type {
   Schema,
@@ -83,14 +92,74 @@ export interface FeathersFindMeta {
   [key: string]: unknown
 }
 
+type FeathersFindResult =
+  | {
+      data: unknown[]
+      total?: number
+      limit?: number
+      skip?: number
+    }
+  | unknown[]
+
+/** Request/response mapping for a cursor-paginated Feathers service. */
+export interface FeathersCursorPagination {
+  query(page: PageRequest): Record<string, unknown>
+  pageInfo(response: unknown): PageInfo
+}
+
+export interface CursorPaginationOptions {
+  /**
+   * Map Figbird's adapter-neutral request to Feathers query controls. Defaults
+   * to Humaans' `cursor`/`cursorLimit`/`returnCursor` protocol.
+   */
+  query?: (page: PageRequest) => Record<string, unknown>
+  /**
+   * Read continuation information from the raw service response. Defaults to
+   * `{ pageInfo: { hasNextPage, endCursor, total? } }`.
+   */
+  pageInfo?: (response: unknown) => PageInfo
+}
+
+/**
+ * Configure one Feathers service to use opaque cursor pagination.
+ *
+ * @example
+ * new FeathersAdapter(client, {
+ *   pagination: { 'api/documents': cursorPagination() },
+ * })
+ */
+export function cursorPagination({
+  query = page => ({
+    cursorLimit: page.limit,
+    returnCursor: true,
+    ...(page.after !== undefined ? { cursor: page.after } : {}),
+    ...(page.returnTotal ? { returnTotal: true } : {}),
+  }),
+  pageInfo = response => {
+    const value = (response as { pageInfo?: Record<string, unknown> } | null)?.pageInfo
+    if (!value || typeof value.hasNextPage !== 'boolean') {
+      throw new Error('Cursor-paginated Feathers response must include pageInfo.hasNextPage')
+    }
+    const result: PageInfo = {
+      hasMore: value.hasNextPage,
+      ...(Object.hasOwn(value, 'endCursor') ? { endCursor: value.endCursor } : {}),
+      ...(typeof value.total === 'number' ? { total: value.total } : {}),
+    }
+    if (result.hasMore && result.endCursor == null) {
+      throw new Error('Cursor-paginated Feathers response has more pages but no pageInfo.endCursor')
+    }
+    return result
+  },
+}: CursorPaginationOptions = {}): FeathersCursorPagination {
+  return { query, pageInfo }
+}
+
 /**
  * Feathers service interface
  */
 export interface FeathersService {
   get(id: string | number, params?: FeathersParams): Promise<unknown>
-  find(
-    params?: FeathersParams,
-  ): Promise<{ data: unknown[]; total?: number; limit?: number; skip?: number } | unknown[]>
+  find(params?: FeathersParams): Promise<FeathersFindResult>
   create(data: unknown, params?: FeathersParams): Promise<unknown>
   create(data: unknown[], params?: FeathersParams): Promise<unknown[]>
   update(id: string | number, data: unknown, params?: FeathersParams): Promise<unknown>
@@ -209,6 +278,8 @@ export interface FeathersAdapterOptions {
    * }
    */
   operators?: Record<string, CustomOperatorRegistration>
+  /** Native pagination strategy, selected by Feathers service path. */
+  pagination?: Record<string, FeathersCursorPagination>
 }
 
 /**
@@ -234,6 +305,7 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
   #defaultPageSize: number | undefined
   #defaultPageSizeWhenFetchingAll: number | undefined
   #operators: Record<string, CustomOperatorRegistration>
+  #pagination: Record<string, FeathersCursorPagination>
 
   /** Names of custom operators registered for every service. */
   get customOperators(): readonly string[] {
@@ -279,6 +351,7 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
       defaultPageSize,
       defaultPageSizeWhenFetchingAll,
       operators = {},
+      pagination = {},
     }: FeathersAdapterOptions = {},
   ) {
     this.feathers = feathers
@@ -287,6 +360,7 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
     this.#defaultPageSize = defaultPageSize
     this.#defaultPageSizeWhenFetchingAll = defaultPageSizeWhenFetchingAll
     this.#operators = operators
+    this.#pagination = pagination
   }
 
   #service(serviceName: string): FeathersService {
@@ -313,11 +387,56 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
     params?: FeathersParams<TQuery>,
   ): Promise<QueryResponse<unknown[], FeathersFindMeta>> {
     const res = await this.#service(serviceName).find(params as FeathersParams)
+    return this.#normalizeFind(res)
+  }
+
+  #normalizeFind(res: FeathersFindResult): QueryResponse<unknown[], FeathersFindMeta> {
     if (Array.isArray(res)) {
       return { data: res, meta: { total: -1, limit: res.length, skip: 0 } }
     } else {
       const { data, total = -1, limit = data.length, skip = 0, ...rest } = res
       return { data, meta: { total, limit, skip, ...rest } }
+    }
+  }
+
+  pageSource(
+    serviceName: string,
+  ): PageSource<FeathersParams<TQuery>, FeathersFindMeta> | undefined {
+    const pagination = this.#pagination[serviceName]
+    if (!pagination) return undefined
+    return {
+      dependency: 'sequential',
+      find: (params, page) => this.#findPage(serviceName, pagination, params, page),
+    }
+  }
+
+  async #findPage(
+    serviceName: string,
+    pagination: FeathersCursorPagination,
+    params: FeathersParams<TQuery> | undefined,
+    page: PageRequest,
+  ): Promise<PageResponse<unknown[], FeathersFindMeta>> {
+    const raw = await this.#service(serviceName).find(
+      this.#mergeQueryParams(params, pagination.query(page)) as FeathersParams,
+    )
+    const normalized = this.#normalizeFind(raw)
+    const pageInfo = pagination.pageInfo(raw)
+    if (typeof pageInfo.hasMore !== 'boolean') {
+      throw new Error(`Cursor pagination for "${serviceName}" did not return hasMore`)
+    }
+    if (pageInfo.hasMore && pageInfo.endCursor == null) {
+      throw new Error(`Cursor pagination for "${serviceName}" has more pages but no endCursor`)
+    }
+    if (pageInfo.hasMore && Object.is(page.after, pageInfo.endCursor)) {
+      throw new Error(`Cursor pagination for "${serviceName}" returned the same cursor twice`)
+    }
+    return {
+      ...normalized,
+      pageInfo,
+      meta:
+        pageInfo.total === undefined
+          ? normalized.meta
+          : { ...normalized.meta, total: pageInfo.total },
     }
   }
 
@@ -339,6 +458,10 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
     serviceName: string,
     params?: FeathersParams<TQuery>,
   ): Promise<QueryResponse<unknown[], FeathersFindMeta>> {
+    const pagination = this.#pagination[serviceName]
+    if (pagination) {
+      return this.#findAllByCursor(serviceName, pagination, params)
+    }
     const defaultPageSize = this.#defaultPageSizeWhenFetchingAll || this.#defaultPageSize
     const queryLimit = (params?.query as Record<string, unknown>)?.$limit
     const baseParams =
@@ -370,6 +493,34 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
       if (done) return result
 
       $skip = result.data.length
+    }
+  }
+
+  async #findAllByCursor(
+    serviceName: string,
+    pagination: FeathersCursorPagination,
+    params?: FeathersParams<TQuery>,
+  ): Promise<QueryResponse<unknown[], FeathersFindMeta>> {
+    const limit = this.#defaultPageSizeWhenFetchingAll || this.#defaultPageSize || 50
+    const result: QueryResponse<unknown[], FeathersFindMeta> = {
+      data: [],
+      meta: { total: -1, limit, skip: 0 },
+    }
+    let after: unknown = undefined
+    let first = true
+
+    while (true) {
+      const page = await this.#findPage(serviceName, pagination, params, {
+        limit,
+        ...(after !== undefined ? { after } : {}),
+        returnTotal: first,
+      })
+      result.data.push(...page.data)
+      const knownTotal = result.meta.total >= 0 ? result.meta.total : page.meta.total
+      result.meta = { ...result.meta, ...page.meta, total: knownTotal, limit, skip: 0 }
+      if (!page.pageInfo.hasMore) return result
+      after = page.pageInfo.endCursor
+      first = false
     }
   }
 

--- a/lib/adapters/feathers.ts
+++ b/lib/adapters/feathers.ts
@@ -2,6 +2,7 @@ import type {
   Adapter,
   EventHandlers,
   MatcherContext,
+  PageCursor,
   PageInfo,
   PageRequest,
   PageResponse,
@@ -120,6 +121,10 @@ export interface CursorPaginationOptions {
   pageInfo?: (response: unknown) => PageInfo
 }
 
+function isPageCursor(value: unknown): value is PageCursor {
+  return typeof value === 'string' || (typeof value === 'number' && Number.isFinite(value))
+}
+
 /**
  * Configure one Feathers service to use opaque cursor pagination.
  *
@@ -140,15 +145,12 @@ export function cursorPagination({
     if (!value || typeof value.hasNextPage !== 'boolean') {
       throw new Error('Cursor-paginated Feathers response must include pageInfo.hasNextPage')
     }
-    const result: PageInfo = {
-      hasMore: value.hasNextPage,
-      ...(Object.hasOwn(value, 'endCursor') ? { endCursor: value.endCursor } : {}),
-      ...(typeof value.total === 'number' ? { total: value.total } : {}),
-    }
-    if (result.hasMore && result.endCursor == null) {
+    const total = typeof value.total === 'number' ? { total: value.total } : {}
+    if (!value.hasNextPage) return { hasMore: false, ...total }
+    if (!isPageCursor(value.endCursor)) {
       throw new Error('Cursor-paginated Feathers response has more pages but no pageInfo.endCursor')
     }
-    return result
+    return { hasMore: true, endCursor: value.endCursor, ...total }
   },
 }: CursorPaginationOptions = {}): FeathersCursorPagination {
   return { query, pageInfo }
@@ -405,7 +407,6 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
     const pagination = this.#pagination[serviceName]
     if (!pagination) return undefined
     return {
-      dependency: 'sequential',
       find: (params, page) => this.#findPage(serviceName, pagination, params, page),
     }
   }
@@ -424,8 +425,8 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
     if (typeof pageInfo.hasMore !== 'boolean') {
       throw new Error(`Cursor pagination for "${serviceName}" did not return hasMore`)
     }
-    if (pageInfo.hasMore && pageInfo.endCursor == null) {
-      throw new Error(`Cursor pagination for "${serviceName}" has more pages but no endCursor`)
+    if (pageInfo.hasMore && !isPageCursor(pageInfo.endCursor)) {
+      throw new Error(`Cursor pagination for "${serviceName}" returned an invalid endCursor`)
     }
     if (pageInfo.hasMore && Object.is(page.after, pageInfo.endCursor)) {
       throw new Error(`Cursor pagination for "${serviceName}" returned the same cursor twice`)
@@ -506,7 +507,7 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
       data: [],
       meta: { total: -1, limit, skip: 0 },
     }
-    let after: unknown = undefined
+    let after: PageCursor | undefined = undefined
     let first = true
 
     while (true) {

--- a/lib/adapters/feathers.ts
+++ b/lib/adapters/feathers.ts
@@ -104,27 +104,34 @@ type FeathersFindResult =
 
 /** Request/response mapping for a cursor-paginated Feathers service. */
 export interface FeathersCursorPagination {
+  kind: 'cursor'
   query(page: PageRequest): Record<string, unknown>
   pageInfo(response: unknown): PageInfo
-  /** Page size used when `.all()` drains this cursor service. */
-  pageSizeWhenFetchingAll?: number
+  /** Largest page the cursor service accepts. */
+  maxPageSize?: number
 }
+
+/** Select the built-in `$limit`/`$skip` behavior for a Feathers service. */
+export interface FeathersOffsetPagination {
+  kind: 'offset'
+}
+
+export type FeathersPagination = FeathersCursorPagination | FeathersOffsetPagination
 
 export interface CursorPaginationOptions {
   /**
-   * Page size used when `.all()` drains this cursor service. Overrides the
-   * adapter-wide `defaultPageSizeWhenFetchingAll` for services with a lower
-   * cursor limit.
+   * Largest page the cursor service accepts. `.all()` caps its batch size at
+   * this value, and larger explicit `.paginate()` page sizes fail locally.
    */
-  pageSizeWhenFetchingAll?: number
+  maxPageSize?: number
   /**
    * Map Figbird's adapter-neutral request to Feathers query controls. Defaults
-   * to Humaans' `cursor`/`cursorLimit`/`returnCursor` protocol.
+   * to `$limit`/`$after` and optional `$total`.
    */
   query?: (page: PageRequest) => Record<string, unknown>
   /**
    * Read continuation information from the raw service response. Defaults to
-   * `{ pageInfo: { hasNextPage, endCursor, total? } }`.
+   * top-level `{ hasNextPage, endCursor, total? }` fields.
    */
   pageInfo?: (response: unknown) => PageInfo
 }
@@ -142,39 +149,43 @@ function isPageCursor(value: unknown): value is PageCursor {
  * })
  */
 export function cursorPagination({
-  pageSizeWhenFetchingAll,
+  maxPageSize,
   query = page => ({
-    cursorLimit: page.limit,
-    returnCursor: true,
-    ...(page.after !== undefined ? { cursor: page.after } : {}),
-    ...(page.returnTotal ? { returnTotal: true } : {}),
+    $limit: page.limit,
+    $after: page.after ?? null,
+    ...(page.returnTotal ? { $total: true } : {}),
   }),
   pageInfo = response => {
-    const value = (response as { pageInfo?: Record<string, unknown> } | null)?.pageInfo
+    const value = response as Record<string, unknown> | null
     if (!value || typeof value.hasNextPage !== 'boolean') {
-      throw new Error('Cursor-paginated Feathers response must include pageInfo.hasNextPage')
+      throw new Error('Cursor-paginated Feathers response must include hasNextPage')
     }
     const total = typeof value.total === 'number' ? { total: value.total } : {}
     if (!value.hasNextPage) return { hasMore: false, ...total }
     if (!isPageCursor(value.endCursor)) {
-      throw new Error('Cursor-paginated Feathers response has more pages but no pageInfo.endCursor')
+      throw new Error('Cursor-paginated Feathers response has more pages but no endCursor')
     }
     return { hasMore: true, endCursor: value.endCursor, ...total }
   },
 }: CursorPaginationOptions = {}): FeathersCursorPagination {
-  if (
-    pageSizeWhenFetchingAll !== undefined &&
-    (!Number.isFinite(pageSizeWhenFetchingAll) || pageSizeWhenFetchingAll <= 0)
-  ) {
+  if (maxPageSize !== undefined && (!Number.isInteger(maxPageSize) || maxPageSize <= 0)) {
     throw new Error(
-      `cursorPagination(): pageSizeWhenFetchingAll must be a positive number, got ${pageSizeWhenFetchingAll}`,
+      `cursorPagination(): maxPageSize must be a positive integer, got ${maxPageSize}`,
     )
   }
   return {
+    kind: 'cursor',
     query,
     pageInfo,
-    ...(pageSizeWhenFetchingAll !== undefined ? { pageSizeWhenFetchingAll } : {}),
+    ...(maxPageSize !== undefined ? { maxPageSize } : {}),
   }
+}
+
+const OFFSET_PAGINATION: FeathersOffsetPagination = { kind: 'offset' }
+
+/** Explicitly keep one Feathers service on the built-in `$limit`/`$skip` path. */
+export function offsetPagination(): FeathersOffsetPagination {
+  return OFFSET_PAGINATION
 }
 
 /**
@@ -301,8 +312,10 @@ export interface FeathersAdapterOptions {
    * }
    */
   operators?: Record<string, CustomOperatorRegistration>
-  /** Native pagination strategy, selected by Feathers service path. */
-  pagination?: Record<string, FeathersCursorPagination>
+  /** Pagination used when a service has no entry in `pagination`. Defaults to offset. */
+  defaultPagination?: FeathersPagination
+  /** Pagination overrides selected by Feathers service path. */
+  pagination?: Record<string, FeathersPagination>
 }
 
 /**
@@ -328,7 +341,8 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
   #defaultPageSize: number | undefined
   #defaultPageSizeWhenFetchingAll: number | undefined
   #operators: Record<string, CustomOperatorRegistration>
-  #pagination: Record<string, FeathersCursorPagination>
+  #defaultPagination: FeathersPagination | undefined
+  #pagination: Record<string, FeathersPagination>
 
   /** Names of custom operators registered for every service. */
   get customOperators(): readonly string[] {
@@ -374,6 +388,7 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
       defaultPageSize,
       defaultPageSizeWhenFetchingAll,
       operators = {},
+      defaultPagination,
       pagination = {},
     }: FeathersAdapterOptions = {},
   ) {
@@ -383,7 +398,12 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
     this.#defaultPageSize = defaultPageSize
     this.#defaultPageSizeWhenFetchingAll = defaultPageSizeWhenFetchingAll
     this.#operators = operators
+    this.#defaultPagination = defaultPagination
     this.#pagination = pagination
+  }
+
+  #paginationFor(serviceName: string): FeathersPagination | undefined {
+    return this.#pagination[serviceName] ?? this.#defaultPagination
   }
 
   #service(serviceName: string): FeathersService {
@@ -425,8 +445,8 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
   pageSource(
     serviceName: string,
   ): PageSource<FeathersParams<TQuery>, FeathersFindMeta> | undefined {
-    const pagination = this.#pagination[serviceName]
-    if (!pagination) return undefined
+    const pagination = this.#paginationFor(serviceName)
+    if (!pagination || pagination.kind === 'offset') return undefined
     return {
       find: (params, page) => this.#findPage(serviceName, pagination, params, page),
     }
@@ -438,6 +458,16 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
     params: FeathersParams<TQuery> | undefined,
     page: PageRequest,
   ): Promise<PageResponse<unknown[], FeathersFindMeta>> {
+    if (!Number.isInteger(page.limit) || page.limit <= 0) {
+      throw new Error(
+        `Cursor pagination for "${serviceName}" requires a positive integer page size, got ${page.limit}`,
+      )
+    }
+    if (pagination.maxPageSize !== undefined && page.limit > pagination.maxPageSize) {
+      throw new Error(
+        `Cursor pagination for "${serviceName}" accepts at most ${pagination.maxPageSize} rows per page, got ${page.limit}`,
+      )
+    }
     const raw = await this.#service(serviceName).find(
       this.#mergeQueryParams(params, pagination.query(page)) as FeathersParams,
     )
@@ -480,8 +510,8 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
     serviceName: string,
     params?: FeathersParams<TQuery>,
   ): Promise<QueryResponse<unknown[], FeathersFindMeta>> {
-    const pagination = this.#pagination[serviceName]
-    if (pagination) {
+    const pagination = this.#paginationFor(serviceName)
+    if (pagination?.kind === 'cursor') {
       return this.#findAllByCursor(serviceName, pagination, params)
     }
     const defaultPageSize = this.#defaultPageSizeWhenFetchingAll || this.#defaultPageSize
@@ -523,30 +553,31 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
     pagination: FeathersCursorPagination,
     params?: FeathersParams<TQuery>,
   ): Promise<QueryResponse<unknown[], FeathersFindMeta>> {
+    const preferredLimit = this.#defaultPageSizeWhenFetchingAll || this.#defaultPageSize || 50
     const limit =
-      pagination.pageSizeWhenFetchingAll ||
-      this.#defaultPageSizeWhenFetchingAll ||
-      this.#defaultPageSize ||
-      50
+      pagination.maxPageSize === undefined
+        ? preferredLimit
+        : Math.min(preferredLimit, pagination.maxPageSize)
     const result: QueryResponse<unknown[], FeathersFindMeta> = {
       data: [],
       meta: { total: -1, limit, skip: 0 },
     }
     let after: PageCursor | undefined = undefined
-    let first = true
 
     while (true) {
       const page = await this.#findPage(serviceName, pagination, params, {
         limit,
         ...(after !== undefined ? { after } : {}),
-        returnTotal: first,
+        returnTotal: false,
       })
       result.data.push(...page.data)
       const knownTotal = result.meta.total >= 0 ? result.meta.total : page.meta.total
       result.meta = { ...result.meta, ...page.meta, total: knownTotal, limit, skip: 0 }
-      if (!page.pageInfo.hasMore) return result
+      if (!page.pageInfo.hasMore) {
+        result.meta = { ...result.meta, total: result.data.length }
+        return result
+      }
       after = page.pageInfo.endCursor
-      first = false
     }
   }
 

--- a/lib/core/cursorMaintenance.ts
+++ b/lib/core/cursorMaintenance.ts
@@ -21,6 +21,11 @@ export function cursorQueryInputsUnchanged(
   return true
 }
 
+/** Whether the query shape can ever support the stable-update proof. */
+export function cursorQueryCanKeepPrefix(query: unknown): boolean {
+  return collectCursorQueryInputPaths(query) !== null
+}
+
 function collectCursorQueryInputPaths(query: unknown): Set<string> | null {
   if (!isPlainRecord(query)) return null
   const paths = new Set<string>()

--- a/lib/core/cursorMaintenance.ts
+++ b/lib/core/cursorMaintenance.ts
@@ -1,0 +1,102 @@
+/**
+ * Prove that an update cannot change a cursor-paginated query's membership or
+ * ordering. The proof is deliberately structural: every explicit filter and
+ * sort field must exist on both row versions and retain the same value. Unknown
+ * query controls and implicit server ordering are not guessable, so they fail
+ * closed and force reconciliation.
+ */
+export function cursorQueryInputsUnchanged(
+  query: unknown,
+  previousItem: unknown,
+  item: unknown,
+): boolean {
+  const paths = collectCursorQueryInputPaths(query)
+  if (!paths) return false
+
+  for (const path of paths) {
+    const previous = readItemPath(previousItem, path)
+    const next = readItemPath(item, path)
+    if (!previous.found || !next.found || !sameValue(previous.value, next.value)) return false
+  }
+  return true
+}
+
+function collectCursorQueryInputPaths(query: unknown): Set<string> | null {
+  if (!isPlainRecord(query)) return null
+  const paths = new Set<string>()
+  let hasExplicitSort = false
+
+  const visitClause = (clause: Record<string, unknown>, root: boolean): boolean => {
+    for (const [key, value] of Object.entries(clause)) {
+      if (key === '$sort') {
+        if (!root || !isPlainRecord(value) || Object.keys(value).length === 0) return false
+        hasExplicitSort = true
+        for (const field of Object.keys(value)) paths.add(field)
+      } else if (key === '$or') {
+        if (!Array.isArray(value)) return false
+        for (const branch of value) {
+          if (!isPlainRecord(branch) || !visitClause(branch, false)) return false
+        }
+      } else if (key.startsWith('$')) {
+        // Top-level custom/search/projection controls may depend on arbitrary
+        // server state. Comparison operators are safe only inside a field value,
+        // which this traversal intentionally treats as opaque.
+        return false
+      } else {
+        paths.add(key)
+      }
+    }
+    return true
+  }
+
+  if (!visitClause(query, true) || !hasExplicitSort) return null
+  return paths
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function readItemPath(item: unknown, path: string): { found: boolean; value?: unknown } {
+  if (!item || typeof item !== 'object') return { found: false }
+  const record = item as Record<string, unknown>
+  if (Object.hasOwn(record, path)) return { found: true, value: record[path] }
+
+  let value: unknown = item
+  for (const part of path.split('.')) {
+    if (!value || typeof value !== 'object' || !Object.hasOwn(value, part)) {
+      return { found: false }
+    }
+    value = (value as Record<string, unknown>)[part]
+  }
+  return { found: true, value }
+}
+
+function sameValue(
+  left: unknown,
+  right: unknown,
+  seen: WeakMap<object, object> = new WeakMap(),
+): boolean {
+  if (Object.is(left, right)) return true
+  if (!left || !right || typeof left !== 'object' || typeof right !== 'object') return false
+  if (left instanceof Date || right instanceof Date) {
+    return left instanceof Date && right instanceof Date && left.getTime() === right.getTime()
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false
+    if (seen.get(left) === right) return true
+    seen.set(left, right)
+    return left.every((value, index) => sameValue(value, right[index], seen))
+  }
+  if (!isPlainRecord(left) || !isPlainRecord(right)) return false
+  if (seen.get(left) === right) return true
+  seen.set(left, right)
+  const leftKeys = Object.keys(left)
+  const rightKeys = Object.keys(right)
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(key => Object.hasOwn(right, key) && sameValue(left[key], right[key], seen))
+  )
+}

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -694,8 +694,13 @@ export class Figbird<
     const builder = isQueryDefinition(queryOrBuilder)
       ? queryOrBuilder.build(queryOrBuilder.validate(args))
       : queryOrBuilder
-    const nodes = explainQuery(builder.toAST(), this.schema?.relationships, serviceName =>
-      locallySupportedOperators(this.adapter, resolveServicePath(this.schema, serviceName)),
+    const nodes = explainQuery(
+      builder.toAST(),
+      this.schema?.relationships,
+      serviceName =>
+        locallySupportedOperators(this.adapter, resolveServicePath(this.schema, serviceName)),
+      serviceName =>
+        this.adapter.pageSource?.(resolveServicePath(this.schema, serviceName)) !== undefined,
     )
     return { nodes }
   }

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -4,6 +4,8 @@ import {
   type AdapterFindMeta,
   type AdapterParams,
   type AdapterQuery,
+  type PageInfo,
+  type PageRequest,
 } from '../adapters/adapter.js'
 import { registerDevtoolsInstance } from './devtoolsBridge.js'
 import type { FigbirdEvents } from './events.js'
@@ -724,6 +726,14 @@ export class Figbird<
           method: query.desc.method,
           ...(query.desc.method === 'get' ? { resourceId: query.desc.resourceId } : {}),
           query: q,
+          ...(query.desc.method === 'find' && query.desc.page
+            ? {
+                page: {
+                  request: query.desc.page,
+                  ...(query.state.pageInfo ? { info: query.state.pageInfo } : {}),
+                },
+              }
+            : {}),
           classification: query.classification,
           status: query.state.status,
           isFetching: query.state.isFetching,
@@ -769,6 +779,8 @@ export interface InspectedQuery {
   method: 'find' | 'get'
   resourceId?: string | number
   query: Record<string, unknown> | undefined
+  /** Native adapter page details. Offset pages remain visible in `query` as `$skip`/`$limit`. */
+  page?: { request: PageRequest; info?: PageInfo }
   classification: QueryNodeClass | 'get'
   status: 'loading' | 'success' | 'error'
   isFetching: boolean

--- a/lib/core/queryBuilder.ts
+++ b/lib/core/queryBuilder.ts
@@ -71,7 +71,7 @@ export interface QueryAST {
   /** Point-in-time result: fetched once, untouched by realtime; refetch() only. */
   snapshot?: boolean
   pageSize?: number
-  returnTotal?: boolean
+  includeTotal?: boolean
 }
 
 /**
@@ -116,7 +116,7 @@ interface QueryBuilderState {
   server: boolean
   snapshot: boolean
   pageSize?: number
-  returnTotal?: boolean
+  includeTotal?: boolean
 }
 
 /**
@@ -203,8 +203,8 @@ export class QueryBuilder<
       ast.pageSize = this.#state.pageSize
     }
 
-    if (this.#state.returnTotal) {
-      ast.returnTotal = true
+    if (this.#state.includeTotal) {
+      ast.includeTotal = true
     }
 
     return ast
@@ -352,7 +352,7 @@ export class QueryBuilder<
   /**
    * Switch this query into infinite-scroll / accumulator mode. The hook returns a
    * standard `data` array plus `loadMore()`, `hasMore`, `isLoadingMore`, and (when
-   * `returnTotal: true`) a `totalCount` field. Each call to `loadMore()` appends the
+   * `includeTotal: true`) a `total` field. Each call to `loadMore()` appends the
    * next `pageSize` rows to `data`.
    *
    * Realtime events on the underlying service refetch the loaded pages — local merge
@@ -367,7 +367,7 @@ export class QueryBuilder<
    */
   paginate(
     this: QueryBuilder<S, TService, TItem, TRelated, TCardinality, 'find'>,
-    options: { pageSize: number; returnTotal?: boolean },
+    options: { pageSize: number; includeTotal?: boolean },
   ): QueryBuilder<S, TService, TItem, TRelated, 'many', 'paginate'> {
     if (!Number.isInteger(options.pageSize) || options.pageSize <= 0) {
       throw new Error(`paginate(): pageSize must be a positive integer, got ${options.pageSize}`)
@@ -377,7 +377,7 @@ export class QueryBuilder<
       kind: 'paginate',
       cardinality: 'many',
       pageSize: options.pageSize,
-      ...(options.returnTotal !== undefined ? { returnTotal: options.returnTotal } : {}),
+      ...(options.includeTotal !== undefined ? { includeTotal: options.includeTotal } : {}),
     }) as QueryBuilder<S, TService, TItem, TRelated, 'many', 'paginate'>
   }
 

--- a/lib/core/queryBuilder.ts
+++ b/lib/core/queryBuilder.ts
@@ -369,8 +369,8 @@ export class QueryBuilder<
     this: QueryBuilder<S, TService, TItem, TRelated, TCardinality, 'find'>,
     options: { pageSize: number; returnTotal?: boolean },
   ): QueryBuilder<S, TService, TItem, TRelated, 'many', 'paginate'> {
-    if (!Number.isFinite(options.pageSize) || options.pageSize <= 0) {
-      throw new Error(`paginate(): pageSize must be a positive number, got ${options.pageSize}`)
+    if (!Number.isInteger(options.pageSize) || options.pageSize <= 0) {
+      throw new Error(`paginate(): pageSize must be a positive integer, got ${options.pageSize}`)
     }
     return new QueryBuilder(this.#schema, this.#state.service, {
       ...this.#state,

--- a/lib/core/queryClassification.ts
+++ b/lib/core/queryClassification.ts
@@ -42,7 +42,13 @@ export const SERVER_ONLY_QUERY_FILTERS = new Set(['$select'])
  * specific operator or filter that triggered it.
  */
 export interface ClassificationReason {
-  code: 'server-flag' | 'select-projection' | 'server-only-operator' | 'window-filter' | 'snapshot'
+  code:
+    | 'server-flag'
+    | 'native-pagination'
+    | 'select-projection'
+    | 'server-only-operator'
+    | 'window-filter'
+    | 'snapshot'
   detail?: string
 }
 
@@ -71,11 +77,13 @@ export function classifyQueryNode(query: unknown, options: ClassifyOptions = {})
 
 /** Explain-only affordances layered on top of classification. */
 export interface ExplainNodeOptions extends ClassifyOptions {
+  /** Override the default `.server()` reason when another plan owns server authority. */
+  serverReasons?: readonly ClassificationReason[] | undefined
   /** `.snapshot()` — appends the snapshot reason (class is unaffected; realtime is manual). */
   snapshot?: boolean | undefined
   /**
-   * A `.paginate()` root — each page runs as a `$limit`/`$skip` window, so an
-   * otherwise local-exact node reports server-window.
+   * An offset `.paginate()` root — each page runs as a `$limit`/`$skip` window,
+   * so an otherwise local-exact node reports server-window.
    */
   paginatedRoot?: boolean | undefined
 }
@@ -86,10 +94,21 @@ export interface ExplainNodeOptions extends ClassifyOptions {
  */
 export function explainQueryNode(
   query: unknown,
-  { server, allPages, localOperators, snapshot, paginatedRoot }: ExplainNodeOptions = {},
+  {
+    server,
+    serverReasons,
+    allPages,
+    localOperators,
+    snapshot,
+    paginatedRoot,
+  }: ExplainNodeOptions = {},
 ): { class: QueryNodeClass; reasons: ClassificationReason[] } {
   const authoritative: ClassificationReason[] = []
-  if (server) authoritative.push({ code: 'server-flag', detail: '.server()' })
+  if (server) {
+    authoritative.push(
+      ...(serverReasons ?? [{ code: 'server-flag' as const, detail: '.server()' }]),
+    )
+  }
 
   const window: ClassificationReason[] = []
   walkQueryKeys(query, (key, top) => {
@@ -173,6 +192,36 @@ export interface RelationPlan {
   windowed: boolean
   /** allPages for the destination fetch (a junction's first hop is always exhaustive). */
   allPages: boolean
+}
+
+/** One plan shared by paginated-root execution and static explanation. */
+export interface RootPaginationPlan {
+  kind: 'offset' | 'sequential'
+  /** Sequential continuations and explicit `.server()` roots are server-authoritative. */
+  server: boolean
+  /** Structured reasons used by `figbird.explain()`. */
+  serverReasons: ClassificationReason[]
+}
+
+export function planRootPagination(
+  nativeSequential: boolean,
+  explicitServer: boolean,
+): RootPaginationPlan {
+  const serverReasons: ClassificationReason[] = []
+  if (nativeSequential) {
+    serverReasons.push({
+      code: 'native-pagination',
+      detail: 'adapter-native sequential pagination',
+    })
+  }
+  if (explicitServer) {
+    serverReasons.push({ code: 'server-flag', detail: '.server()' })
+  }
+  return {
+    kind: nativeSequential ? 'sequential' : 'offset',
+    server: serverReasons.length > 0,
+    serverReasons,
+  }
 }
 
 /**
@@ -290,9 +339,10 @@ export function explainQuery(
   ast: QueryAST,
   relationships: SchemaRelationships | undefined,
   localOperatorsFor: (serviceName: string) => ReadonlySet<string>,
+  hasNativePagination: (serviceName: string) => boolean,
 ): ExplainNode[] {
   const nodes: ExplainNode[] = []
-  explainAst(ast, '(root)', true, nodes, relationships, localOperatorsFor)
+  explainAst(ast, '(root)', true, nodes, relationships, localOperatorsFor, hasNativePagination)
   return nodes
 }
 
@@ -303,17 +353,24 @@ function explainAst(
   nodes: ExplainNode[],
   relationships: SchemaRelationships | undefined,
   localOperatorsFor: (serviceName: string) => ReadonlySet<string>,
+  hasNativePagination: (serviceName: string) => boolean,
 ): void {
   const snapshot = Boolean(ast.snapshot)
+  const paginationPlan =
+    isRoot && ast.kind === 'paginate'
+      ? planRootPagination(hasNativePagination(ast.service), Boolean(ast.server))
+      : null
   // Root fetch shape comes from the same plan the runtime executes (rootAllPages):
   // .all() drains every page, so window filters ($sort — the builder refuses
-  // $limit/$skip) don't demote the class; a paginate root reports server-window.
+  // $limit/$skip) don't demote the class. Offset pagination is a server window;
+  // native sequential pagination is server-authoritative.
   const explained = explainQueryNode(ast.query, {
-    server: ast.server,
+    server: paginationPlan?.server ?? ast.server,
+    ...(paginationPlan ? { serverReasons: paginationPlan.serverReasons } : {}),
     allPages: rootAllPages(ast.kind),
     localOperators: localOperatorsFor(ast.service),
     snapshot,
-    paginatedRoot: isRoot && ast.kind === 'paginate',
+    paginatedRoot: paginationPlan?.kind === 'offset',
   })
 
   nodes.push({

--- a/lib/core/queryRef.ts
+++ b/lib/core/queryRef.ts
@@ -1,7 +1,12 @@
 import { createQueryId } from './queryIdentity.js'
 import type { AnySchema, Schema } from './schema.js'
 import type { QueryStore } from './queryStore.js'
-import type { QueryConfig, QueryDescriptor, QueryState } from './queryTypes.js'
+import type {
+  ProcessedRealtimeEvent,
+  QueryConfig,
+  QueryDescriptor,
+  QueryState,
+} from './queryTypes.js'
 
 // a lightweight query reference object to make it easy
 // subscribe to state changes and read query data
@@ -84,5 +89,23 @@ export class QueryRef<
   refetch(): void {
     this.#queryStore.materialize(this)
     return this.#queryStore.refetch(this.#queryId)
+  }
+
+  /** Route an event-driven refetch through the store's reconciliation gate. @internal */
+  reconcile(): void {
+    this.#queryStore.materialize(this)
+    this.#queryStore.reconcile(this.#queryId)
+  }
+
+  /** Apply a value-only update to an already-visible row. @internal */
+  applyVisibleEvent(event: ProcessedRealtimeEvent): void {
+    this.#queryStore.materialize(this)
+    this.#queryStore.applyVisibleEvent(this.#queryId, event)
+  }
+
+  /** Register this ref as a composite query's reconnect sentinel. @internal */
+  registerReconnectReconciliation(): () => void {
+    this.#queryStore.materialize(this)
+    return this.#queryStore.registerReconnectQuery(this.#queryId)
   }
 }

--- a/lib/core/queryRoots.ts
+++ b/lib/core/queryRoots.ts
@@ -1,0 +1,532 @@
+import type { QueryRef } from './queryRef.js'
+import type { QueryState } from './queryTypes.js'
+import type { AnySchema, Schema } from './schema.js'
+
+/** The relational engine's adapter-neutral view of its root rows. */
+export interface RootSnapshot {
+  phase: 'loading' | 'error' | 'ready'
+  /** Valid when phase is 'ready'. Identity is stable while the underlying data is. */
+  rows: unknown[]
+  isFetching: boolean
+  error: Error | null
+}
+
+/** Common lifecycle for a single-query root and an accumulating page root. */
+export interface RootSource {
+  snapshot(): RootSnapshot
+  setStaleTime(staleTime: number): void
+  ensureFresh(staleTime?: number): void
+  refetch(): void
+  teardown(): void
+  queryIds(): string[]
+}
+
+/** Pagination metadata exposed by `.paginate(...)` queries. */
+export interface RelationalPaginationState {
+  /** Sticky while `loadMore()` is in flight. */
+  hasMore: boolean
+  isLoadingMore: boolean
+  loadMoreError: Error | null
+  /** Present when page one requested a total and the adapter supplied one. */
+  totalCount: number | undefined
+}
+
+export interface PaginatedRootSource extends RootSource {
+  loadMore(): void
+  pagination(): RelationalPaginationState
+}
+
+const EMPTY_ROWS: unknown[] = []
+const LOADING_ROOT: RootSnapshot = {
+  phase: 'loading',
+  rows: EMPTY_ROWS,
+  isFetching: true,
+  error: null,
+}
+
+/**
+ * Store listeners fire only on changes. Seed from the current state as well so a
+ * query already warmed by another consumer does not look cold until its SWR fetch
+ * settles.
+ */
+export function subscribeAndSeed<
+  S extends Schema,
+  TParams,
+  TMeta extends Record<string, unknown>,
+  TQuery,
+>(
+  queryRef: QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>,
+  onSuccess: (data: unknown[]) => void,
+  onChange: () => void,
+  staleTime = 0,
+): () => void {
+  const unsub = queryRef.subscribe(
+    state => {
+      if (state.status === 'success') onSuccess(state.data as unknown[])
+      onChange()
+    },
+    { staleTime },
+  )
+  const initial = queryRef.getSnapshot()
+  if (initial?.status === 'success') onSuccess(initial.data as unknown[])
+  return unsub
+}
+
+/** Root backed by one find or get query. */
+export class SingleQueryRoot<
+  S extends Schema = AnySchema,
+  TParams = unknown,
+  TMeta extends Record<string, unknown> = Record<string, unknown>,
+  TQuery = Record<string, unknown>,
+> implements RootSource {
+  #queryRef: QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>
+  #unsub: () => void
+  #isGet: boolean
+  #lastGetData: unknown = undefined
+  #lastGetDataAsArray: unknown[] = []
+
+  constructor({
+    queryRef,
+    isGet,
+    onRows,
+    onChange,
+    staleTime = 0,
+  }: {
+    queryRef: QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>
+    isGet: boolean
+    onRows: (rows: unknown[]) => void
+    onChange: () => void
+    staleTime?: number
+  }) {
+    this.#queryRef = queryRef
+    this.#isGet = isGet
+    this.#unsub = subscribeAndSeed(
+      queryRef,
+      data => onRows(this.#asRows(data)),
+      onChange,
+      staleTime,
+    )
+  }
+
+  #asRows(data: unknown): unknown[] {
+    if (!this.#isGet) return data as unknown[]
+    if (data === this.#lastGetData) return this.#lastGetDataAsArray
+    this.#lastGetData = data
+    this.#lastGetDataAsArray = data == null ? [] : [data]
+    return this.#lastGetDataAsArray
+  }
+
+  snapshot(): RootSnapshot {
+    const state = this.#queryRef.getSnapshot()
+    if (!state || state.status === 'loading') return LOADING_ROOT
+    if (state.status === 'error') {
+      return { phase: 'error', rows: EMPTY_ROWS, isFetching: false, error: state.error }
+    }
+    return {
+      phase: 'ready',
+      rows: this.#asRows(state.data),
+      isFetching: state.isFetching,
+      error: null,
+    }
+  }
+
+  ensureFresh(staleTime?: number): void {
+    this.#queryRef.ensureFresh({ staleTime })
+  }
+
+  setStaleTime(_staleTime: number): void {}
+
+  refetch(): void {
+    this.#queryRef.refetch()
+  }
+
+  teardown(): void {
+    this.#unsub()
+  }
+
+  queryIds(): string[] {
+    return [this.#queryRef.details().queryId]
+  }
+}
+
+type SequentialReconcileState =
+  | { phase: 'idle' }
+  | {
+      phase: 'running'
+      targetPages: number
+      rows: unknown[]
+      previousQueryIds: ReadonlySet<string>
+      rerun: boolean
+    }
+  | {
+      phase: 'failed'
+      targetPages: number
+      rows: unknown[]
+      previousQueryIds: ReadonlySet<string>
+    }
+
+/**
+ * Root backed by an accumulating sequence of pages. Offset pages are independent.
+ * Native continuation pages are sequential: page zero is the QueryStore lifecycle
+ * sentinel, and a background fetch there rebuilds the loaded prefix before exposing
+ * any of it.
+ */
+export class PagedQueryRoot<
+  S extends Schema = AnySchema,
+  TParams = unknown,
+  TMeta extends Record<string, unknown> = Record<string, unknown>,
+  TQuery = Record<string, unknown>,
+> implements PaginatedRootSource {
+  #makePageRef: (
+    pageIndex: number,
+    after?: unknown,
+  ) => QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>
+  #onRows: (rows: unknown[]) => void
+  #onChange: () => void
+  #pageSize: number
+  #returnTotal: boolean
+  #sequential: boolean
+
+  #pageRefs: Array<QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>> = []
+  #pageUnsubs: Array<() => void> = []
+  #staleTime = 0
+  #isLoadingMore = false
+  #loadMoreError: Error | null = null
+  #hasMoreSticky = true
+  #lastPageDataRefs: unknown[] = []
+  #lastAllPagesData: unknown[] = []
+  #reconcile: SequentialReconcileState = { phase: 'idle' }
+  #lastPagination: RelationalPaginationState | null = null
+
+  constructor({
+    pageSize,
+    returnTotal,
+    sequential,
+    makePageRef,
+    onRows,
+    onChange,
+    staleTime = 0,
+  }: {
+    pageSize: number
+    returnTotal: boolean
+    sequential: boolean
+    makePageRef: (
+      pageIndex: number,
+      after?: unknown,
+    ) => QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>
+    onRows: (rows: unknown[]) => void
+    onChange: () => void
+    staleTime?: number
+  }) {
+    this.#pageSize = pageSize
+    this.#returnTotal = returnTotal
+    this.#sequential = sequential
+    this.#makePageRef = makePageRef
+    this.#onRows = onRows
+    this.#onChange = onChange
+    this.#staleTime = staleTime
+    this.#setupPage(0)
+  }
+
+  #setupPage(
+    pageIndex: number,
+    settle?: { onError: (error: Error) => void },
+    after?: unknown,
+  ): void {
+    const queryRef = this.#makePageRef(pageIndex, after)
+    this.#pageRefs.push(queryRef)
+    let pendingSettle = settle
+    const reconcile = this.#reconcile
+    const wasFetching =
+      reconcile.phase === 'running' &&
+      reconcile.previousQueryIds.has(queryRef.details().queryId) &&
+      queryRef.getSnapshot()?.isFetching
+
+    const onState = (state: ReturnType<(typeof queryRef)['getSnapshot']>): void => {
+      if (
+        this.#sequential &&
+        pageIndex === 0 &&
+        state?.isFetching &&
+        (this.#pageRefs.length > 1 || this.#reconcile.phase !== 'idle')
+      ) {
+        this.#beginReconcile()
+      }
+
+      if (state?.status === 'success') {
+        const pageData = (state.data ?? []) as unknown[]
+        if (pendingSettle && !state.isFetching) {
+          pendingSettle = undefined
+          this.#isLoadingMore = false
+          this.#loadMoreError = null
+          this.#hasMoreSticky = this.#pageHasMore(state, pageData)
+        } else if (!this.#isLoadingMore && !state.isFetching) {
+          this.#hasMoreSticky = this.#pageHasMore(state, pageData)
+        }
+        this.#onRows(this.#allPagesData())
+        if (
+          this.#reconcile.phase === 'running' &&
+          !state.isFetching &&
+          pageIndex === this.#pageRefs.length - 1
+        ) {
+          this.#advanceReconcile(pageIndex, state)
+        }
+      } else if (state?.status === 'error' && pendingSettle) {
+        const currentSettle = pendingSettle
+        pendingSettle = undefined
+        currentSettle.onError(state.error)
+      } else if (state?.status === 'error' && this.#reconcile.phase === 'running') {
+        this.#abortReconcile()
+      }
+    }
+
+    const unsub = queryRef.subscribe(
+      state => {
+        onState(state)
+        this.#onChange()
+      },
+      { staleTime: reconcile.phase === 'running' ? 0 : this.#staleTime },
+    )
+    this.#pageUnsubs.push(unsub)
+    // A dropped page can still have its old request in flight. Mark it dirty so
+    // QueryStore follows that response with a request issued from this fresh chain.
+    if (wasFetching) queryRef.refetch()
+    onState(queryRef.getSnapshot())
+  }
+
+  loadMore(): void {
+    if (this.#reconcile.phase !== 'idle') return
+    if (this.#isLoadingMore || !this.#hasMoreSticky || this.#pageRefs.length === 0) return
+
+    const firstPageState = this.#pageRefs[0]?.getSnapshot()
+    if (!firstPageState || firstPageState.status !== 'success') return
+
+    const previousPageState = this.#pageRefs.at(-1)?.getSnapshot()
+    if (!previousPageState || previousPageState.status !== 'success') return
+    const after = this.#sequential ? previousPageState.pageInfo?.endCursor : undefined
+    if (this.#sequential && after === undefined) return
+
+    this.#isLoadingMore = true
+    this.#loadMoreError = null
+    this.#setupPage(
+      this.#pageRefs.length,
+      {
+        onError: error => {
+          this.#isLoadingMore = false
+          this.#loadMoreError = error
+          this.#hasMoreSticky = true
+          this.#pageRefs.pop()
+          this.#pageUnsubs.pop()?.()
+        },
+      },
+      after,
+    )
+    this.#onChange()
+  }
+
+  snapshot(): RootSnapshot {
+    if (this.#pageRefs.length === 0) return LOADING_ROOT
+
+    const pageStates: QueryState<unknown, TMeta>[] = []
+    for (const ref of this.#pageRefs) {
+      const state = ref.getSnapshot()
+      if (!state) return LOADING_ROOT
+      pageStates.push(state)
+    }
+    for (const state of pageStates) {
+      if (state.status === 'error') {
+        return { phase: 'error', rows: EMPTY_ROWS, isFetching: false, error: state.error }
+      }
+    }
+    if (pageStates[0]!.status === 'loading') return LOADING_ROOT
+
+    return {
+      phase: 'ready',
+      rows: this.#allPagesData(),
+      isFetching: pageStates.some(state => state.isFetching),
+      error: null,
+    }
+  }
+
+  ensureFresh(staleTime?: number): void {
+    if (this.#sequential) {
+      this.#pageRefs[0]?.ensureFresh({ staleTime })
+      return
+    }
+    for (const ref of this.#pageRefs) ref.ensureFresh({ staleTime })
+  }
+
+  setStaleTime(staleTime: number): void {
+    this.#staleTime = staleTime
+  }
+
+  pagination(): RelationalPaginationState {
+    const hasMore = this.#hasMoreSticky
+    const isLoadingMore = this.#isLoadingMore
+    const loadMoreError = this.#loadMoreError
+    const totalCount = this.#computeTotalCount()
+    const previous = this.#lastPagination
+    if (
+      previous &&
+      previous.hasMore === hasMore &&
+      previous.isLoadingMore === isLoadingMore &&
+      previous.loadMoreError === loadMoreError &&
+      previous.totalCount === totalCount
+    ) {
+      return previous
+    }
+    const next = { hasMore, isLoadingMore, loadMoreError, totalCount }
+    this.#lastPagination = next
+    return next
+  }
+
+  /** Manual refetch deliberately resets the cursor chain to page zero. */
+  refetch(): void {
+    this.#reconcile = { phase: 'idle' }
+    this.#dropFollowupPages()
+    this.#hasMoreSticky = true
+    this.#isLoadingMore = false
+    this.#loadMoreError = null
+    this.#pageRefs[0]?.refetch()
+    this.#onChange()
+  }
+
+  teardown(): void {
+    for (const unsub of this.#pageUnsubs) unsub()
+    this.#pageUnsubs.length = 0
+    this.#pageRefs.length = 0
+    this.#reconcile = { phase: 'idle' }
+  }
+
+  queryIds(): string[] {
+    return this.#pageRefs.map(ref => ref.details().queryId)
+  }
+
+  #computeTotalCount(): number | undefined {
+    if (!this.#returnTotal) return undefined
+    const state = this.#pageRefs[0]?.getSnapshot()
+    if (!state || state.status !== 'success') return undefined
+    if (state.pageInfo && typeof state.pageInfo.total === 'number' && state.pageInfo.total >= 0) {
+      return state.pageInfo.total
+    }
+    const meta = state.meta as { total?: number } | undefined
+    if (!meta || typeof meta.total !== 'number' || meta.total < 0) return undefined
+    return meta.total
+  }
+
+  #pageHasMore(state: QueryState<unknown, TMeta>, data: unknown[]): boolean {
+    if (this.#sequential) return state.pageInfo?.hasMore ?? false
+    return data.length >= this.#pageSize
+  }
+
+  #beginReconcile(): void {
+    const current = this.#reconcile
+    if (current.phase === 'running') {
+      if (!current.rerun) this.#reconcile = { ...current, rerun: true }
+      return
+    }
+
+    const targetPages = current.phase === 'failed' ? current.targetPages : this.#pageRefs.length
+    if (targetPages <= 1 && current.phase === 'idle') return
+    const rows = current.phase === 'failed' ? current.rows : this.#allPagesData()
+    const previousQueryIds =
+      current.phase === 'failed'
+        ? current.previousQueryIds
+        : new Set(this.#pageRefs.slice(1).map(ref => ref.details().queryId))
+    this.#reconcile = {
+      phase: 'running',
+      targetPages,
+      rows,
+      previousQueryIds,
+      rerun: false,
+    }
+    this.#dropFollowupPages()
+    this.#hasMoreSticky = true
+    this.#isLoadingMore = false
+    this.#loadMoreError = null
+    this.#onChange()
+  }
+
+  #advanceReconcile(pageIndex: number, state: QueryState<unknown, TMeta>): void {
+    const current = this.#reconcile
+    if (current.phase !== 'running') return
+
+    const data = state.status === 'success' && Array.isArray(state.data) ? state.data : []
+    const hasMore = this.#pageHasMore(state, data)
+    if (pageIndex + 1 < current.targetPages && hasMore) {
+      const after = state.pageInfo?.endCursor
+      if (after === undefined) {
+        this.#abortReconcile()
+        return
+      }
+      this.#setupPage(pageIndex + 1, undefined, after)
+      return
+    }
+
+    if (current.rerun) {
+      this.#restartReconcile(current)
+      return
+    }
+
+    this.#reconcile = { phase: 'idle' }
+    this.#onRows(this.#allPagesData())
+    this.#onChange()
+  }
+
+  #restartReconcile(current: Extract<SequentialReconcileState, { phase: 'running' }>): void {
+    this.#reconcile = { ...current, rerun: false }
+    this.#dropFollowupPages()
+    const firstPage = this.#pageRefs[0]?.getSnapshot()
+    if (firstPage?.status === 'success' && !firstPage.isFetching) {
+      this.#advanceReconcile(0, firstPage)
+    }
+  }
+
+  #abortReconcile(): void {
+    const current = this.#reconcile
+    if (current.phase !== 'running') return
+    this.#reconcile = {
+      phase: 'failed',
+      targetPages: current.targetPages,
+      rows: current.rows,
+      previousQueryIds: current.previousQueryIds,
+    }
+    this.#onChange()
+  }
+
+  #dropFollowupPages(): void {
+    for (let index = 1; index < this.#pageUnsubs.length; index++) {
+      this.#pageUnsubs[index]?.()
+    }
+    this.#pageUnsubs.length = Math.min(1, this.#pageUnsubs.length)
+    this.#pageRefs.length = Math.min(1, this.#pageRefs.length)
+  }
+
+  /** Concatenate all settled pages, preserving identity until a page ref changes. */
+  #allPagesData(): unknown[] {
+    if (this.#reconcile.phase !== 'idle') return this.#reconcile.rows
+
+    const refs: unknown[] = []
+    for (const ref of this.#pageRefs) {
+      const state = ref.getSnapshot()
+      refs.push(state?.status === 'success' && Array.isArray(state.data) ? state.data : null)
+    }
+    let unchanged = refs.length === this.#lastPageDataRefs.length
+    if (unchanged) {
+      for (let index = 0; index < refs.length; index++) {
+        if (refs[index] !== this.#lastPageDataRefs[index]) {
+          unchanged = false
+          break
+        }
+      }
+    }
+    if (unchanged) return this.#lastAllPagesData
+
+    const all: unknown[] = []
+    for (const ref of refs) {
+      if (Array.isArray(ref)) all.push(...ref)
+    }
+    this.#lastPageDataRefs = refs
+    this.#lastAllPagesData = all
+    return all
+  }
+}

--- a/lib/core/queryRoots.ts
+++ b/lib/core/queryRoots.ts
@@ -1,6 +1,6 @@
 import type { PageCursor, PageInfo } from '../adapters/adapter.js'
 import type { QueryRef } from './queryRef.js'
-import type { QueryState } from './queryTypes.js'
+import type { ProcessedRealtimeEvent, QueryState } from './queryTypes.js'
 import type { AnySchema, Schema } from './schema.js'
 
 /** The relational engine's adapter-neutral view of its root rows. */
@@ -29,7 +29,7 @@ export interface RelationalPaginationState {
   isLoadingMore: boolean
   loadMoreError: Error | null
   /** Present when page one requested a total and the adapter supplied one. */
-  totalCount: number | undefined
+  total: number | undefined
 }
 
 export interface PaginatedRootSource extends RootSource {
@@ -185,7 +185,7 @@ export class PagedQueryRoot<
   #onRows: (rows: unknown[]) => void
   #onChange: () => void
   #pageSize: number
-  #returnTotal: boolean
+  #includeTotal: boolean
   #sequential: boolean
 
   #pageRefs: Array<QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>> = []
@@ -198,18 +198,21 @@ export class PagedQueryRoot<
   #lastAllPagesData: unknown[] = []
   #reconcile: SequentialReconcileState = { phase: 'idle' }
   #lastPagination: RelationalPaginationState | null = null
+  #cursorEventUnsub: (() => void) | null = null
+  #cursorReconnectUnsub: (() => void) | null = null
 
   constructor({
     pageSize,
-    returnTotal,
+    includeTotal,
     sequential,
     makePageRef,
     onRows,
     onChange,
+    cursorRealtime,
     staleTime = 0,
   }: {
     pageSize: number
-    returnTotal: boolean
+    includeTotal: boolean
     sequential: boolean
     makePageRef: (
       pageIndex: number,
@@ -217,16 +220,30 @@ export class PagedQueryRoot<
     ) => QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>
     onRows: (rows: unknown[]) => void
     onChange: () => void
+    cursorRealtime?: {
+      subscribe(fn: (event: ProcessedRealtimeEvent) => void): () => void
+      canKeepPrefix(event: ProcessedRealtimeEvent): boolean
+    }
     staleTime?: number
   }) {
     this.#pageSize = pageSize
-    this.#returnTotal = returnTotal
+    this.#includeTotal = includeTotal
     this.#sequential = sequential
     this.#makePageRef = makePageRef
     this.#onRows = onRows
     this.#onChange = onChange
     this.#staleTime = staleTime
     this.#setupPage(0)
+    if (cursorRealtime) {
+      this.#cursorReconnectUnsub = this.#pageRefs[0]?.registerReconnectReconciliation() ?? null
+      this.#cursorEventUnsub = cursorRealtime.subscribe(event => {
+        if (cursorRealtime.canKeepPrefix(event)) {
+          for (const pageRef of this.#pageRefs) pageRef.applyVisibleEvent(event)
+        } else {
+          this.#pageRefs[0]?.reconcile()
+        }
+      })
+    }
   }
 
   #setupPage(
@@ -372,18 +389,18 @@ export class PagedQueryRoot<
     const hasMore = this.#hasMoreSticky
     const isLoadingMore = this.#isLoadingMore
     const loadMoreError = this.#loadMoreError
-    const totalCount = this.#computeTotalCount()
+    const total = this.#computeTotal()
     const previous = this.#lastPagination
     if (
       previous &&
       previous.hasMore === hasMore &&
       previous.isLoadingMore === isLoadingMore &&
       previous.loadMoreError === loadMoreError &&
-      previous.totalCount === totalCount
+      previous.total === total
     ) {
       return previous
     }
-    const next = { hasMore, isLoadingMore, loadMoreError, totalCount }
+    const next = { hasMore, isLoadingMore, loadMoreError, total }
     this.#lastPagination = next
     return next
   }
@@ -400,6 +417,10 @@ export class PagedQueryRoot<
   }
 
   teardown(): void {
+    this.#cursorEventUnsub?.()
+    this.#cursorEventUnsub = null
+    this.#cursorReconnectUnsub?.()
+    this.#cursorReconnectUnsub = null
     for (const unsub of this.#pageUnsubs) unsub()
     this.#pageUnsubs.length = 0
     this.#pageRefs.length = 0
@@ -410,8 +431,8 @@ export class PagedQueryRoot<
     return this.#pageRefs.map(ref => ref.details().queryId)
   }
 
-  #computeTotalCount(): number | undefined {
-    if (!this.#returnTotal) return undefined
+  #computeTotal(): number | undefined {
+    if (!this.#includeTotal) return undefined
     const state = this.#pageRefs[0]?.getSnapshot()
     if (!state || state.status !== 'success') return undefined
     if (state.pageInfo && typeof state.pageInfo.total === 'number' && state.pageInfo.total >= 0) {

--- a/lib/core/queryRoots.ts
+++ b/lib/core/queryRoots.ts
@@ -32,9 +32,22 @@ export interface RelationalPaginationState {
   total: number | undefined
 }
 
+/** Stable, adapter-neutral pagination details exposed to devtools. */
+export interface InspectedPagination {
+  strategy: 'offset' | 'cursor'
+  realtime: 'manual' | 'merge-or-reconcile' | 'reconcile'
+  pageSize: number
+  includeTotal: boolean
+  loadedPages: number
+  hasMore: boolean
+  isLoadingMore: boolean
+  total?: number
+}
+
 export interface PaginatedRootSource extends RootSource {
   loadMore(): void
   pagination(): RelationalPaginationState
+  inspectPagination(): InspectedPagination
 }
 
 const EMPTY_ROWS: unknown[] = []
@@ -187,6 +200,7 @@ export class PagedQueryRoot<
   #pageSize: number
   #includeTotal: boolean
   #sequential: boolean
+  #realtime: InspectedPagination['realtime']
 
   #pageRefs: Array<QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>> = []
   #pageUnsubs: Array<() => void> = []
@@ -209,6 +223,7 @@ export class PagedQueryRoot<
     onRows,
     onChange,
     cursorRealtime,
+    realtime,
     staleTime = 0,
   }: {
     pageSize: number
@@ -224,11 +239,13 @@ export class PagedQueryRoot<
       subscribe(fn: (event: ProcessedRealtimeEvent) => void): () => void
       canKeepPrefix(event: ProcessedRealtimeEvent): boolean
     }
+    realtime: InspectedPagination['realtime']
     staleTime?: number
   }) {
     this.#pageSize = pageSize
     this.#includeTotal = includeTotal
     this.#sequential = sequential
+    this.#realtime = realtime
     this.#makePageRef = makePageRef
     this.#onRows = onRows
     this.#onChange = onChange
@@ -403,6 +420,20 @@ export class PagedQueryRoot<
     const next = { hasMore, isLoadingMore, loadMoreError, total }
     this.#lastPagination = next
     return next
+  }
+
+  inspectPagination(): InspectedPagination {
+    const { hasMore, isLoadingMore, total } = this.pagination()
+    return {
+      strategy: this.#sequential ? 'cursor' : 'offset',
+      realtime: this.#realtime,
+      pageSize: this.#pageSize,
+      includeTotal: this.#includeTotal,
+      loadedPages: this.#pageRefs.length,
+      hasMore,
+      isLoadingMore,
+      ...(total !== undefined ? { total } : {}),
+    }
   }
 
   /** Manual refetch deliberately resets the cursor chain to page zero. */

--- a/lib/core/queryRoots.ts
+++ b/lib/core/queryRoots.ts
@@ -1,3 +1,4 @@
+import type { PageCursor, PageInfo } from '../adapters/adapter.js'
 import type { QueryRef } from './queryRef.js'
 import type { QueryState } from './queryTypes.js'
 import type { AnySchema, Schema } from './schema.js'
@@ -179,7 +180,7 @@ export class PagedQueryRoot<
 > implements PaginatedRootSource {
   #makePageRef: (
     pageIndex: number,
-    after?: unknown,
+    after?: PageCursor,
   ) => QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>
   #onRows: (rows: unknown[]) => void
   #onChange: () => void
@@ -212,7 +213,7 @@ export class PagedQueryRoot<
     sequential: boolean
     makePageRef: (
       pageIndex: number,
-      after?: unknown,
+      after?: PageCursor,
     ) => QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>
     onRows: (rows: unknown[]) => void
     onChange: () => void
@@ -231,16 +232,17 @@ export class PagedQueryRoot<
   #setupPage(
     pageIndex: number,
     settle?: { onError: (error: Error) => void },
-    after?: unknown,
+    after?: PageCursor,
   ): void {
     const queryRef = this.#makePageRef(pageIndex, after)
     this.#pageRefs.push(queryRef)
     let pendingSettle = settle
     const reconcile = this.#reconcile
-    const wasFetching =
+    let refetchAfterCurrent = Boolean(
       reconcile.phase === 'running' &&
       reconcile.previousQueryIds.has(queryRef.details().queryId) &&
-      queryRef.getSnapshot()?.isFetching
+      queryRef.getSnapshot()?.isFetching,
+    )
 
     const onState = (state: ReturnType<(typeof queryRef)['getSnapshot']>): void => {
       if (
@@ -250,6 +252,15 @@ export class PagedQueryRoot<
         (this.#pageRefs.length > 1 || this.#reconcile.phase !== 'idle')
       ) {
         this.#beginReconcile()
+      }
+
+      // This query id can still belong to a request started by the old cursor
+      // chain. Let that attempt settle, then start the request owned by this chain;
+      // never advance or expose the old terminal state.
+      if (refetchAfterCurrent && state && !state.isFetching) {
+        refetchAfterCurrent = false
+        queryRef.refetch()
+        return
       }
 
       if (state?.status === 'success') {
@@ -287,9 +298,6 @@ export class PagedQueryRoot<
       { staleTime: reconcile.phase === 'running' ? 0 : this.#staleTime },
     )
     this.#pageUnsubs.push(unsub)
-    // A dropped page can still have its old request in flight. Mark it dirty so
-    // QueryStore follows that response with a request issued from this fresh chain.
-    if (wasFetching) queryRef.refetch()
     onState(queryRef.getSnapshot())
   }
 
@@ -302,8 +310,9 @@ export class PagedQueryRoot<
 
     const previousPageState = this.#pageRefs.at(-1)?.getSnapshot()
     if (!previousPageState || previousPageState.status !== 'success') return
-    const after = this.#sequential ? previousPageState.pageInfo?.endCursor : undefined
-    if (this.#sequential && after === undefined) return
+    const pageInfo = this.#sequential ? this.#requirePageInfo(previousPageState) : undefined
+    if (pageInfo && !pageInfo.hasMore) return
+    const after = pageInfo?.endCursor
 
     this.#isLoadingMore = true
     this.#loadMoreError = null
@@ -414,8 +423,15 @@ export class PagedQueryRoot<
   }
 
   #pageHasMore(state: QueryState<unknown, TMeta>, data: unknown[]): boolean {
-    if (this.#sequential) return state.pageInfo?.hasMore ?? false
+    if (this.#sequential) return this.#requirePageInfo(state).hasMore
     return data.length >= this.#pageSize
+  }
+
+  #requirePageInfo(state: QueryState<unknown, TMeta>): PageInfo {
+    if (!state.pageInfo) {
+      throw new Error('Native page query settled without pageInfo')
+    }
+    return state.pageInfo
   }
 
   #beginReconcile(): void {
@@ -450,15 +466,9 @@ export class PagedQueryRoot<
     const current = this.#reconcile
     if (current.phase !== 'running') return
 
-    const data = state.status === 'success' && Array.isArray(state.data) ? state.data : []
-    const hasMore = this.#pageHasMore(state, data)
-    if (pageIndex + 1 < current.targetPages && hasMore) {
-      const after = state.pageInfo?.endCursor
-      if (after === undefined) {
-        this.#abortReconcile()
-        return
-      }
-      this.#setupPage(pageIndex + 1, undefined, after)
+    const pageInfo = this.#requirePageInfo(state)
+    if (pageIndex + 1 < current.targetPages && pageInfo.hasMore) {
+      this.#setupPage(pageIndex + 1, undefined, pageInfo.endCursor)
       return
     }
 

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -1,4 +1,9 @@
-import { locallySupportedOperators, type Adapter, type QueryResponse } from '../adapters/adapter.js'
+import {
+  locallySupportedOperators,
+  type Adapter,
+  type PageResponse,
+  type QueryResponse,
+} from '../adapters/adapter.js'
 import type { AnySchema, Schema } from './schema.js'
 import type { QueryRef } from './queryRef.js'
 import { isEphemeralQuery } from './queryIdentity.js'
@@ -58,7 +63,9 @@ export type ReconnectJitter = number | readonly [number, number]
 export type RetryDelay = number | ((attempt: number, error: Error) => number)
 
 type FetchAttemptOutcome =
-  { kind: 'completed' } | { kind: 'stale' } | { kind: 'failed'; error: Error }
+  | { kind: 'completed' }
+  | { kind: 'stale' }
+  | { kind: 'failed'; error: Error }
 
 const DEFAULT_RETRIES = 3
 const MAX_RETRY_DELAY = 30_000
@@ -66,6 +73,9 @@ const MAX_RETRY_DELAY = 30_000
 function defaultRetryDelay(attempt: number): number {
   return Math.min(1000 * 2 ** (attempt - 1), MAX_RETRY_DELAY)
 }
+
+type StoreResponse<TMeta> =
+  QueryResponse<unknown, TMeta | undefined> | PageResponse<unknown[], TMeta>
 
 type ItemId = string | number
 
@@ -670,7 +680,7 @@ export class QueryStore<
     }
   }
 
-  #fetch(queryId: string): Promise<QueryResponse<unknown, TMeta | undefined>> {
+  #fetch(queryId: string): Promise<StoreResponse<TMeta>> {
     const query = this.#getQuery(queryId)
     if (!query) {
       return Promise.reject(new Error('Query not found'))
@@ -683,6 +693,15 @@ export class QueryStore<
       if (local) return Promise.resolve(local)
       return this.#adapter.get(desc.serviceName, desc.resourceId, desc.params as TParams)
     } else {
+      if (desc.page) {
+        const pageSource = this.#adapter.pageSource?.(desc.serviceName)
+        if (!pageSource) {
+          return Promise.reject(
+            new Error(`Adapter does not support native pagination for "${desc.serviceName}"`),
+          )
+        }
+        return pageSource.find(desc.params as TParams, desc.page)
+      }
       const local = this.#tryLocalFind(query)
       if (local) return Promise.resolve(local)
       const findConfig = config as FindQueryConfig<unknown, unknown>
@@ -819,7 +838,7 @@ export class QueryStore<
     journalEvents,
   }: {
     queryId: string
-    result: QueryResponse<unknown, TMeta | undefined>
+    result: StoreResponse<TMeta>
     journalEvents: readonly ProcessedRealtimeEvent[]
   }): void {
     let shouldRefetch = false
@@ -861,6 +880,7 @@ export class QueryStore<
         isCompleteSet && !findConfig.server ? new Map(service.entities) : null
 
       const meta = (result as { meta?: TMeta }).meta
+      const pageInfo = 'pageInfo' in result ? result.pageInfo : undefined
       const rebasedResponse = rebaseResponseData({
         data,
         preserveSnapshot: query.config.realtime === 'disabled',
@@ -924,6 +944,7 @@ export class QueryStore<
           status: 'success' as const,
           data: rebasedResponse.data,
           meta: meta || this.#adapter.emptyMeta(),
+          ...(pageInfo ? { pageInfo } : {}),
           isFetching: false,
           error: null,
         },

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -14,6 +14,7 @@ import { FetchEventJournal, planFetchRebase, rebaseResponseData } from './fetchR
 import {
   addQueryToItemIndex,
   applyEventsToService,
+  applyVisibleEventToQuery,
   createServiceState,
   diffCompleteSet,
   groupQueuedEvents,
@@ -144,6 +145,7 @@ export class QueryStore<
   #retryDelay: RetryDelay
   #reconnectJitter: readonly [number, number]
   #reconnectSweepTimer: ReturnType<typeof setTimeout> | null = null
+  #reconnectQueryIds: Set<string> = new Set()
   #warnedMissingIdServices: Set<string> = new Set()
 
   #eventQueue: QueuedEvent[] = []
@@ -380,6 +382,35 @@ export class QueryStore<
         })
       })
     }
+  }
+
+  /** Route an event-driven refetch through cooldown and visibility handling. @internal */
+  reconcile(queryId: string): void {
+    this.#requestReconcile(queryId)
+  }
+
+  /** Replace/remove a row already visible in one query without changing membership. @internal */
+  applyVisibleEvent(queryId: string, event: ProcessedRealtimeEvent): void {
+    const serviceName = this.#serviceNamesByQueryId.get(queryId)
+    if (!serviceName) return
+    const getId = this.#getIdReader(serviceName)
+    const touched = this.#transactOverServiceByName(serviceName, (service, touch) => {
+      applyVisibleEventToQuery({
+        service,
+        queryId,
+        event,
+        touch,
+        getId,
+        itemRemoved: meta => this.#adapter.itemRemoved(meta),
+      })
+    })
+    this.#notify(touched)
+  }
+
+  /** Keep a composite query's sentinel in the reconnect sweep while events are controller-owned. */
+  registerReconnectQuery(queryId: string): () => void {
+    this.#reconnectQueryIds.add(queryId)
+    return () => this.#reconnectQueryIds.delete(queryId)
   }
 
   /** Perform a service mutation and update the store from the result. */
@@ -1413,7 +1444,7 @@ export class QueryStore<
         if (query.queryId === service.materialized?.queryId) continue
         if (
           !query.config.skip &&
-          query.config.realtime !== 'disabled' &&
+          (query.config.realtime !== 'disabled' || this.#reconnectQueryIds.has(query.queryId)) &&
           this.#listenerCount(query.queryId) > 0
         ) {
           this.#requestReconcile(query.queryId)

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -63,9 +63,7 @@ export type ReconnectJitter = number | readonly [number, number]
 export type RetryDelay = number | ((attempt: number, error: Error) => number)
 
 type FetchAttemptOutcome =
-  | { kind: 'completed' }
-  | { kind: 'stale' }
-  | { kind: 'failed'; error: Error }
+  { kind: 'completed' } | { kind: 'stale' } | { kind: 'failed'; error: Error }
 
 const DEFAULT_RETRIES = 3
 const MAX_RETRY_DELAY = 30_000

--- a/lib/core/queryTypes.ts
+++ b/lib/core/queryTypes.ts
@@ -1,5 +1,6 @@
 import type { AnySchema, Schema, ServiceItem, ServiceNames } from './schema.js'
 import type { StoredQueryClass } from './queryClassification.js'
+import type { PageInfo, PageRequest } from '../adapters/adapter.js'
 
 /**
  * Event types supported by Figbird
@@ -68,6 +69,7 @@ export type QueryState<T, TMeta = Record<string, unknown>> =
       status: 'loading'
       data: null
       meta: TMeta
+      pageInfo?: PageInfo
       isFetching: boolean
       error: null
     }
@@ -75,6 +77,7 @@ export type QueryState<T, TMeta = Record<string, unknown>> =
       status: 'success'
       data: T
       meta: TMeta
+      pageInfo?: PageInfo
       isFetching: boolean
       error: null
     }
@@ -82,6 +85,7 @@ export type QueryState<T, TMeta = Record<string, unknown>> =
       status: 'error'
       data: null
       meta: TMeta
+      pageInfo?: PageInfo
       isFetching: boolean
       error: Error
     }
@@ -140,6 +144,8 @@ export interface FindDescriptor {
   serviceName: string
   method: 'find'
   params?: unknown
+  /** Internal adapter-managed page request. Kept outside params.query deliberately. */
+  page?: PageRequest
 }
 
 /**

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -7,9 +7,16 @@ import type {
   ProcessedRealtimeEvent,
   QueryConfig,
   QueryDescriptor,
-  QueryState,
   ServiceState,
 } from './queryTypes.js'
+import {
+  PagedQueryRoot,
+  SingleQueryRoot,
+  subscribeAndSeed,
+  type PaginatedRootSource,
+  type RelationalPaginationState,
+  type RootSource,
+} from './queryRoots.js'
 import {
   assembleRelations,
   getFieldValueAsList,
@@ -29,10 +36,11 @@ import {
 import type { AnySchema, RelationshipDef, Schema } from './schema.js'
 import { resolveServicePath } from './schema.js'
 
+export type { RelationalPaginationState } from './queryRoots.js'
+
 // This module is organised top-down: the consumer-facing RelationalQueryRef first,
-// followed by its internal machinery — root sources (single query vs page
-// accumulator behind one snapshot contract). The pure assembly pass lives in
-// relationalAssembly.ts.
+// followed by its relation-subscription machinery. Root query execution lives in
+// queryRoots.ts and the pure assembly pass lives in relationalAssembly.ts.
 
 // Above this many parents, a windowed relation's per-parent queries are almost
 // certainly the wrong shape (N requests for one screen) — warn and point at embed.
@@ -50,6 +58,7 @@ export interface RelationalQueryHost<TMeta extends Record<string, unknown>, TQue
       options?: unknown,
       context?: MatcherContext,
     ): (item: unknown) => boolean
+    pageSource?(serviceName: string): { dependency: 'sequential' } | undefined
   }
   queryStore: {
     subscribeToProcessedEvents(fn: (event: ProcessedRealtimeEvent) => void): () => void
@@ -175,7 +184,7 @@ export class RelationalQueryRef<
   // `.paginate()` builders. `#pagedRoot` aliases the same object when paginated so
   // pagination-specific calls (loadMore, pagination block) don't need casts.
   #root: RootSource | null = null
-  #pagedRoot: PagedQueryRoot<S, TParams, TMeta, TQuery> | null = null
+  #pagedRoot: PaginatedRootSource | null = null
 
   // Per-relation state, keyed by dotted relation path (e.g. "comments" or
   // "comments.reactions"). A relation is "synced" once its entry exists here — even a
@@ -674,26 +683,44 @@ export class RelationalQueryRef<
 
     if (this.#ast.kind === 'paginate') {
       const pageSize = this.#ast.pageSize!
+      const sequential = this.#host.adapter.pageSource?.(serviceName)?.dependency === 'sequential'
       this.#pagedRoot = new PagedQueryRoot({
         pageSize,
         returnTotal: Boolean(this.#ast.returnTotal),
+        sequential,
         staleTime: this.#staleTime,
-        makePageRef: pageIndex =>
+        makePageRef: (pageIndex, after) =>
           this.#query(
-            {
-              serviceName,
-              method: 'find',
-              params: {
-                query: {
-                  ...this.#ast.query,
-                  $limit: pageSize,
-                  $skip: pageIndex * pageSize,
+            sequential
+              ? {
+                  serviceName,
+                  method: 'find',
+                  params: { query: this.#ast.query },
+                  page: {
+                    limit: pageSize,
+                    ...(after !== undefined ? { after } : {}),
+                    returnTotal: Boolean(this.#ast.returnTotal) && pageIndex === 0,
+                  },
+                }
+              : {
+                  serviceName,
+                  method: 'find',
+                  params: {
+                    query: {
+                      ...this.#ast.query,
+                      $limit: pageSize,
+                      $skip: pageIndex * pageSize,
+                    },
+                  },
                 },
-              },
-            },
             {
-              realtime: this.#realtimeMode,
+              realtime: sequential
+                ? !this.#ast.snapshot && pageIndex === 0
+                  ? 'refetch'
+                  : 'disabled'
+                : this.#realtimeMode,
               fetchPolicy: 'swr',
+              ...(sequential ? { server: true } : {}),
               ...matcherConfig,
             },
           ),
@@ -1314,432 +1341,4 @@ export function suspensePromiseAll(
     })
   })
   return aggregate
-}
-
-// ---------------------------------------------------------------------------
-// Root sources
-// ---------------------------------------------------------------------------
-
-/**
- * Root sources for relational queries. A relational query's root data comes from one
- * of two shapes — a single find/get query, or an accumulating sequence of pages — and
- * everything downstream (relation sync, gathering, assembly) only cares about "the
- * current root rows". `RootSource` is that seam: the RelationalQueryRef consumes one
- * unified snapshot contract, and the paginate-specific machinery (loadMore, hasMore,
- * page accumulation) lives entirely inside `PagedQueryRoot`.
- */
-
-interface RootSnapshot {
-  phase: 'loading' | 'error' | 'ready'
-  /** Valid when phase is 'ready'. Identity is stable while the underlying data is. */
-  rows: unknown[]
-  isFetching: boolean
-  error: Error | null
-}
-
-interface RootSource {
-  snapshot(): RootSnapshot
-  setStaleTime(staleTime: number): void
-  ensureFresh(staleTime?: number): void
-  refetch(): void
-  teardown(): void
-  queryIds(): string[]
-}
-
-/**
- * Pagination metadata exposed by paginated queries. Present on the relational
- * snapshot only when the underlying builder used `.paginate(...)`.
- */
-export interface RelationalPaginationState {
-  /**
-   * Whether more pages are likely to exist. Sticky during a `loadMore()` so the UI
-   * doesn't flicker between "more available" / "loading" / "more available".
-   */
-  hasMore: boolean
-  /** A `loadMore()` is in-flight. */
-  isLoadingMore: boolean
-  /** The most recent `loadMore()` failed. Cleared on the next attempt. */
-  loadMoreError: Error | null
-  /** Total row count from the first page's meta, if `returnTotal: true` was set. */
-  totalCount: number | undefined
-}
-
-const EMPTY_ROWS: unknown[] = []
-const LOADING_ROOT: RootSnapshot = {
-  phase: 'loading',
-  rows: EMPTY_ROWS,
-  isFetching: true,
-  error: null,
-}
-
-/**
- * Subscribe to a store query and seed from its current state. Store listeners fire
- * only on state *changes* — a query that is already warm in the QueryStore (resolved
- * earlier by another consumer) never invokes the callback, so without the seed a warm
- * read would report "loading" until the SWR refetch finished.
- */
-function subscribeAndSeed<S extends Schema, TParams, TMeta extends Record<string, unknown>, TQuery>(
-  queryRef: QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>,
-  onSuccess: (data: unknown[]) => void,
-  onChange: () => void,
-  staleTime = 0,
-): () => void {
-  const unsub = queryRef.subscribe(
-    state => {
-      if (state.status === 'success') onSuccess(state.data as unknown[])
-      onChange()
-    },
-    { staleTime },
-  )
-  const initial = queryRef.getSnapshot()
-  if (initial?.status === 'success') onSuccess(initial.data as unknown[])
-  return unsub
-}
-
-/**
- * Root backed by a single find or get query. For get roots the single item is
- * normalized to a one-element array with a cached identity — downstream change
- * detection compares row array refs, so the wrapper must be stable across reads.
- */
-class SingleQueryRoot<
-  S extends Schema = AnySchema,
-  TParams = unknown,
-  TMeta extends Record<string, unknown> = Record<string, unknown>,
-  TQuery = Record<string, unknown>,
-> implements RootSource {
-  #queryRef: QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>
-  #unsub: () => void
-  #isGet: boolean
-  #lastGetData: unknown = undefined
-  #lastGetDataAsArray: unknown[] = []
-
-  constructor({
-    queryRef,
-    isGet,
-    onRows,
-    onChange,
-    staleTime = 0,
-  }: {
-    queryRef: QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>
-    isGet: boolean
-    onRows: (rows: unknown[]) => void
-    onChange: () => void
-    staleTime?: number
-  }) {
-    this.#queryRef = queryRef
-    this.#isGet = isGet
-    this.#unsub = subscribeAndSeed(
-      queryRef,
-      data => onRows(this.#asRows(data)),
-      onChange,
-      staleTime,
-    )
-  }
-
-  #asRows(data: unknown): unknown[] {
-    if (!this.#isGet) return data as unknown[]
-    if (data === this.#lastGetData) return this.#lastGetDataAsArray
-    this.#lastGetData = data
-    this.#lastGetDataAsArray = data == null ? [] : [data]
-    return this.#lastGetDataAsArray
-  }
-
-  snapshot(): RootSnapshot {
-    const s = this.#queryRef.getSnapshot()
-    if (!s || s.status === 'loading') return LOADING_ROOT
-    if (s.status === 'error') {
-      return { phase: 'error', rows: EMPTY_ROWS, isFetching: false, error: s.error }
-    }
-    return { phase: 'ready', rows: this.#asRows(s.data), isFetching: s.isFetching, error: null }
-  }
-
-  ensureFresh(staleTime?: number): void {
-    this.#queryRef.ensureFresh({ staleTime })
-  }
-
-  setStaleTime(_staleTime: number): void {}
-
-  refetch(): void {
-    this.#queryRef.refetch()
-  }
-
-  teardown(): void {
-    this.#unsub()
-  }
-
-  queryIds(): string[] {
-    return [this.#queryRef.details().queryId]
-  }
-}
-
-/**
- * Root backed by an accumulating sequence of page queries. Each loaded page is its
- * own `find` query in the QueryStore with its own `$skip + $limit` window; together
- * they form the accumulated rows. Refetching/realtime is per-page.
- */
-class PagedQueryRoot<
-  S extends Schema = AnySchema,
-  TParams = unknown,
-  TMeta extends Record<string, unknown> = Record<string, unknown>,
-  TQuery = Record<string, unknown>,
-> implements RootSource {
-  #makePageRef: (pageIndex: number) => QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>
-  #onRows: (rows: unknown[]) => void
-  #onChange: () => void
-  #pageSize: number
-  #returnTotal: boolean
-
-  #pageRefs: Array<QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>> = []
-  #pageUnsubs: Array<() => void> = []
-  #staleTime = 0
-  #isLoadingMore = false
-  #loadMoreError: Error | null = null
-  // Sticky `hasMore`: only flips to false when we've observed a partial page. Stays true
-  // while `loadMore()` is in flight so the UI's "Load more" button doesn't flicker.
-  #hasMoreSticky = true
-  // Cache of per-page data refs and the concatenated array — identity is stable for
-  // useSyncExternalStore. Recomputed only when at least one page's data ref changes.
-  #lastPageDataRefs: unknown[] = []
-  #lastAllPagesData: unknown[] = []
-  // Memoized pagination object — stable identity is required by useSyncExternalStore.
-  #lastPagination: RelationalPaginationState | null = null
-
-  constructor({
-    pageSize,
-    returnTotal,
-    makePageRef,
-    onRows,
-    onChange,
-    staleTime = 0,
-  }: {
-    pageSize: number
-    returnTotal: boolean
-    makePageRef: (pageIndex: number) => QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>
-    onRows: (rows: unknown[]) => void
-    onChange: () => void
-    staleTime?: number
-  }) {
-    this.#pageSize = pageSize
-    this.#returnTotal = returnTotal
-    this.#makePageRef = makePageRef
-    this.#onRows = onRows
-    this.#onChange = onChange
-    this.#staleTime = staleTime
-    this.#setupPage(0)
-  }
-
-  /**
-   * Subscribe a page query. Each page has exactly one subscription, which also
-   * owns the pagination flags: `settle` is the one-shot hook a `loadMore()` page
-   * carries, consumed on the page's first success (clear `isLoadingMore`) or
-   * first error (report and drop the page); after that the page behaves like any
-   * other. Single ownership is what keeps `hasMore` from flickering as pages
-   * resolve in unexpected orders.
-   */
-  #setupPage(pageIndex: number, settle?: { onError: (error: Error) => void }): void {
-    const queryRef = this.#makePageRef(pageIndex)
-    this.#pageRefs.push(queryRef)
-    let pendingSettle = settle
-    const onState = (state: ReturnType<(typeof queryRef)['getSnapshot']>): void => {
-      if (state?.status === 'success') {
-        const pageData = (state.data ?? []) as unknown[]
-        // A page that returned fewer rows than requested is the last page. The page
-        // settling a `loadMore()` owns the flag for that load; unrelated page
-        // refetches leave it alone while a load is in flight.
-        if (pendingSettle) {
-          pendingSettle = undefined
-          this.#isLoadingMore = false
-          this.#loadMoreError = null
-          this.#hasMoreSticky = pageData.length >= this.#pageSize
-        } else if (!this.#isLoadingMore) {
-          this.#hasMoreSticky = pageData.length >= this.#pageSize
-        }
-        this.#onRows(this.#allPagesData())
-      } else if (state?.status === 'error' && pendingSettle) {
-        const s = pendingSettle
-        pendingSettle = undefined
-        s.onError(state.error)
-      }
-    }
-    const unsub = queryRef.subscribe(
-      state => {
-        onState(state)
-        this.#onChange()
-      },
-      { staleTime: this.#staleTime },
-    )
-    this.#pageUnsubs.push(unsub)
-    // Seed from a warm snapshot (mirrors subscribeAndSeed) — after the unsub is
-    // registered, so a settle-on-error can pop this page's subscription.
-    onState(queryRef.getSnapshot())
-  }
-
-  /**
-   * Append the next page to the accumulator. No-op when a load is already in flight,
-   * when the previous page indicated no more rows, or when the first page hasn't
-   * resolved yet.
-   */
-  loadMore(): void {
-    if (this.#isLoadingMore) return
-    if (!this.#hasMoreSticky) return
-    if (this.#pageRefs.length === 0) return
-
-    // Need the first page to have succeeded before we know whether to add more. Without
-    // this guard, a fast double-click during the initial load would queue a useless page 1.
-    const firstPageState = this.#pageRefs[0]?.getSnapshot()
-    if (!firstPageState || firstPageState.status !== 'success') return
-
-    this.#isLoadingMore = true
-    this.#loadMoreError = null
-    this.#setupPage(this.#pageRefs.length, {
-      onError: error => {
-        this.#isLoadingMore = false
-        this.#loadMoreError = error
-        // Keep hasMore truthy so the UI can offer a retry via loadMore again. Drop the
-        // failed page so a future loadMore retries the same skip rather than skipping past.
-        this.#hasMoreSticky = true
-        this.#pageRefs.pop()
-        const popped = this.#pageUnsubs.pop()
-        popped?.()
-      },
-    })
-    // The new page's subscription notifies when it settles. Notify now so the UI
-    // flips to "loading more" synchronously.
-    this.#onChange()
-  }
-
-  snapshot(): RootSnapshot {
-    if (this.#pageRefs.length === 0) return LOADING_ROOT
-
-    const pageStates: QueryState<unknown, TMeta>[] = []
-    for (const ref of this.#pageRefs) {
-      const s = ref.getSnapshot()
-      if (!s) return LOADING_ROOT
-      pageStates.push(s)
-    }
-    // Surface the first page error.
-    for (const s of pageStates) {
-      if (s.status === 'error') {
-        return { phase: 'error', rows: EMPTY_ROWS, isFetching: false, error: s.error }
-      }
-    }
-    // The first page must have succeeded once before we present data. Follow-up pages
-    // may still be loading: the accumulated rows cover what's been read so far, and
-    // `isLoadingMore` signals the in-flight load.
-    if (pageStates[0]!.status === 'loading') return LOADING_ROOT
-
-    return {
-      phase: 'ready',
-      rows: this.#allPagesData(),
-      isFetching: pageStates.some(s => s.isFetching),
-      error: null,
-    }
-  }
-
-  ensureFresh(staleTime?: number): void {
-    for (const ref of this.#pageRefs) {
-      ref.ensureFresh({ staleTime })
-    }
-  }
-
-  setStaleTime(staleTime: number): void {
-    this.#staleTime = staleTime
-  }
-
-  /** Memoized pagination block for the relational snapshot. */
-  pagination(): RelationalPaginationState {
-    const hasMore = this.#hasMoreSticky
-    const isLoadingMore = this.#isLoadingMore
-    const loadMoreError = this.#loadMoreError
-    const totalCount = this.#computeTotalCount()
-    const prev = this.#lastPagination
-    if (
-      prev &&
-      prev.hasMore === hasMore &&
-      prev.isLoadingMore === isLoadingMore &&
-      prev.loadMoreError === loadMoreError &&
-      prev.totalCount === totalCount
-    ) {
-      return prev
-    }
-    const next: RelationalPaginationState = { hasMore, isLoadingMore, loadMoreError, totalCount }
-    this.#lastPagination = next
-    return next
-  }
-
-  /**
-   * Refetch from page 0. Pages 1+ are dropped — they may now be invalid (the dataset
-   * shifted). Page 0 stays so the existing UI doesn't blank out; the QueryStore
-   * re-fetches it in place.
-   */
-  refetch(): void {
-    for (let i = 1; i < this.#pageUnsubs.length; i++) {
-      this.#pageUnsubs[i]?.()
-    }
-    this.#pageUnsubs.length = 1
-    this.#pageRefs.length = 1
-    this.#hasMoreSticky = true
-    // Dropping pages 1+ also drops any in-flight loadMore page (its subscription —
-    // and with it the pending settle — was just unsubscribed), so the flag must
-    // reset here or loadMore() would be blocked forever.
-    this.#isLoadingMore = false
-    this.#loadMoreError = null
-    this.#pageRefs[0]?.refetch()
-    // Notify so subscribers see the re-evaluated `hasMore`/`isLoadingMore` even if no
-    // store-level transition fired (e.g. nothing actually changed).
-    this.#onChange()
-  }
-
-  teardown(): void {
-    for (const unsub of this.#pageUnsubs) {
-      unsub()
-    }
-    this.#pageUnsubs.length = 0
-    this.#pageRefs.length = 0
-  }
-
-  queryIds(): string[] {
-    return this.#pageRefs.map(ref => ref.details().queryId)
-  }
-
-  /**
-   * Total count from the first page's meta if `returnTotal: true` was set. Returns
-   * `undefined` when the adapter didn't supply a total (e.g. Feathers `total: -1`).
-   */
-  #computeTotalCount(): number | undefined {
-    if (!this.#returnTotal) return undefined
-    const first = this.#pageRefs[0]
-    if (!first) return undefined
-    const s = first.getSnapshot()
-    if (!s || s.status !== 'success') return undefined
-    const meta = s.meta as { total?: number } | undefined
-    if (!meta || typeof meta.total !== 'number' || meta.total < 0) return undefined
-    return meta.total
-  }
-
-  /** Concatenate the data of all loaded pages. Stable identity across calls. */
-  #allPagesData(): unknown[] {
-    const refs: unknown[] = []
-    for (const ref of this.#pageRefs) {
-      const s = ref.getSnapshot()
-      refs.push(s?.status === 'success' && Array.isArray(s.data) ? s.data : null)
-    }
-    let unchanged = refs.length === this.#lastPageDataRefs.length
-    if (unchanged) {
-      for (let i = 0; i < refs.length; i++) {
-        if (refs[i] !== this.#lastPageDataRefs[i]) {
-          unchanged = false
-          break
-        }
-      }
-    }
-    if (unchanged) return this.#lastAllPagesData
-    const all: unknown[] = []
-    for (const ref of refs) {
-      if (Array.isArray(ref)) all.push(...ref)
-    }
-    this.#lastPageDataRefs = refs
-    this.#lastAllPagesData = all
-    return all
-  }
 }

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -1,7 +1,8 @@
 import { hashObject } from './hash.js'
 import type { MatcherContext, PageSource } from '../adapters/adapter.js'
+import { cursorQueryInputsUnchanged } from './cursorMaintenance.js'
 import type { QueryAST } from './queryBuilder.js'
-import { planRelation, rootAllPages } from './queryClassification.js'
+import { planRelation, planRootPagination, rootAllPages } from './queryClassification.js'
 import type { QueryRef } from './queryRef.js'
 import type {
   ProcessedRealtimeEvent,
@@ -683,10 +684,26 @@ export class RelationalQueryRef<
 
     if (this.#ast.kind === 'paginate') {
       const pageSize = this.#ast.pageSize!
-      const sequential = this.#host.adapter.pageSource?.(serviceName) !== undefined
+      const pageSource = this.#host.adapter.pageSource?.(serviceName)
+      const paginationPlan = planRootPagination(pageSource !== undefined, Boolean(this.#ast.server))
+      const sequential = paginationPlan.kind === 'sequential'
+      const cursorRealtime =
+        sequential && pageSource?.cursorStability === 'ordering' && !this.#ast.snapshot
+          ? {
+              subscribe: (fn: (event: ProcessedRealtimeEvent) => void) =>
+                this.#host.queryStore.subscribeToProcessedEvents(event => {
+                  if (event.serviceName === serviceName) fn(event)
+                }),
+              canKeepPrefix: (event: ProcessedRealtimeEvent) =>
+                !this.#ast.server &&
+                (event.type === 'patched' || event.type === 'updated') &&
+                event.previousItem !== null &&
+                cursorQueryInputsUnchanged(this.#ast.query, event.previousItem, event.item),
+            }
+          : undefined
       this.#pagedRoot = new PagedQueryRoot({
         pageSize,
-        returnTotal: Boolean(this.#ast.returnTotal),
+        includeTotal: Boolean(this.#ast.includeTotal),
         sequential,
         staleTime: this.#staleTime,
         makePageRef: (pageIndex, after) =>
@@ -699,7 +716,7 @@ export class RelationalQueryRef<
                   page: {
                     limit: pageSize,
                     ...(after !== undefined ? { after } : {}),
-                    returnTotal: Boolean(this.#ast.returnTotal) && pageIndex === 0,
+                    includeTotal: Boolean(this.#ast.includeTotal) && pageIndex === 0,
                   },
                 }
               : {
@@ -715,17 +732,20 @@ export class RelationalQueryRef<
                 },
             {
               realtime: sequential
-                ? !this.#ast.snapshot && pageIndex === 0
-                  ? 'refetch'
-                  : 'disabled'
+                ? cursorRealtime
+                  ? 'disabled'
+                  : !this.#ast.snapshot && pageIndex === 0
+                    ? 'refetch'
+                    : 'disabled'
                 : this.#realtimeMode,
               fetchPolicy: 'swr',
-              ...(sequential ? { server: true } : {}),
+              ...(paginationPlan.server ? { server: true } : {}),
               ...matcherConfig,
             },
           ),
         onRows,
         onChange,
+        ...(cursorRealtime ? { cursorRealtime } : {}),
       })
       this.#root = this.#pagedRoot
       return

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -1,6 +1,6 @@
 import { hashObject } from './hash.js'
 import type { MatcherContext, PageSource } from '../adapters/adapter.js'
-import { cursorQueryInputsUnchanged } from './cursorMaintenance.js'
+import { cursorQueryCanKeepPrefix, cursorQueryInputsUnchanged } from './cursorMaintenance.js'
 import type { QueryAST } from './queryBuilder.js'
 import { planRelation, planRootPagination, rootAllPages } from './queryClassification.js'
 import type { QueryRef } from './queryRef.js'
@@ -15,6 +15,7 @@ import {
   SingleQueryRoot,
   subscribeAndSeed,
   type PaginatedRootSource,
+  type InspectedPagination,
   type RelationalPaginationState,
   type RootSource,
 } from './queryRoots.js'
@@ -158,6 +159,7 @@ export interface InspectedRelationalQuery {
   name?: string
   service: string
   ast: QueryAST
+  pagination?: InspectedPagination
   nodes: Array<{
     path: string
     role?: 'junction'
@@ -296,6 +298,7 @@ export class RelationalQueryRef<
       ...(this.#name ? { name: this.#name } : {}),
       service: this.#ast.service,
       ast: this.#ast,
+      ...(this.#pagedRoot ? { pagination: this.#pagedRoot.inspectPagination() } : {}),
       nodes,
     }
   }
@@ -688,7 +691,11 @@ export class RelationalQueryRef<
       const paginationPlan = planRootPagination(pageSource !== undefined, Boolean(this.#ast.server))
       const sequential = paginationPlan.kind === 'sequential'
       const cursorRealtime =
-        sequential && pageSource?.cursorStability === 'ordering' && !this.#ast.snapshot
+        sequential &&
+        pageSource?.cursorStability === 'ordering' &&
+        !this.#ast.server &&
+        !this.#ast.snapshot &&
+        cursorQueryCanKeepPrefix(this.#ast.query)
           ? {
               subscribe: (fn: (event: ProcessedRealtimeEvent) => void) =>
                 this.#host.queryStore.subscribeToProcessedEvents(event => {
@@ -705,6 +712,13 @@ export class RelationalQueryRef<
         pageSize,
         includeTotal: Boolean(this.#ast.includeTotal),
         sequential,
+        realtime: this.#ast.snapshot
+          ? 'manual'
+          : sequential && !cursorRealtime
+            ? 'reconcile'
+            : this.#ast.server
+              ? 'reconcile'
+              : 'merge-or-reconcile',
         staleTime: this.#staleTime,
         makePageRef: (pageIndex, after) =>
           this.#query(

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -1,5 +1,5 @@
 import { hashObject } from './hash.js'
-import type { MatcherContext } from '../adapters/adapter.js'
+import type { MatcherContext, PageSource } from '../adapters/adapter.js'
 import type { QueryAST } from './queryBuilder.js'
 import { planRelation, rootAllPages } from './queryClassification.js'
 import type { QueryRef } from './queryRef.js'
@@ -51,14 +51,14 @@ const WINDOWED_RELATION_FANOUT_WARN_THRESHOLD = 10
  * this structural (rather than importing the Figbird class) avoids a circular
  * dependency and states exactly what the engine relies on.
  */
-export interface RelationalQueryHost<TMeta extends Record<string, unknown>, TQuery> {
+export interface RelationalQueryHost<TParams, TMeta extends Record<string, unknown>, TQuery> {
   adapter: {
     matcher(
       query: TQuery | undefined,
       options?: unknown,
       context?: MatcherContext,
     ): (item: unknown) => boolean
-    pageSource?(serviceName: string): { dependency: 'sequential' } | undefined
+    pageSource?(serviceName: string): PageSource<TParams, TMeta> | undefined
   }
   queryStore: {
     subscribeToProcessedEvents(fn: (event: ProcessedRealtimeEvent) => void): () => void
@@ -175,7 +175,7 @@ export class RelationalQueryRef<
   TMeta extends Record<string, unknown> = Record<string, unknown>,
   TQuery = Record<string, unknown>,
 > {
-  #host: RelationalQueryHost<TMeta, TQuery>
+  #host: RelationalQueryHost<TParams, TMeta, TQuery>
   #ast: QueryAST
   #schema: S
   #queryId: string
@@ -236,7 +236,7 @@ export class RelationalQueryRef<
   #name: string | undefined
 
   constructor(
-    host: RelationalQueryHost<TMeta, TQuery>,
+    host: RelationalQueryHost<TParams, TMeta, TQuery>,
     ast: QueryAST,
     schema: S,
     onEvict?: () => void,
@@ -683,7 +683,7 @@ export class RelationalQueryRef<
 
     if (this.#ast.kind === 'paginate') {
       const pageSize = this.#ast.pageSize!
-      const sequential = this.#host.adapter.pageSource?.(serviceName)?.dependency === 'sequential'
+      const sequential = this.#host.adapter.pageSource?.(serviceName) !== undefined
       this.#pagedRoot = new PagedQueryRoot({
         pageSize,
         returnTotal: Boolean(this.#ast.returnTotal),

--- a/lib/core/windowMaintenance.ts
+++ b/lib/core/windowMaintenance.ts
@@ -320,6 +320,41 @@ function applyVisibleEventEffect<TMeta>(
   return true
 }
 
+/**
+ * Apply only the value-level effect of an already-processed event to one query.
+ * Cursor-prefix maintenance uses this after separately proving whether page
+ * membership and ordering are unchanged.
+ */
+export function applyVisibleEventToQuery<TMeta>({
+  service,
+  queryId,
+  event,
+  touch,
+  getId,
+  itemRemoved,
+}: {
+  service: ServiceState<TMeta>
+  queryId: string
+  event: ProcessedRealtimeEvent
+  touch: (queryId: string) => void
+  getId: (item: unknown) => ItemId | undefined
+  itemRemoved: (meta: TMeta) => TMeta
+}): boolean {
+  return applyVisibleEventEffect(
+    {
+      service,
+      touch,
+      getId,
+      itemAdded: meta => meta,
+      itemRemoved,
+      defaultSort: undefined,
+    },
+    queryId,
+    event,
+    event.type === 'removed' ? 'remove' : 'replace',
+  )
+}
+
 function applyMergeEventToQuery<TMeta>(
   context: QueryEventContext<TMeta>,
   queryId: string,

--- a/lib/devtools/QueriesTab.tsx
+++ b/lib/devtools/QueriesTab.tsx
@@ -27,7 +27,7 @@ const QUERY_COLUMNS = [
     label: 'class',
     width: '12%',
     description:
-      'How Figbird maintains the result.\nlocal-exact: membership and ordering are provable locally.\nserver-window: a limited or sorted server result; uncertain changes trigger a refetch.\nserver-authoritative: the server decides membership; realtime changes trigger a refetch.\nget: a direct lookup by ID.',
+      'How Figbird maintains the result.\nlocal-exact: membership and ordering are provable locally.\nserver-window: a limited or sorted server result; uncertain changes trigger a refetch.\nserver-authoritative: the server decides membership; cursor queries may still merge updates proven not to move page boundaries.\nget: a direct lookup by ID.',
   },
   {
     label: 'rows',

--- a/lib/devtools/QueryDetails.tsx
+++ b/lib/devtools/QueryDetails.tsx
@@ -8,7 +8,12 @@ import {
 } from 'react'
 import type { QueryRecord } from './collector.js'
 import { compactJson, formatMs, prettyJson } from './format.js'
-import type { DevtoolsOperation, QuerySummary, UnderlyingFetch } from './model.js'
+import type {
+  DevtoolsOperation,
+  OperationPagination,
+  QuerySummary,
+  UnderlyingFetch,
+} from './model.js'
 import { ClassBadge, plural, queryStatus, QueryStatusDot } from './QueryPresentation.js'
 import { Badge, DetailsPane, useDevtoolsTheme, type DevtoolsColors } from './ui.js'
 
@@ -177,6 +182,9 @@ export function QueryDetails({
           <Sparkline spans={activeQuery.spans} />
         </QueryDetailSection>
       ) : null}
+      {!selectedUnderlying && operation.pagination ? (
+        <PaginationDetails pagination={operation.pagination} pages={rootFetches} />
+      ) : null}
       {!selectedUnderlying || directChildren.length > 0 ? (
         <QueryDetailSection
           label={selectedUnderlying ? 'Related queries' : 'Query plan'}
@@ -274,6 +282,81 @@ export function QueryDetails({
         </pre>
       </details>
     </DetailsPane>
+  )
+}
+
+function PaginationDetails({
+  pagination,
+  pages,
+}: {
+  pagination: OperationPagination
+  pages: QueryRecord[]
+}) {
+  const { colors, styles } = useDevtoolsTheme()
+  const state = [
+    pagination.realtime === 'manual'
+      ? 'manual realtime'
+      : pagination.realtime === 'reconcile'
+        ? 'reconciles on events'
+        : 'merges stable updates',
+    pagination.hasMore ? 'has more' : 'complete',
+    pagination.isLoadingMore ? 'loading next page' : '',
+    pagination.total !== undefined ? `${pagination.total} total` : '',
+  ]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <QueryDetailSection
+      label={pagination.strategy === 'cursor' ? 'Cursor page chain' : 'Pages'}
+      meta={`${pagination.loadedPages} loaded · size ${pagination.pageSize} · ${state}`}
+    >
+      <div style={{ borderTop: `1px solid ${colors.rowBorder}` }}>
+        {pages.map((page, index) => {
+          const request = page.page?.request
+          const info = page.page?.info
+          const position =
+            pagination.strategy === 'cursor'
+              ? `after ${request?.after === undefined ? 'start' : compactJson(request.after)}`
+              : `offset ${String(page.query?.$skip ?? index * pagination.pageSize)}`
+          const continuation =
+            pagination.strategy === 'cursor' && info
+              ? info.hasMore
+                ? `next ${compactJson(info.endCursor)}`
+                : 'end'
+              : ''
+          return (
+            <div
+              key={page.queryId}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '55px minmax(0, 1fr) auto',
+                gap: 8,
+                alignItems: 'baseline',
+                padding: '7px 0',
+                borderBottom: `1px solid ${colors.rowBorder}`,
+              }}
+            >
+              <strong style={{ fontWeight: 600 }}>Page {index + 1}</strong>
+              <code
+                title={[position, continuation].filter(Boolean).join(' · ')}
+                style={{
+                  ...styles.code,
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  color: colors.muted,
+                }}
+              >
+                {[position, continuation].filter(Boolean).join(' · ')}
+              </code>
+              <span style={{ color: colors.muted }}>{plural(page.itemCount, 'row', 'rows')}</span>
+            </div>
+          )
+        })}
+      </div>
+    </QueryDetailSection>
   )
 }
 

--- a/lib/devtools/QueryPresentation.tsx
+++ b/lib/devtools/QueryPresentation.tsx
@@ -7,7 +7,7 @@ export const QUERY_CLASS_DESCRIPTIONS: Record<string, string> = {
   'server-window':
     'This is a limited or sorted server result. Figbird merges provable changes and refetches when a change could affect the window.',
   'server-authoritative':
-    'The server decides which records belong in this result. Realtime changes trigger a server refetch.',
+    'The server decides which records belong in this result. Figbird normally refetches after realtime changes; a cursor query may merge a row update when it proves that page boundaries stay valid.',
   get: 'A direct record lookup by ID.',
 }
 

--- a/lib/devtools/model.ts
+++ b/lib/devtools/model.ts
@@ -1,4 +1,5 @@
 import type { QueryAST } from '../core/queryBuilder.js'
+import type { InspectedRelationalQuery } from '../core/relationalQuery.js'
 import type { DevtoolsSnapshot, QueryRecord } from './collector.js'
 import { compactJson } from './format.js'
 
@@ -8,7 +9,9 @@ export interface UnderlyingFetch {
   query: QueryRecord
 }
 
-export type QuerySummary = Omit<QueryRecord, 'generation' | 'queryId'>
+export type QuerySummary = Omit<QueryRecord, 'generation' | 'page' | 'queryId'>
+
+export type OperationPagination = NonNullable<InspectedRelationalQuery['pagination']>
 
 export interface QueryComposition {
   detail: string
@@ -30,6 +33,7 @@ export interface DevtoolsOperation {
   rootFetches: QueryRecord[]
   underlying: UnderlyingFetch[]
   composition?: QueryComposition
+  pagination?: OperationPagination
 }
 
 export interface DevtoolsModel {
@@ -88,7 +92,8 @@ export function buildDevtoolsModel(snapshot: DevtoolsSnapshot): DevtoolsModel {
       summary: summarizeRootFetches(rootFetches),
       rootFetches,
       underlying: [...underlyingByPath.values()],
-      composition: describeComposition(group.ast, group.name),
+      composition: describeComposition(group.ast, group.name, group.pagination),
+      ...(group.pagination ? { pagination: group.pagination } : {}),
     })
   }
 
@@ -150,6 +155,7 @@ function summarizeRootFetches(roots: QueryRecord[]): QuerySummary {
 
 function querySummary({
   generation: _generation,
+  page: _page,
   queryId: _queryId,
   ...summary
 }: QueryRecord): QuerySummary {
@@ -179,12 +185,17 @@ function addScope(
   scopes.set(queryId, current)
 }
 
-function describeComposition(ast: QueryAST, name?: string): QueryComposition {
+function describeComposition(
+  ast: QueryAST,
+  name?: string,
+  pagination?: OperationPagination,
+): QueryComposition {
   const head = formatAstHead(ast)
   const rootQuery = compactAstQuery(ast.query)
   const related = relationPaths(ast)
   const parts = [
     head,
+    pagination ? describePagination(pagination) : '',
     rootQuery,
     related.length > 0 ? `with ${formatList(related)}` : '',
     ast.server ? 'server' : '',
@@ -193,11 +204,19 @@ function describeComposition(ast: QueryAST, name?: string): QueryComposition {
   return {
     detail: parts.join(' · '),
     operation: `${ast.service}.${head}`,
-    planDetail: [rootQuery || 'all', related.length > 0 ? `with ${formatList(related)}` : '']
+    planDetail: [
+      pagination ? describePagination(pagination) : '',
+      rootQuery || 'all',
+      related.length > 0 ? `with ${formatList(related)}` : '',
+    ]
       .filter(Boolean)
       .join(' · '),
     title: [name, astToTitle(ast)].filter(Boolean).join('\n'),
   }
+}
+
+function describePagination(pagination: OperationPagination): string {
+  return `${pagination.strategy} · ${pagination.loadedPages} ${pagination.loadedPages === 1 ? 'page' : 'pages'}`
 }
 
 function astToTitle(ast: QueryAST, path = '(root)'): string {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -87,6 +87,7 @@ export type {
   AdapterQuery,
   EventHandlers,
   MatcherContext,
+  PageCursor,
   PageInfo,
   PageRequest,
   PageResponse,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -68,7 +68,7 @@ export { RelationalQueryRef } from './core/figbird.js'
 export type { RelationalQueryState } from './core/figbird.js'
 
 // adapters
-export { cursorPagination, FeathersAdapter } from './adapters/feathers.js'
+export { cursorPagination, FeathersAdapter, offsetPagination } from './adapters/feathers.js'
 export type {
   CursorPaginationOptions,
   CustomOperator,
@@ -76,6 +76,8 @@ export type {
   CustomOperatorRegistration,
   FeathersAdapterOptions,
   FeathersCursorPagination,
+  FeathersOffsetPagination,
+  FeathersPagination,
 } from './adapters/feathers.js'
 export { matcher } from './adapters/matcher.js'
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -68,12 +68,14 @@ export { RelationalQueryRef } from './core/figbird.js'
 export type { RelationalQueryState } from './core/figbird.js'
 
 // adapters
-export { FeathersAdapter } from './adapters/feathers.js'
+export { cursorPagination, FeathersAdapter } from './adapters/feathers.js'
 export type {
+  CursorPaginationOptions,
   CustomOperator,
   CustomOperatorContext,
   CustomOperatorRegistration,
   FeathersAdapterOptions,
+  FeathersCursorPagination,
 } from './adapters/feathers.js'
 export { matcher } from './adapters/matcher.js'
 
@@ -85,6 +87,10 @@ export type {
   AdapterQuery,
   EventHandlers,
   MatcherContext,
+  PageInfo,
+  PageRequest,
+  PageResponse,
+  PageSource,
 } from './adapters/adapter.js'
 
 // react hooks

--- a/lib/react/useQuery.ts
+++ b/lib/react/useQuery.ts
@@ -42,7 +42,7 @@ export interface PaginationControls {
   hasMore: boolean
   isLoadingMore: boolean
   loadMoreError: Error | null
-  totalCount: number | undefined
+  total: number | undefined
 }
 
 /**
@@ -134,8 +134,8 @@ const idleState: RelationalQueryState<null> = {
  * ```
  *
  * For paginated builders (`.paginate({ pageSize })`), the result widens to include
- * `loadMore`, `hasMore`, `isLoadingMore`, `loadMoreError`, and (if `returnTotal: true`
- * was set) `totalCount`. The pagination shape is selected by the second type
+ * `loadMore`, `hasMore`, `isLoadingMore`, `loadMoreError`, and (if `includeTotal: true`
+ * was set) `total`. The pagination shape is selected by the second type
  * parameter, which the hook infers from the builder's `TKind`.
  */
 export type SuspenseQueryResult<T, TKind extends 'find' | 'get' | 'paginate' | 'all' = 'find'> = {
@@ -299,7 +299,7 @@ export const idlePagination: RelationalPaginationState = {
   hasMore: false,
   isLoadingMore: false,
   loadMoreError: null,
-  totalCount: undefined,
+  total: undefined,
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,10 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
   "dependencies": {
     "sift": "^17.1.3"
   },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
   "devDependencies": {
     "@swc-node/register": "^1.11.1",
     "@swc/cli": "^0.8.1",

--- a/test/cursor-pagination.test.tsx
+++ b/test/cursor-pagination.test.tsx
@@ -19,6 +19,8 @@ import { dom } from './helpers.js'
 interface Item {
   id: number
   rank: number
+  title?: string
+  virtualStatus?: string
 }
 
 interface ItemService {
@@ -44,11 +46,13 @@ function createCursorApp(
     retry,
     retryDelay,
     cursorMaxPageSize,
+    cursorStability = 'ordering',
   }: {
     visibility?: VisibilitySource
     retry?: number | false
     retryDelay?: number
     cursorMaxPageSize?: number
+    cursorStability?: 'ordering' | false
   } = {},
 ) {
   let serverRows = rows
@@ -107,6 +111,7 @@ function createCursorApp(
     pagination: {
       items: cursorPagination({
         ...(cursorMaxPageSize !== undefined ? { maxPageSize: cursorMaxPageSize } : {}),
+        ...(cursorStability ? { cursorStability } : {}),
       }),
     },
   })
@@ -186,7 +191,7 @@ test('cursor paginate: chains opaque cursors and trusts hasNextPage on a full fi
 
   function List() {
     const result = useQuery(
-      figbird.q.items.where({ rank: { $gte: 1 } }).paginate({ pageSize: 3, returnTotal: true }),
+      figbird.q.items.where({ rank: { $gte: 1 } }).paginate({ pageSize: 3, includeTotal: true }),
     )
     loadMore = result.loadMore
     return (
@@ -194,7 +199,7 @@ test('cursor paginate: chains opaque cursors and trusts hasNextPage on a full fi
         className='items'
         data-ids={result.data.map(item => item.id).join(',')}
         data-more={String(result.hasMore)}
-        data-total={String(result.totalCount)}
+        data-total={String(result.total)}
       />
     )
   }
@@ -228,6 +233,24 @@ test('cursor paginate: chains opaque cursors and trusts hasNextPage on a full fi
     $after: 'cursor:3',
   })
   unmount()
+})
+
+test('cursor paginate: explain reports adapter-native pagination as server-authoritative', t => {
+  const { figbird } = createCursorApp(makeRows(3))
+
+  t.deepEqual(figbird.explain(figbird.q.items.paginate({ pageSize: 3 })).nodes[0], {
+    path: '(root)',
+    service: 'items',
+    kind: 'paginate',
+    class: 'server-authoritative',
+    reasons: [
+      {
+        code: 'native-pagination',
+        detail: 'adapter-native sequential pagination',
+      },
+    ],
+    realtime: 'refetch',
+  })
 })
 
 test('cursor all: drains every page without requesting a server total', async t => {
@@ -283,7 +306,7 @@ test('cursorPagination: validates and enforces the service maximum', async t => 
   })
   const pageSource = adapter.pageSource('items')
   if (!pageSource) return t.fail('expected items to expose native pagination')
-  await t.throwsAsync(pageSource.find(undefined, { limit: 3, returnTotal: false }), {
+  await t.throwsAsync(pageSource.find(undefined, { limit: 3, includeTotal: false }), {
     message: /accepts at most 2 rows per page, got 3/,
   })
   t.is(calls.length, 0)
@@ -321,6 +344,122 @@ test('cursor paginate: realtime rebuilds the loaded prefix with a fresh cursor c
   t.is($('.items')?.getAttribute('data-ids'), '99,1,2,3,4,5')
   const lastTwoCalls = cursorApp.calls.slice(-2).map(call => call.query.$after)
   t.deepEqual(lastTwoCalls, [null, 'cursor:3'])
+  unmount()
+})
+
+test('cursor paginate: stable visible updates merge locally; ordering changes rebuild', async t => {
+  const { render, unmount, flush, $ } = dom()
+  const initialRows = makeRows(7).map(row => ({ ...row, title: `Item ${row.id}` }))
+  const cursorApp = createCursorApp(initialRows)
+  let loadMore: (() => void) | undefined
+
+  function List() {
+    const result = useQuery(
+      cursorApp.figbird.q.items.orderBy('rank', 'asc').paginate({ pageSize: 3 }),
+    )
+    loadMore = result.loadMore
+    return (
+      <div
+        className='items'
+        data-rows={result.data.map(item => `${item.id}:${item.title}`).join(',')}
+      />
+    )
+  }
+
+  render(
+    <cursorApp.App>
+      <React.Suspense fallback={<div>loading</div>}>
+        <List />
+      </React.Suspense>
+    </cursorApp.App>,
+  )
+  await flush()
+  await flush(() => loadMore?.())
+
+  const callsBeforePatch = cursorApp.calls.length
+  const renamed = { ...initialRows[4]!, title: 'Renamed' }
+  cursorApp.replaceRows(initialRows.map(row => (row.id === renamed.id ? renamed : row)))
+  await flush(() => cursorApp.emit('patched', renamed))
+
+  t.is(cursorApp.calls.length, callsBeforePatch)
+  t.true($('.items')?.getAttribute('data-rows')?.includes('5:Renamed'))
+
+  const reordered = { ...renamed, rank: 0 }
+  cursorApp.replaceRows([reordered, ...initialRows.filter(row => row.id !== reordered.id)])
+  await flush(async () => {
+    cursorApp.emit('patched', reordered)
+    await new Promise(resolve => setTimeout(resolve, 20))
+  })
+
+  t.is(cursorApp.calls.length, callsBeforePatch + 2)
+  t.true($('.items')?.getAttribute('data-rows')?.startsWith('5:Renamed,1:Item 1'))
+  unmount()
+})
+
+test('cursor paginate: without a cursor stability contract, visible updates rebuild', async t => {
+  const { render, unmount, flush } = dom()
+  const initialRows = makeRows(3).map(row => ({ ...row, title: `Item ${row.id}` }))
+  const cursorApp = createCursorApp(initialRows, 3, { cursorStability: false })
+
+  function List() {
+    useQuery(cursorApp.figbird.q.items.orderBy('rank', 'asc').paginate({ pageSize: 3 }))
+    return null
+  }
+
+  render(
+    <cursorApp.App>
+      <React.Suspense fallback={<div>loading</div>}>
+        <List />
+      </React.Suspense>
+    </cursorApp.App>,
+  )
+  await flush()
+
+  const callsBeforePatch = cursorApp.calls.length
+  const renamed = { ...initialRows[1]!, title: 'Renamed' }
+  cursorApp.replaceRows(initialRows.map(row => (row.id === renamed.id ? renamed : row)))
+  await flush(async () => {
+    cursorApp.emit('patched', renamed)
+    await new Promise(resolve => setTimeout(resolve, 20))
+  })
+
+  t.is(cursorApp.calls.length, callsBeforePatch + 1)
+  unmount()
+})
+
+test('cursor paginate: missing server-only inputs make a visible update rebuild', async t => {
+  const { render, unmount, flush } = dom()
+  const initialRows = makeRows(3).map(row => ({ ...row, title: `Item ${row.id}` }))
+  const cursorApp = createCursorApp(initialRows)
+
+  function List() {
+    useQuery(
+      cursorApp.figbird.q.items
+        .where({ virtualStatus: 'visible' })
+        .orderBy('rank', 'asc')
+        .paginate({ pageSize: 3 }),
+    )
+    return null
+  }
+
+  render(
+    <cursorApp.App>
+      <React.Suspense fallback={<div>loading</div>}>
+        <List />
+      </React.Suspense>
+    </cursorApp.App>,
+  )
+  await flush()
+
+  const callsBeforePatch = cursorApp.calls.length
+  const renamed = { ...initialRows[1]!, title: 'Renamed' }
+  cursorApp.replaceRows(initialRows.map(row => (row.id === renamed.id ? renamed : row)))
+  await flush(async () => {
+    cursorApp.emit('patched', renamed)
+    await new Promise(resolve => setTimeout(resolve, 20))
+  })
+
+  t.is(cursorApp.calls.length, callsBeforePatch + 1)
   unmount()
 })
 
@@ -549,7 +688,7 @@ test('cursor pagination: rejects a response that cannot continue safely', async 
   const pageSource = adapter.pageSource('items')
   if (!pageSource) return t.fail('expected items to expose native pagination')
 
-  await t.throwsAsync(pageSource.find(undefined, { limit: 10, returnTotal: false }), {
+  await t.throwsAsync(pageSource.find(undefined, { limit: 10, includeTotal: false }), {
     message: /no endCursor/,
   })
 })

--- a/test/cursor-pagination.test.tsx
+++ b/test/cursor-pagination.test.tsx
@@ -30,16 +30,26 @@ interface CursorCall {
   query: Record<string, unknown>
 }
 
+interface CursorHold {
+  promise: Promise<void>
+  release(): void
+}
+
 function createCursorApp(
   rows: Item[],
   pageSizeWhenFetchingAll = 3,
-  { visibility }: { visibility?: VisibilitySource } = {},
+  {
+    visibility,
+    retry,
+    retryDelay,
+  }: { visibility?: VisibilitySource; retry?: number | false; retryDelay?: number } = {},
 ) {
   let serverRows = rows
   const calls: CursorCall[] = []
   const listeners = new Map<string, Set<(item: unknown) => void>>()
   const reconnectListeners = new Set<() => void>()
   const failingCursors = new Set<string>()
+  const cursorHolds = new Map<string, CursorHold[]>()
   const cursorService = {
     async find(params: FeathersParams = {}) {
       const query = (params.query ?? {}) as Record<string, unknown>
@@ -53,6 +63,8 @@ function createCursorApp(
       const data = serverRows.slice(start, start + limit)
       const end = start + data.length
       const hasNextPage = end < serverRows.length
+      const hold = cursor ? cursorHolds.get(cursor)?.shift() : undefined
+      if (hold) await hold.promise
       return {
         data,
         pageInfo: {
@@ -93,6 +105,8 @@ function createCursorApp(
     reconcileCooldown: 0,
     reconnectJitter: 0,
     ...(visibility ? { visibility } : {}),
+    ...(retry !== undefined ? { retry } : {}),
+    ...(retryDelay !== undefined ? { retryDelay } : {}),
   })
   const Provider = FigbirdProvider<typeof schema, typeof adapter>
 
@@ -110,6 +124,16 @@ function createCursorApp(
     },
     failNextCursor(cursor: string) {
       failingCursors.add(cursor)
+    },
+    holdNextCursor(cursor: string) {
+      let release = () => {}
+      const promise = new Promise<void>(resolve => {
+        release = resolve
+      })
+      const holds = cursorHolds.get(cursor) ?? []
+      holds.push({ promise, release })
+      cursorHolds.set(cursor, holds)
+      return release
     },
     emit(event: string, item: unknown) {
       for (const listener of listeners.get(event) ?? []) listener(item)
@@ -251,6 +275,59 @@ test('cursor paginate: realtime rebuilds the loaded prefix with a fresh cursor c
   unmount()
 })
 
+test('cursor paginate: an old in-flight page never leaks into a rebuilt prefix', async t => {
+  const { render, unmount, flush, $ } = dom()
+  const cursorApp = createCursorApp(makeRows(7))
+  let loadMore: (() => void) | undefined
+
+  function List() {
+    const result = useQuery(cursorApp.figbird.q.items.paginate({ pageSize: 3 }))
+    loadMore = result.loadMore
+    return <div className='items' data-ids={result.data.map(item => item.id).join(',')} />
+  }
+
+  render(
+    <cursorApp.App>
+      <React.Suspense fallback={<div>loading</div>}>
+        <List />
+      </React.Suspense>
+    </cursorApp.App>,
+  )
+  await flush()
+
+  const releaseOldPage = cursorApp.holdNextCursor('cursor:3')
+  await flush(() => loadMore?.())
+  t.is($('.items')?.getAttribute('data-ids'), '1,2,3')
+
+  const inserted = { id: 99, rank: 0 }
+  cursorApp.replaceRows([inserted, ...makeRows(7)])
+  await flush(async () => {
+    cursorApp.emit('created', inserted)
+    await new Promise(resolve => setTimeout(resolve, 20))
+  })
+
+  const releaseFreshPage = cursorApp.holdNextCursor('cursor:3')
+  await flush(async () => {
+    releaseOldPage()
+    await new Promise(resolve => setTimeout(resolve, 20))
+  })
+
+  t.is($('.items')?.getAttribute('data-ids'), '1,2,3')
+  t.is(
+    cursorApp.calls.filter(call => call.query.cursor === 'cursor:3').length,
+    2,
+    'the fresh page request started without publishing the old response',
+  )
+
+  await flush(async () => {
+    releaseFreshPage()
+    await new Promise(resolve => setTimeout(resolve, 20))
+  })
+
+  t.is($('.items')?.getAttribute('data-ids'), '99,1,2,3,4,5')
+  unmount()
+})
+
 test('cursor paginate: reconnect rebuilds every loaded page from page zero', async t => {
   const { render, unmount, flush, $ } = dom()
   const cursorApp = createCursorApp(makeRows(7))
@@ -329,7 +406,7 @@ test('cursor paginate: hidden reconnect waits, then rebuilds on visibility', asy
 
 test('cursor paginate: failed prefix rebuild stays atomic and retries its depth', async t => {
   const { render, unmount, flush, $ } = dom()
-  const cursorApp = createCursorApp(makeRows(7))
+  const cursorApp = createCursorApp(makeRows(7), 3, { retry: false })
   let loadMore: (() => void) | undefined
 
   function List() {
@@ -369,6 +446,43 @@ test('cursor paginate: failed prefix rebuild stays atomic and retries its depth'
   t.deepEqual(
     cursorApp.calls.slice(-2).map(call => call.query.cursor),
     [undefined, 'cursor:3'],
+  )
+  unmount()
+})
+
+test('cursor paginate: automatic fetch retry stays inside the frozen rebuild', async t => {
+  const { render, unmount, flush, $ } = dom()
+  const cursorApp = createCursorApp(makeRows(7), 3, { retry: 1, retryDelay: 0 })
+  let loadMore: (() => void) | undefined
+
+  function List() {
+    const result = useQuery(cursorApp.figbird.q.items.paginate({ pageSize: 3 }))
+    loadMore = result.loadMore
+    return <div className='items' data-ids={result.data.map(item => item.id).join(',')} />
+  }
+
+  render(
+    <cursorApp.App>
+      <React.Suspense fallback={<div>loading</div>}>
+        <List />
+      </React.Suspense>
+    </cursorApp.App>,
+  )
+  await flush()
+  await flush(() => loadMore?.())
+
+  const inserted = { id: 99, rank: 0 }
+  cursorApp.failNextCursor('cursor:3')
+  cursorApp.replaceRows([inserted, ...makeRows(7)])
+  await flush(async () => {
+    cursorApp.emit('created', inserted)
+    await new Promise(resolve => setTimeout(resolve, 20))
+  })
+
+  t.is($('.items')?.getAttribute('data-ids'), '99,1,2,3,4,5')
+  t.deepEqual(
+    cursorApp.calls.slice(-3).map(call => call.query.cursor),
+    [undefined, 'cursor:3', 'cursor:3'],
   )
   unmount()
 })

--- a/test/cursor-pagination.test.tsx
+++ b/test/cursor-pagination.test.tsx
@@ -1,0 +1,392 @@
+import test from 'ava'
+import React, { type ReactNode } from 'react'
+import {
+  createSchema,
+  cursorPagination,
+  FeathersAdapter,
+  Figbird,
+  FigbirdProvider,
+  service,
+  useQuery,
+  type FeathersClient,
+  type FeathersParams,
+  type FeathersService,
+  type VisibilitySource,
+} from '../lib/index.js'
+import { dom } from './helpers.js'
+
+interface Item {
+  id: number
+  rank: number
+}
+
+interface ItemService {
+  item: Item
+}
+
+const schema = createSchema({ services: { items: service<ItemService>() } })
+
+interface CursorCall {
+  query: Record<string, unknown>
+}
+
+function createCursorApp(
+  rows: Item[],
+  pageSizeWhenFetchingAll = 3,
+  { visibility }: { visibility?: VisibilitySource } = {},
+) {
+  let serverRows = rows
+  const calls: CursorCall[] = []
+  const listeners = new Map<string, Set<(item: unknown) => void>>()
+  const reconnectListeners = new Set<() => void>()
+  const failingCursors = new Set<string>()
+  const cursorService = {
+    async find(params: FeathersParams = {}) {
+      const query = (params.query ?? {}) as Record<string, unknown>
+      calls.push({ query })
+      const limit = query.cursorLimit as number
+      const cursor = query.cursor as string | undefined
+      if (cursor && failingCursors.delete(cursor)) {
+        throw new Error(`failed ${cursor}`)
+      }
+      const start = cursor ? Number(cursor.slice('cursor:'.length)) : 0
+      const data = serverRows.slice(start, start + limit)
+      const end = start + data.length
+      const hasNextPage = end < serverRows.length
+      return {
+        data,
+        pageInfo: {
+          hasNextPage,
+          endCursor: hasNextPage ? `cursor:${end}` : null,
+          ...(query.returnTotal ? { total: serverRows.length } : {}),
+        },
+      }
+    },
+    on(event: string, listener: (item: unknown) => void) {
+      const set = listeners.get(event) ?? new Set()
+      set.add(listener)
+      listeners.set(event, set)
+    },
+    off(event: string, listener: (item: unknown) => void) {
+      listeners.get(event)?.delete(listener)
+    },
+  }
+  const feathers: FeathersClient = {
+    service: () => cursorService as unknown as FeathersService,
+    io: {
+      on(event: string, listener: () => void) {
+        if (event === 'reconnect') reconnectListeners.add(listener)
+      },
+      off(event: string, listener: () => void) {
+        if (event === 'reconnect') reconnectListeners.delete(listener)
+      },
+    },
+  }
+  const adapter = new FeathersAdapter(feathers, {
+    defaultPageSizeWhenFetchingAll: pageSizeWhenFetchingAll,
+    pagination: { items: cursorPagination() },
+  })
+  const figbird = new Figbird({
+    schema,
+    adapter,
+    eventBatchInterval: 0,
+    reconcileCooldown: 0,
+    reconnectJitter: 0,
+    ...(visibility ? { visibility } : {}),
+  })
+  const Provider = FigbirdProvider<typeof schema, typeof adapter>
+
+  function App({ children }: { children?: ReactNode }) {
+    return <Provider figbird={figbird}>{children}</Provider>
+  }
+
+  return {
+    App,
+    adapter,
+    calls,
+    figbird,
+    replaceRows(next: Item[]) {
+      serverRows = next
+    },
+    failNextCursor(cursor: string) {
+      failingCursors.add(cursor)
+    },
+    emit(event: string, item: unknown) {
+      for (const listener of listeners.get(event) ?? []) listener(item)
+    },
+    emitReconnect() {
+      for (const listener of reconnectListeners) listener()
+    },
+  }
+}
+
+function fakeVisibility(initiallyHidden: boolean) {
+  let hidden = initiallyHidden
+  const listeners = new Set<() => void>()
+  return {
+    source: {
+      isHidden: () => hidden,
+      onChange(listener: () => void) {
+        listeners.add(listener)
+        return () => listeners.delete(listener)
+      },
+    } satisfies VisibilitySource,
+    set(nextHidden: boolean) {
+      hidden = nextHidden
+      for (const listener of listeners) listener()
+    },
+  }
+}
+
+function makeRows(count: number): Item[] {
+  return Array.from({ length: count }, (_, index) => ({ id: index + 1, rank: index + 1 }))
+}
+
+test('cursor paginate: chains opaque cursors and trusts hasNextPage on a full final page', async t => {
+  const { render, unmount, flush, $ } = dom()
+  const { App, calls, figbird } = createCursorApp(makeRows(6))
+  let loadMore: (() => void) | undefined
+
+  function List() {
+    const result = useQuery(
+      figbird.q.items.where({ rank: { $gte: 1 } }).paginate({ pageSize: 3, returnTotal: true }),
+    )
+    loadMore = result.loadMore
+    return (
+      <div
+        className='items'
+        data-ids={result.data.map(item => item.id).join(',')}
+        data-more={String(result.hasMore)}
+        data-total={String(result.totalCount)}
+      />
+    )
+  }
+
+  render(
+    <App>
+      <React.Suspense fallback={<div>loading</div>}>
+        <List />
+      </React.Suspense>
+    </App>,
+  )
+  await flush()
+
+  t.is($('.items')?.getAttribute('data-ids'), '1,2,3')
+  t.is($('.items')?.getAttribute('data-total'), '6')
+  t.deepEqual(calls[0]?.query, {
+    rank: { $gte: 1 },
+    cursorLimit: 3,
+    returnCursor: true,
+    returnTotal: true,
+  })
+
+  await flush(() => loadMore?.())
+
+  t.is($('.items')?.getAttribute('data-ids'), '1,2,3,4,5,6')
+  t.is($('.items')?.getAttribute('data-more'), 'false')
+  const nextPageCall = calls.find(call => call.query.cursor === 'cursor:3')
+  t.deepEqual(nextPageCall?.query, {
+    rank: { $gte: 1 },
+    cursorLimit: 3,
+    returnCursor: true,
+    cursor: 'cursor:3',
+  })
+  unmount()
+})
+
+test('cursor all: drains every page and only requests the total on page one', async t => {
+  const { calls, figbird } = createCursorApp(makeRows(7), 3)
+  const ref = figbird.query(figbird.q.items.all())
+  const unsub = ref.subscribe(() => {})
+
+  await new Promise(resolve => setTimeout(resolve, 10))
+
+  t.deepEqual(
+    (ref.getSnapshot().data as Item[]).map(item => item.id),
+    [1, 2, 3, 4, 5, 6, 7],
+  )
+  t.is(calls.length, 3)
+  t.true(calls[0]?.query.returnTotal === true)
+  t.false(Object.hasOwn(calls[1]?.query ?? {}, 'returnTotal'))
+  t.false(Object.hasOwn(calls[2]?.query ?? {}, 'returnTotal'))
+  t.deepEqual(
+    calls.map(call => call.query.cursor),
+    [undefined, 'cursor:3', 'cursor:6'],
+  )
+  unsub()
+})
+
+test('cursor paginate: realtime rebuilds the loaded prefix with a fresh cursor chain', async t => {
+  const { render, unmount, flush, $ } = dom()
+  const cursorApp = createCursorApp(makeRows(7))
+  let loadMore: (() => void) | undefined
+
+  function List() {
+    const result = useQuery(cursorApp.figbird.q.items.paginate({ pageSize: 3 }))
+    loadMore = result.loadMore
+    return <div className='items' data-ids={result.data.map(item => item.id).join(',')} />
+  }
+
+  render(
+    <cursorApp.App>
+      <React.Suspense fallback={<div>loading</div>}>
+        <List />
+      </React.Suspense>
+    </cursorApp.App>,
+  )
+  await flush()
+  await flush(() => loadMore?.())
+  t.is($('.items')?.getAttribute('data-ids'), '1,2,3,4,5,6')
+
+  const inserted = { id: 99, rank: 0 }
+  cursorApp.replaceRows([inserted, ...makeRows(7)])
+  await flush(async () => {
+    cursorApp.emit('created', inserted)
+    await new Promise(resolve => setTimeout(resolve, 20))
+  })
+
+  t.is($('.items')?.getAttribute('data-ids'), '99,1,2,3,4,5')
+  const lastTwoCalls = cursorApp.calls.slice(-2).map(call => call.query.cursor)
+  t.deepEqual(lastTwoCalls, [undefined, 'cursor:3'])
+  unmount()
+})
+
+test('cursor paginate: reconnect rebuilds every loaded page from page zero', async t => {
+  const { render, unmount, flush, $ } = dom()
+  const cursorApp = createCursorApp(makeRows(7))
+  let loadMore: (() => void) | undefined
+
+  function List() {
+    const result = useQuery(cursorApp.figbird.q.items.paginate({ pageSize: 3 }))
+    loadMore = result.loadMore
+    return <div className='items' data-ids={result.data.map(item => item.id).join(',')} />
+  }
+
+  render(
+    <cursorApp.App>
+      <React.Suspense fallback={<div>loading</div>}>
+        <List />
+      </React.Suspense>
+    </cursorApp.App>,
+  )
+  await flush()
+  await flush(() => loadMore?.())
+
+  cursorApp.replaceRows([{ id: 99, rank: 0 }, ...makeRows(7)])
+  await flush(async () => {
+    cursorApp.emitReconnect()
+    await new Promise(resolve => setTimeout(resolve, 20))
+  })
+
+  t.is($('.items')?.getAttribute('data-ids'), '99,1,2,3,4,5')
+  t.deepEqual(
+    cursorApp.calls.slice(-2).map(call => call.query.cursor),
+    [undefined, 'cursor:3'],
+  )
+  unmount()
+})
+
+test('cursor paginate: hidden reconnect waits, then rebuilds on visibility', async t => {
+  const { render, unmount, flush, $ } = dom()
+  const visibility = fakeVisibility(false)
+  const cursorApp = createCursorApp(makeRows(7), 3, { visibility: visibility.source })
+  let loadMore: (() => void) | undefined
+
+  function List() {
+    const result = useQuery(cursorApp.figbird.q.items.paginate({ pageSize: 3 }))
+    loadMore = result.loadMore
+    return <div className='items' data-ids={result.data.map(item => item.id).join(',')} />
+  }
+
+  render(
+    <cursorApp.App>
+      <React.Suspense fallback={<div>loading</div>}>
+        <List />
+      </React.Suspense>
+    </cursorApp.App>,
+  )
+  await flush()
+  await flush(() => loadMore?.())
+  const baselineCalls = cursorApp.calls.length
+
+  visibility.set(true)
+  cursorApp.replaceRows([{ id: 99, rank: 0 }, ...makeRows(7)])
+  cursorApp.emitReconnect()
+  await new Promise(resolve => setTimeout(resolve, 20))
+
+  t.is(cursorApp.calls.length, baselineCalls)
+  t.is($('.items')?.getAttribute('data-ids'), '1,2,3,4,5,6')
+
+  await flush(async () => {
+    visibility.set(false)
+    await new Promise(resolve => setTimeout(resolve, 20))
+  })
+
+  t.is($('.items')?.getAttribute('data-ids'), '99,1,2,3,4,5')
+  t.is(cursorApp.calls.length, baselineCalls + 2)
+  unmount()
+})
+
+test('cursor paginate: failed prefix rebuild stays atomic and retries its depth', async t => {
+  const { render, unmount, flush, $ } = dom()
+  const cursorApp = createCursorApp(makeRows(7))
+  let loadMore: (() => void) | undefined
+
+  function List() {
+    const result = useQuery(cursorApp.figbird.q.items.paginate({ pageSize: 3 }))
+    loadMore = result.loadMore
+    return <div className='items' data-ids={result.data.map(item => item.id).join(',')} />
+  }
+
+  render(
+    <cursorApp.App>
+      <React.Suspense fallback={<div>loading</div>}>
+        <List />
+      </React.Suspense>
+    </cursorApp.App>,
+  )
+  await flush()
+  await flush(() => loadMore?.())
+
+  const firstInserted = { id: 99, rank: 0 }
+  cursorApp.failNextCursor('cursor:3')
+  cursorApp.replaceRows([firstInserted, ...makeRows(7)])
+  await flush(async () => {
+    cursorApp.emit('created', firstInserted)
+    await new Promise(resolve => setTimeout(resolve, 20))
+  })
+
+  t.is($('.items')?.getAttribute('data-ids'), '1,2,3,4,5,6')
+
+  const secondInserted = { id: 100, rank: -1 }
+  cursorApp.replaceRows([secondInserted, firstInserted, ...makeRows(7)])
+  await flush(async () => {
+    cursorApp.emit('created', secondInserted)
+    await new Promise(resolve => setTimeout(resolve, 20))
+  })
+
+  t.is($('.items')?.getAttribute('data-ids'), '100,99,1,2,3,4')
+  t.deepEqual(
+    cursorApp.calls.slice(-2).map(call => call.query.cursor),
+    [undefined, 'cursor:3'],
+  )
+  unmount()
+})
+
+test('cursor pagination: rejects a response that cannot continue safely', async t => {
+  const feathers: FeathersClient = {
+    service: () =>
+      ({
+        find: async () => ({ data: [], pageInfo: { hasNextPage: true, endCursor: null } }),
+      }) as unknown as FeathersService,
+  }
+  const adapter = new FeathersAdapter(feathers, {
+    pagination: { items: cursorPagination() },
+  })
+  const pageSource = adapter.pageSource('items')
+  if (!pageSource) return t.fail('expected items to expose native pagination')
+
+  await t.throwsAsync(pageSource.find(undefined, { limit: 10, returnTotal: false }), {
+    message: /no pageInfo\.endCursor/,
+  })
+})

--- a/test/cursor-pagination.test.tsx
+++ b/test/cursor-pagination.test.tsx
@@ -42,7 +42,13 @@ function createCursorApp(
     visibility,
     retry,
     retryDelay,
-  }: { visibility?: VisibilitySource; retry?: number | false; retryDelay?: number } = {},
+    cursorPageSizeWhenFetchingAll,
+  }: {
+    visibility?: VisibilitySource
+    retry?: number | false
+    retryDelay?: number
+    cursorPageSizeWhenFetchingAll?: number
+  } = {},
 ) {
   let serverRows = rows
   const calls: CursorCall[] = []
@@ -96,7 +102,13 @@ function createCursorApp(
   }
   const adapter = new FeathersAdapter(feathers, {
     defaultPageSizeWhenFetchingAll: pageSizeWhenFetchingAll,
-    pagination: { items: cursorPagination() },
+    pagination: {
+      items: cursorPagination({
+        ...(cursorPageSizeWhenFetchingAll !== undefined
+          ? { pageSizeWhenFetchingAll: cursorPageSizeWhenFetchingAll }
+          : {}),
+      }),
+    },
   })
   const figbird = new Figbird({
     schema,
@@ -238,6 +250,29 @@ test('cursor all: drains every page and only requests the total on page one', as
     [undefined, 'cursor:3', 'cursor:6'],
   )
   unsub()
+})
+
+test('cursor all: a per-service page size overrides the adapter-wide default', async t => {
+  const { calls, figbird } = createCursorApp(makeRows(201), 2500, {
+    cursorPageSizeWhenFetchingAll: 100,
+  })
+  const ref = figbird.query(figbird.q.items.all())
+  const unsub = ref.subscribe(() => {})
+
+  await new Promise(resolve => setTimeout(resolve, 10))
+
+  t.is((ref.getSnapshot().data as Item[]).length, 201)
+  t.deepEqual(
+    calls.map(call => call.query.cursorLimit),
+    [100, 100, 100],
+  )
+  unsub()
+})
+
+test('cursorPagination: rejects an invalid all-page size', t => {
+  t.throws(() => cursorPagination({ pageSizeWhenFetchingAll: 0 }), {
+    message: /pageSizeWhenFetchingAll/,
+  })
 })
 
 test('cursor paginate: realtime rebuilds the loaded prefix with a fresh cursor chain', async t => {

--- a/test/cursor-pagination.test.tsx
+++ b/test/cursor-pagination.test.tsx
@@ -232,6 +232,31 @@ test('cursor paginate: chains opaque cursors and trusts hasNextPage on a full fi
     $limit: 3,
     $after: 'cursor:3',
   })
+
+  const inspectedPages = figbird.inspect().filter(query => query.page)
+  t.deepEqual(
+    inspectedPages.map(query => query.page),
+    [
+      {
+        request: { limit: 3, includeTotal: true },
+        info: { hasMore: true, endCursor: 'cursor:3', total: 6 },
+      },
+      {
+        request: { limit: 3, after: 'cursor:3', includeTotal: false },
+        info: { hasMore: false },
+      },
+    ],
+  )
+  t.deepEqual(figbird.inspectRelational()[0]?.pagination, {
+    strategy: 'cursor',
+    realtime: 'reconcile',
+    pageSize: 3,
+    includeTotal: true,
+    loadedPages: 2,
+    hasMore: false,
+    isLoadingMore: false,
+    total: 6,
+  })
   unmount()
 })
 
@@ -377,6 +402,7 @@ test('cursor paginate: stable visible updates merge locally; ordering changes re
   await flush(() => loadMore?.())
 
   const callsBeforePatch = cursorApp.calls.length
+  t.is(cursorApp.figbird.inspectRelational()[0]?.pagination?.realtime, 'merge-or-reconcile')
   const renamed = { ...initialRows[4]!, title: 'Renamed' }
   cursorApp.replaceRows(initialRows.map(row => (row.id === renamed.id ? renamed : row)))
   await flush(() => cursorApp.emit('patched', renamed))

--- a/test/cursor-pagination.test.tsx
+++ b/test/cursor-pagination.test.tsx
@@ -6,6 +6,7 @@ import {
   FeathersAdapter,
   Figbird,
   FigbirdProvider,
+  offsetPagination,
   service,
   useQuery,
   type FeathersClient,
@@ -42,12 +43,12 @@ function createCursorApp(
     visibility,
     retry,
     retryDelay,
-    cursorPageSizeWhenFetchingAll,
+    cursorMaxPageSize,
   }: {
     visibility?: VisibilitySource
     retry?: number | false
     retryDelay?: number
-    cursorPageSizeWhenFetchingAll?: number
+    cursorMaxPageSize?: number
   } = {},
 ) {
   let serverRows = rows
@@ -60,8 +61,8 @@ function createCursorApp(
     async find(params: FeathersParams = {}) {
       const query = (params.query ?? {}) as Record<string, unknown>
       calls.push({ query })
-      const limit = query.cursorLimit as number
-      const cursor = query.cursor as string | undefined
+      const limit = query.$limit as number
+      const cursor = query.$after as string | null
       if (cursor && failingCursors.delete(cursor)) {
         throw new Error(`failed ${cursor}`)
       }
@@ -73,11 +74,12 @@ function createCursorApp(
       if (hold) await hold.promise
       return {
         data,
-        pageInfo: {
-          hasNextPage,
-          endCursor: hasNextPage ? `cursor:${end}` : null,
-          ...(query.returnTotal ? { total: serverRows.length } : {}),
-        },
+        limit,
+        hasPreviousPage: cursor !== null,
+        hasNextPage,
+        startCursor: data.length > 0 ? `cursor:${start}` : null,
+        endCursor: data.length > 0 ? `cursor:${end}` : null,
+        ...(query.$total ? { total: serverRows.length } : {}),
       }
     },
     on(event: string, listener: (item: unknown) => void) {
@@ -104,9 +106,7 @@ function createCursorApp(
     defaultPageSizeWhenFetchingAll: pageSizeWhenFetchingAll,
     pagination: {
       items: cursorPagination({
-        ...(cursorPageSizeWhenFetchingAll !== undefined
-          ? { pageSizeWhenFetchingAll: cursorPageSizeWhenFetchingAll }
-          : {}),
+        ...(cursorMaxPageSize !== undefined ? { maxPageSize: cursorMaxPageSize } : {}),
       }),
     },
   })
@@ -130,6 +130,7 @@ function createCursorApp(
     App,
     adapter,
     calls,
+    feathers,
     figbird,
     replaceRows(next: Item[]) {
       serverRows = next
@@ -211,68 +212,81 @@ test('cursor paginate: chains opaque cursors and trusts hasNextPage on a full fi
   t.is($('.items')?.getAttribute('data-total'), '6')
   t.deepEqual(calls[0]?.query, {
     rank: { $gte: 1 },
-    cursorLimit: 3,
-    returnCursor: true,
-    returnTotal: true,
+    $limit: 3,
+    $after: null,
+    $total: true,
   })
 
   await flush(() => loadMore?.())
 
   t.is($('.items')?.getAttribute('data-ids'), '1,2,3,4,5,6')
   t.is($('.items')?.getAttribute('data-more'), 'false')
-  const nextPageCall = calls.find(call => call.query.cursor === 'cursor:3')
+  const nextPageCall = calls.find(call => call.query.$after === 'cursor:3')
   t.deepEqual(nextPageCall?.query, {
     rank: { $gte: 1 },
-    cursorLimit: 3,
-    returnCursor: true,
-    cursor: 'cursor:3',
+    $limit: 3,
+    $after: 'cursor:3',
   })
   unmount()
 })
 
-test('cursor all: drains every page and only requests the total on page one', async t => {
-  const { calls, figbird } = createCursorApp(makeRows(7), 3)
-  const ref = figbird.query(figbird.q.items.all())
-  const unsub = ref.subscribe(() => {})
-
-  await new Promise(resolve => setTimeout(resolve, 10))
+test('cursor all: drains every page without requesting a server total', async t => {
+  const { adapter, calls } = createCursorApp(makeRows(7), 3)
+  const result = await adapter.findAll('items')
 
   t.deepEqual(
-    (ref.getSnapshot().data as Item[]).map(item => item.id),
+    (result.data as Item[]).map(item => item.id),
     [1, 2, 3, 4, 5, 6, 7],
   )
   t.is(calls.length, 3)
-  t.true(calls[0]?.query.returnTotal === true)
-  t.false(Object.hasOwn(calls[1]?.query ?? {}, 'returnTotal'))
-  t.false(Object.hasOwn(calls[2]?.query ?? {}, 'returnTotal'))
+  t.true(calls.every(call => !Object.hasOwn(call.query, '$total')))
+  t.is(result.meta.total, 7)
   t.deepEqual(
-    calls.map(call => call.query.cursor),
-    [undefined, 'cursor:3', 'cursor:6'],
+    calls.map(call => call.query.$after),
+    [null, 'cursor:3', 'cursor:6'],
   )
-  unsub()
 })
 
-test('cursor all: a per-service page size overrides the adapter-wide default', async t => {
-  const { calls, figbird } = createCursorApp(makeRows(201), 2500, {
-    cursorPageSizeWhenFetchingAll: 100,
+test('cursor all: a global default accepts per-service offset overrides', async t => {
+  const { calls, feathers } = createCursorApp(makeRows(201))
+  const cursor100 = cursorPagination({ maxPageSize: 100 })
+  const adapter = new FeathersAdapter(feathers, {
+    defaultPageSizeWhenFetchingAll: 2500,
+    defaultPagination: cursor100,
   })
-  const ref = figbird.query(figbird.q.items.all())
-  const unsub = ref.subscribe(() => {})
+  const result = await adapter.findAll('items')
 
-  await new Promise(resolve => setTimeout(resolve, 10))
-
-  t.is((ref.getSnapshot().data as Item[]).length, 201)
+  t.is(result.data.length, 201)
   t.deepEqual(
-    calls.map(call => call.query.cursorLimit),
+    calls.map(call => call.query.$limit),
     [100, 100, 100],
   )
-  unsub()
+
+  const adapterWithOverride = new FeathersAdapter(feathers, {
+    defaultPagination: cursor100,
+    pagination: { items: offsetPagination() },
+  })
+  t.is(adapterWithOverride.pageSource('items'), undefined)
+  t.truthy(adapterWithOverride.pageSource('other-items'))
 })
 
-test('cursorPagination: rejects an invalid all-page size', t => {
-  t.throws(() => cursorPagination({ pageSizeWhenFetchingAll: 0 }), {
-    message: /pageSizeWhenFetchingAll/,
+test('cursorPagination: validates and enforces the service maximum', async t => {
+  t.throws(() => cursorPagination({ maxPageSize: 0 }), {
+    message: /maxPageSize must be a positive integer/,
   })
+  t.throws(() => cursorPagination({ maxPageSize: 1.5 }), {
+    message: /maxPageSize must be a positive integer/,
+  })
+
+  const { adapter, calls } = createCursorApp(makeRows(3), 3, {
+    cursorMaxPageSize: 2,
+  })
+  const pageSource = adapter.pageSource('items')
+  if (!pageSource) return t.fail('expected items to expose native pagination')
+  await t.throwsAsync(pageSource.find(undefined, { limit: 3, returnTotal: false }), {
+    message: /accepts at most 2 rows per page, got 3/,
+  })
+  t.is(calls.length, 0)
 })
 
 test('cursor paginate: realtime rebuilds the loaded prefix with a fresh cursor chain', async t => {
@@ -305,8 +319,8 @@ test('cursor paginate: realtime rebuilds the loaded prefix with a fresh cursor c
   })
 
   t.is($('.items')?.getAttribute('data-ids'), '99,1,2,3,4,5')
-  const lastTwoCalls = cursorApp.calls.slice(-2).map(call => call.query.cursor)
-  t.deepEqual(lastTwoCalls, [undefined, 'cursor:3'])
+  const lastTwoCalls = cursorApp.calls.slice(-2).map(call => call.query.$after)
+  t.deepEqual(lastTwoCalls, [null, 'cursor:3'])
   unmount()
 })
 
@@ -349,7 +363,7 @@ test('cursor paginate: an old in-flight page never leaks into a rebuilt prefix',
 
   t.is($('.items')?.getAttribute('data-ids'), '1,2,3')
   t.is(
-    cursorApp.calls.filter(call => call.query.cursor === 'cursor:3').length,
+    cursorApp.calls.filter(call => call.query.$after === 'cursor:3').length,
     2,
     'the fresh page request started without publishing the old response',
   )
@@ -392,8 +406,8 @@ test('cursor paginate: reconnect rebuilds every loaded page from page zero', asy
 
   t.is($('.items')?.getAttribute('data-ids'), '99,1,2,3,4,5')
   t.deepEqual(
-    cursorApp.calls.slice(-2).map(call => call.query.cursor),
-    [undefined, 'cursor:3'],
+    cursorApp.calls.slice(-2).map(call => call.query.$after),
+    [null, 'cursor:3'],
   )
   unmount()
 })
@@ -479,8 +493,8 @@ test('cursor paginate: failed prefix rebuild stays atomic and retries its depth'
 
   t.is($('.items')?.getAttribute('data-ids'), '100,99,1,2,3,4')
   t.deepEqual(
-    cursorApp.calls.slice(-2).map(call => call.query.cursor),
-    [undefined, 'cursor:3'],
+    cursorApp.calls.slice(-2).map(call => call.query.$after),
+    [null, 'cursor:3'],
   )
   unmount()
 })
@@ -516,8 +530,8 @@ test('cursor paginate: automatic fetch retry stays inside the frozen rebuild', a
 
   t.is($('.items')?.getAttribute('data-ids'), '99,1,2,3,4,5')
   t.deepEqual(
-    cursorApp.calls.slice(-3).map(call => call.query.cursor),
-    [undefined, 'cursor:3', 'cursor:3'],
+    cursorApp.calls.slice(-3).map(call => call.query.$after),
+    [null, 'cursor:3', 'cursor:3'],
   )
   unmount()
 })
@@ -526,7 +540,7 @@ test('cursor pagination: rejects a response that cannot continue safely', async 
   const feathers: FeathersClient = {
     service: () =>
       ({
-        find: async () => ({ data: [], pageInfo: { hasNextPage: true, endCursor: null } }),
+        find: async () => ({ data: [], hasNextPage: true, endCursor: null }),
       }) as unknown as FeathersService,
   }
   const adapter = new FeathersAdapter(feathers, {
@@ -536,6 +550,6 @@ test('cursor pagination: rejects a response that cannot continue safely', async 
   if (!pageSource) return t.fail('expected items to expose native pagination')
 
   await t.throwsAsync(pageSource.find(undefined, { limit: 10, returnTotal: false }), {
-    message: /no pageInfo\.endCursor/,
+    message: /no endCursor/,
   })
 })

--- a/test/devtools.test.tsx
+++ b/test/devtools.test.tsx
@@ -7,6 +7,7 @@ import {
 } from '../lib/devtools/Devtools.js'
 import {
   createCollector,
+  type Collector,
   type DevtoolsSnapshot,
   type FigbirdLikeForDevtools,
   type QueryRecord,
@@ -599,8 +600,24 @@ test('devtools model keeps operation identity separate from shared fetch identit
   const root = queryRecord('root', 'issues')
   const team = queryRecord('team', 'teams')
   const labels = queryRecord('labels', 'labels')
-  const page1 = queryRecord('page-1', 'issues', { itemCount: 25, fetchCount: 2 })
-  const page2 = queryRecord('page-2', 'issues', { itemCount: 10, fetchCount: 1 })
+  const page1 = queryRecord('page-1', 'issues', {
+    itemCount: 25,
+    fetchCount: 2,
+    classification: 'server-authoritative',
+    page: {
+      request: { limit: 25, includeTotal: true },
+      info: { hasMore: true, endCursor: 'cursor:25', total: 35 },
+    },
+  })
+  const page2 = queryRecord('page-2', 'issues', {
+    itemCount: 10,
+    fetchCount: 1,
+    classification: 'server-authoritative',
+    page: {
+      request: { limit: 25, after: 'cursor:25', includeTotal: false },
+      info: { hasMore: false },
+    },
+  })
   const snapshot: DevtoolsSnapshot = {
     queries: [root, team, labels, page1, page2],
     relational: [
@@ -616,6 +633,16 @@ test('devtools model keeps operation identity separate from shared fetch identit
           cardinality: 'many',
           pageSize: 25,
           related: {},
+        },
+        pagination: {
+          strategy: 'cursor',
+          realtime: 'merge-or-reconcile',
+          pageSize: 25,
+          includeTotal: true,
+          loadedPages: 2,
+          hasMore: false,
+          isLoadingMore: false,
+          total: 35,
         },
         nodes: [
           { path: '(root)', queryId: page1.queryId },
@@ -642,8 +669,91 @@ test('devtools model keeps operation identity separate from shared fetch identit
   t.is(pages?.rootFetches.length, 2)
   t.is(pages?.summary.itemCount, 35)
   t.is(pages?.summary.fetchCount, 3)
+  t.false(pages ? 'page' in pages.summary : true)
+  t.is(pages?.pagination?.strategy, 'cursor')
+  t.true(pages?.composition?.detail.includes('paginate(25) · cursor · 2 pages') ?? false)
+  t.is(pages?.rootFetches[1]?.page?.request.after, 'cursor:25')
   t.false(pages ? 'queryId' in pages.summary : true)
   t.is(model.scopesByQueryId.get(root.queryId)?.length, 2)
+})
+
+test('query details show a cursor operation as one inspectable page chain', t => {
+  const { render, unmount, click, $, $all } = dom()
+  const first = queryRecord('cursor-page-1', 'issues', {
+    classification: 'server-authoritative',
+    itemCount: 25,
+    page: {
+      request: { limit: 25, includeTotal: true },
+      info: { hasMore: true, endCursor: 'cursor:25', total: 35 },
+    },
+  })
+  const second = queryRecord('cursor-page-2', 'issues', {
+    classification: 'server-authoritative',
+    itemCount: 10,
+    page: {
+      request: { limit: 25, after: 'cursor:25', includeTotal: false },
+      info: { hasMore: false },
+    },
+  })
+  const snapshot: DevtoolsSnapshot = {
+    queries: [first, second],
+    relational: [
+      {
+        key: 'rq/cursor-pages',
+        service: 'issues',
+        ast: {
+          service: 'issues',
+          kind: 'paginate',
+          query: { status: 'open', $sort: { createdAt: -1 } },
+          cardinality: 'many',
+          pageSize: 25,
+          includeTotal: true,
+          related: {},
+        },
+        pagination: {
+          strategy: 'cursor',
+          realtime: 'merge-or-reconcile',
+          pageSize: 25,
+          includeTotal: true,
+          loadedPages: 2,
+          hasMore: false,
+          isLoadingMore: false,
+          total: 35,
+        },
+        nodes: [
+          { path: '(root)', queryId: first.queryId },
+          { path: '(root)', queryId: second.queryId },
+        ],
+      },
+    ],
+    events: [],
+    timeline: { startedAt: 0, laneOrder: [], realtime: [] },
+    writes: [],
+    inFlightWrites: 0,
+  }
+  const collector: Collector = {
+    start() {},
+    stop() {},
+    subscribe: () => () => {},
+    getSnapshot: () => snapshot,
+    clearEvents() {},
+    clearTimeline() {},
+    clearWrites() {},
+  }
+
+  render(<FigbirdDevtoolsPanel collector={collector} theme='light' />)
+  const row = $all('tbody tr')[0]
+  t.truthy(row)
+  t.true((row?.textContent ?? '').includes('paginate(25) · cursor · 2 pages'))
+  click(row!)
+
+  const details = $('[aria-label="Figbird devtools"]')?.textContent ?? ''
+  t.true(details.includes('Cursor page chain'))
+  t.true(details.includes('merges stable updates'))
+  t.true(details.includes('after start · next "cursor:25"'))
+  t.true(details.includes('after "cursor:25" · end'))
+  t.true(details.includes('35 total'))
+  unmount()
 })
 
 test('extension bridge starts debug collection only while connected', t => {

--- a/test/paginate.test.tsx
+++ b/test/paginate.test.tsx
@@ -111,10 +111,11 @@ test('QueryBuilder.paginate: returnTotal defaults to omitted (undefined)', t => 
   t.is(ast.returnTotal, undefined)
 })
 
-test('QueryBuilder.paginate: rejects non-positive pageSize', t => {
+test('QueryBuilder.paginate: requires a positive integer pageSize', t => {
   const { figbird } = createPaginateApp()
   t.throws(() => figbird.q.issues.paginate({ pageSize: 0 }), { message: /pageSize/i })
   t.throws(() => figbird.q.issues.paginate({ pageSize: -3 }), { message: /pageSize/i })
+  t.throws(() => figbird.q.issues.paginate({ pageSize: 1.5 }), { message: /pageSize/i })
 })
 
 test('QueryBuilder.paginate: composes with where and orderBy before paginate', t => {

--- a/test/paginate.test.tsx
+++ b/test/paginate.test.tsx
@@ -94,21 +94,21 @@ function createPaginateApp(opts: PaginateAppOptions = {}) {
 // QueryBuilder unit tests
 // ============================================================================
 
-test('QueryBuilder.paginate: sets kind=paginate, pageSize, returnTotal in AST', t => {
+test('QueryBuilder.paginate: sets kind=paginate, pageSize, includeTotal in AST', t => {
   const { figbird } = createPaginateApp()
-  const ast = figbird.q.issues.paginate({ pageSize: 4, returnTotal: true }).toAST()
+  const ast = figbird.q.issues.paginate({ pageSize: 4, includeTotal: true }).toAST()
   t.is(ast.kind, 'paginate')
   t.is(ast.pageSize, 4)
-  t.is(ast.returnTotal, true)
+  t.is(ast.includeTotal, true)
   t.is(ast.cardinality, 'many')
 })
 
-test('QueryBuilder.paginate: returnTotal defaults to omitted (undefined)', t => {
+test('QueryBuilder.paginate: includeTotal defaults to omitted (undefined)', t => {
   const { figbird } = createPaginateApp()
   const ast = figbird.q.issues.paginate({ pageSize: 4 }).toAST()
   t.is(ast.kind, 'paginate')
   t.is(ast.pageSize, 4)
-  t.is(ast.returnTotal, undefined)
+  t.is(ast.includeTotal, undefined)
 })
 
 test('QueryBuilder.paginate: requires a positive integer pageSize', t => {
@@ -130,13 +130,13 @@ test('QueryBuilder.paginate: composes with where and orderBy before paginate', t
   t.deepEqual(ast.query, { status: 'open', $sort: { rank: -1 } })
 })
 
-test('QueryBuilder.paginate: hash differs by pageSize and returnTotal', t => {
+test('QueryBuilder.paginate: hash differs by pageSize and includeTotal', t => {
   const { figbird } = createPaginateApp()
   const a = figbird.q.issues.paginate({ pageSize: 4 })
   const b = figbird.q.issues.paginate({ pageSize: 5 })
-  const c = figbird.q.issues.paginate({ pageSize: 4, returnTotal: true })
+  const c = figbird.q.issues.paginate({ pageSize: 4, includeTotal: true })
   t.not(a.hash(), b.hash(), 'pageSize must affect hash')
-  t.not(a.hash(), c.hash(), 'returnTotal must affect hash')
+  t.not(a.hash(), c.hash(), 'includeTotal must affect hash')
 })
 
 // ============================================================================
@@ -233,15 +233,15 @@ test('useQuery + paginate: loadMore appends the next page and flips hasMore fals
   unmount()
 })
 
-test('useQuery + paginate: returnTotal exposes totalCount from the first page meta', async t => {
+test('useQuery + paginate: includeTotal exposes total from the first page meta', async t => {
   const { render, unmount, flush, $ } = dom()
   const { App, figbird } = createPaginateApp({ totalIssues: 12 })
 
   function IssueList() {
-    const { totalCount } = useQuery(
-      figbird.q.issues.orderBy('rank', 'asc').paginate({ pageSize: 4, returnTotal: true }),
+    const { total } = useQuery(
+      figbird.q.issues.orderBy('rank', 'asc').paginate({ pageSize: 4, includeTotal: true }),
     )
-    return <div className='issues' data-total={String(totalCount ?? 'unset')} />
+    return <div className='issues' data-total={String(total ?? 'unset')} />
   }
 
   render(
@@ -258,15 +258,15 @@ test('useQuery + paginate: returnTotal exposes totalCount from the first page me
   unmount()
 })
 
-test('useQuery + paginate: totalCount is undefined when adapter omits total', async t => {
+test('useQuery + paginate: total is undefined when adapter omits it', async t => {
   const { render, unmount, flush, $ } = dom()
   const { App, figbird } = createPaginateApp({ totalIssues: 12, skipTotal: true })
 
   function IssueList() {
-    const { totalCount } = useQuery(
-      figbird.q.issues.orderBy('rank', 'asc').paginate({ pageSize: 4, returnTotal: true }),
+    const { total } = useQuery(
+      figbird.q.issues.orderBy('rank', 'asc').paginate({ pageSize: 4, includeTotal: true }),
     )
-    return <div className='issues' data-total={String(totalCount ?? 'unset')} />
+    return <div className='issues' data-total={String(total ?? 'unset')} />
   }
 
   render(
@@ -420,5 +420,41 @@ test('useQuery + paginate: realtime create that provably sorts into a page merge
   )
   t.is($('.issues')!.getAttribute('data-count'), '3')
 
+  unmount()
+})
+
+test('useQuery + paginate: .server() makes an offset page refetch on realtime', async t => {
+  const { render, unmount, flush, $ } = dom()
+  const { App, figbird, feathers, issuesService } = createPaginateApp({ totalIssues: 5 })
+
+  function IssueList() {
+    const { data } = useQuery(
+      figbird.q.issues.orderBy('rank', 'asc').server().paginate({ pageSize: 3 }),
+    )
+    return <div className='issues' data-titles={data.map(issue => issue.title).join(',')} />
+  }
+
+  render(
+    <App>
+      <React.Suspense fallback={<div className='fallback'>...</div>}>
+        <IssueList />
+      </React.Suspense>
+    </App>,
+  )
+
+  await flush()
+  const findCountBefore = issuesService.counts.find
+
+  await flush(async () => {
+    await feathers.service('issues').create({
+      id: 99,
+      title: 'Inserted',
+      status: 'open',
+      rank: 0,
+    })
+  })
+
+  t.is(issuesService.counts.find, findCountBefore + 1)
+  t.is($('.issues')!.getAttribute('data-titles'), 'Inserted,Issue 1,Issue 2')
   unmount()
 })


### PR DESCRIPTION
## Summary

- add adapter-native cursor pagination to the existing `.paginate()` and `.all()` query APIs
- add Feathers pagination configuration with global defaults and per-service cursor or offset overrides
- rebuild loaded cursor chains safely after realtime events and refetches
- support service page-size limits and optional first-page totals
- document the built-in Feathers protocol and custom adapter contract
- declare the React runtime peer dependencies used by the package

## Wire contract

The default Feathers mapping requests the first page with:

```ts
{
  $limit: 25,
  $after: null,
  $total: true
}
```

Following pages send the previous `endCursor` through `$after`. Responses use a flat envelope with `data`, `limit`, `hasNextPage`, `endCursor`, and an optional top-level `total`.

## Why

Cursor-backed services should work through the normal Figbird query API without separate hooks or pagination state in application code. The adapter owns the transport mapping while the query engine owns page accumulation, loading state, caching, and reconciliation.

## Validation

- `npm run test`
- 300 tests passed
- linked this branch into Humaans and exercised cursor-backed document and companion query flows
