### PR TITLE
Retry only transient query failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Retry failed query fetches up to three times with exponential backoff before exposing
   the error. Configure the instance with `retry` and `retryDelay`; descriptor queries can
-  override both or disable retries with `retry: false`.
+  override both or disable retries with `retry: false`. Network errors, timeouts, `408`,
+  `429`, and `5xx` responses retry; other `4xx` responses fail immediately.
 
 ## 0.24.0
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ function NoteRow({ note }: { note: Note & { author?: User } }) {
 ```
 
 No provider needed — the hooks are bound to the instance. Cold reads suspend into your `<Suspense>` boundary; warm reads render synchronously.
-Failed fetches retry up to three times with exponential backoff before Figbird exposes the error.
+Transient fetch failures retry up to three times with exponential backoff before Figbird exposes the error. Client errors fail immediately, except for `408` and `429` responses.
 
 ## Features
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -785,6 +785,9 @@ The query stays in its fetching state between attempts, so a cold query keeps su
 and a background refetch keeps showing its cached data. Only the final failure enters the
 error state.
 
+Retries apply to network failures, timeouts, `408`, `429`, and `5xx` responses. Other
+`4xx` responses fail immediately because repeating the same request will not fix them.
+
 Configure the policy on the instance:
 
 ```ts

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1022,6 +1022,8 @@ Figbird works with any REST / WebSocket / RPC API wrapped in a Figbird-compatibl
 2. Support the operations `find`, `get`, `create`, `update`, `patch`, `remove`
 3. For realtime, emit `created`, `patched`, `updated`, `removed` events after mutations
 4. Optionally implement `subscribeToReconnect` so active queries refetch after connectivity gaps
+5. Optionally implement `isRetryableError` to return `false` for errors that another query
+   attempt cannot fix; adapters without it treat all query errors as retryable
 
 For example, a `comments` resource maps to `GET /comments`, `GET /comments/:id`, `POST /comments`, `PUT/PATCH/DELETE /comments/:id`, with `find` returning `{ data, total, limit, skip }` or similar. See [`lib/adapters/feathers.ts`](https://github.com/humaans/figbird/blob/master/lib/adapters/feathers.ts) for the reference implementation of the `Adapter` interface.
 

--- a/lib/adapters/adapter.ts
+++ b/lib/adapters/adapter.ts
@@ -45,6 +45,9 @@ export interface Adapter<
 
   mutate(serviceName: string, method: string, args: unknown[]): Promise<unknown>
 
+  /** Return false when retrying a failed query cannot help. Errors retry by default. */
+  isRetryableError?(error: Error): boolean
+
   // Optional real-time support
   subscribe?(serviceName: string, handlers: EventHandlers): () => void
 

--- a/lib/adapters/feathers.ts
+++ b/lib/adapters/feathers.ts
@@ -293,6 +293,11 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
     return this.feathers.service(serviceName)
   }
 
+  isRetryableError(error: Error): boolean {
+    const code = 'code' in error ? error.code : undefined
+    return typeof code !== 'number' || code < 400 || code === 408 || code === 429 || code >= 500
+  }
+
   async get(
     serviceName: string,
     resourceId: string | number,

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -67,6 +67,33 @@ function defaultRetryDelay(attempt: number): number {
   return Math.min(1000 * 2 ** (attempt - 1), MAX_RETRY_DELAY)
 }
 
+function getHttpStatus(error: Error): number | undefined {
+  const errorRecord = error as Error & Record<string, unknown>
+  const response = errorRecord.response
+  const responseStatus =
+    response && typeof response === 'object'
+      ? (response as Record<string, unknown>).status
+      : undefined
+
+  for (const status of [
+    errorRecord.status,
+    errorRecord.statusCode,
+    errorRecord.code,
+    responseStatus,
+  ]) {
+    if (typeof status === 'number' && Number.isInteger(status) && status >= 400 && status < 600) {
+      return status
+    }
+  }
+
+  return undefined
+}
+
+function isRetryableError(error: Error): boolean {
+  const status = getHttpStatus(error)
+  return status === undefined || status === 408 || status === 429 || status >= 500
+}
+
 type ItemId = string | number
 
 /** The realtime event type a mutation verb produces. */
@@ -543,7 +570,7 @@ export class QueryStore<
         !query ||
         this.#queryGenerations.get(queryId) !== generation ||
         !this.#hasRetryOwner(queryId) ||
-        !this.#shouldRetry(query, retryAttempt)
+        !this.#shouldRetry(query, retryAttempt, outcome.error)
       ) {
         if (query && this.#queryGenerations.get(queryId) === generation) {
           this.#fetchFailed({ queryId, error: outcome.error })
@@ -639,9 +666,9 @@ export class QueryStore<
     }
   }
 
-  #shouldRetry(query: Query<unknown, TMeta, unknown>, retryAttempt: number): boolean {
+  #shouldRetry(query: Query<unknown, TMeta, unknown>, retryAttempt: number, error: Error): boolean {
     const retry = this.#normalizeRetry(query.config.retry ?? this.#retry)
-    return retry !== false && retryAttempt < retry
+    return retry !== false && retryAttempt < retry && isRetryableError(error)
   }
 
   #normalizeRetry(retry: number | false): number | false {

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -67,33 +67,6 @@ function defaultRetryDelay(attempt: number): number {
   return Math.min(1000 * 2 ** (attempt - 1), MAX_RETRY_DELAY)
 }
 
-function getHttpStatus(error: Error): number | undefined {
-  const errorRecord = error as Error & Record<string, unknown>
-  const response = errorRecord.response
-  const responseStatus =
-    response && typeof response === 'object'
-      ? (response as Record<string, unknown>).status
-      : undefined
-
-  for (const status of [
-    errorRecord.status,
-    errorRecord.statusCode,
-    errorRecord.code,
-    responseStatus,
-  ]) {
-    if (typeof status === 'number' && Number.isInteger(status) && status >= 400 && status < 600) {
-      return status
-    }
-  }
-
-  return undefined
-}
-
-function isRetryableError(error: Error): boolean {
-  const status = getHttpStatus(error)
-  return status === undefined || status === 408 || status === 429 || status >= 500
-}
-
 type ItemId = string | number
 
 /** The realtime event type a mutation verb produces. */
@@ -668,7 +641,9 @@ export class QueryStore<
 
   #shouldRetry(query: Query<unknown, TMeta, unknown>, retryAttempt: number, error: Error): boolean {
     const retry = this.#normalizeRetry(query.config.retry ?? this.#retry)
-    return retry !== false && retryAttempt < retry && isRetryableError(error)
+    return (
+      retry !== false && retryAttempt < retry && (this.#adapter.isRetryableError?.(error) ?? true)
+    )
   }
 
   #normalizeRetry(retry: number | false): number | false {

--- a/test/fetch-races.test.ts
+++ b/test/fetch-races.test.ts
@@ -91,21 +91,41 @@ test('failed fetches retry with backoff before exposing an error', async t => {
   unsub()
 })
 
-test('retry exhaustion exposes the final error and per-query retry false opts out', async t => {
+test('retry policy handles server errors, client errors, and per-query opt-out', async t => {
   const { figbird, notes } = createApp({}, { retry: 2, retryDelay: 0 })
   notes.find = async () => {
     notes.counts.find++
-    throw new Error('still offline')
+    throw Object.assign(new Error('server unavailable'), { code: 503 })
   }
 
   const retried = figbird.queryDesc({ serviceName: 'notes', method: 'find' })
   const unsubRetried = retried.subscribe(() => {})
   await waitFor(() => retried.getSnapshot()?.status === 'error', 'retry exhaustion')
   t.is(notes.counts.find, 3)
-  t.is(retried.getSnapshot()?.error?.message, 'still offline')
+  t.is(retried.getSnapshot()?.error?.message, 'server unavailable')
   unsubRetried()
 
   notes.counts.find = 0
+  notes.find = async () => {
+    notes.counts.find++
+    throw Object.assign(new Error('bad request'), { code: 400 })
+  }
+  const clientError = figbird.queryDesc({
+    serviceName: 'notes',
+    method: 'find',
+    params: { query: { invalid: true } },
+  })
+  const unsubClientError = clientError.subscribe(() => {})
+  await waitFor(() => clientError.getSnapshot()?.status === 'error', 'client error')
+  t.is(notes.counts.find, 1)
+  t.is(clientError.getSnapshot()?.error?.message, 'bad request')
+  unsubClientError()
+
+  notes.counts.find = 0
+  notes.find = async () => {
+    notes.counts.find++
+    throw new Error('offline')
+  }
   const noRetry = figbird.queryDesc(
     { serviceName: 'notes', method: 'find', params: { query: { disabled: true } } },
     { retry: false },


### PR DESCRIPTION
## What changed

- Retry query fetches for network failures, timeouts, HTTP 408 and 429 responses, and 5xx responses.
- Expose other 4xx errors immediately instead of exhausting the retry budget.
- Let adapters classify their own errors through an optional `isRetryableError` hook.
- Classify Feathers errors from their standard numeric `code`.
- Update the existing retry coverage and documentation.

## Why

The automatic retry flow treated every query error as transient. Client errors such as 400, 401, 403, and 404 usually cannot succeed when the same request runs again, so retries delayed the useful error state without helping recovery.

## Validation

- `npm run tsc`
- `npm run lint`
- `npm run ava` — 289 tests passed
- `npm run test` — full suite passed
