### PR TITLE
Automate browser extension releases

### DIFF
--- a/.github/workflows/devtools-release.yml
+++ b/.github/workflows/devtools-release.yml
@@ -1,6 +1,11 @@
 name: Release browser devtools
 
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - extensions/version.json
   workflow_dispatch:
     inputs:
       sign_firefox:
@@ -19,6 +24,9 @@ on:
 permissions:
   contents: write
   id-token: write
+
+concurrency:
+  group: devtools-release
 
 jobs:
   release:
@@ -41,7 +49,7 @@ jobs:
             extensions/build/figbird-devtools-firefox-unsigned.zip
             extensions/build/figbird-devtools-source.zip
       - name: Sign the unlisted Firefox extension
-        if: inputs.sign_firefox
+        if: github.event_name == 'push' || inputs.sign_firefox
         env:
           AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
           AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
@@ -56,13 +64,13 @@ jobs:
             --approval-timeout 900000 \
             --timeout 900000
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: inputs.sign_firefox
+        if: github.event_name == 'push' || inputs.sign_firefox
         with:
           if-no-files-found: error
           name: figbird-devtools-firefox-signed
           path: extensions/build/firefox-signed/*.xpi
       - name: Publish the signed Firefox extension
-        if: inputs.sign_firefox
+        if: github.event_name == 'push' || inputs.sign_firefox
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -83,7 +91,7 @@ jobs:
               --notes "Mozilla-signed Firefox build for self-distribution. Download the XPI in Firefox and approve the installation prompt."
           fi
       - id: google-auth
-        if: inputs.upload_chrome || inputs.submit_chrome
+        if: github.event_name == 'push' || inputs.upload_chrome || inputs.submit_chrome
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           access_token_scopes: https://www.googleapis.com/auth/chromewebstore
@@ -91,11 +99,11 @@ jobs:
           token_format: access_token
           workload_identity_provider: ${{ vars.CHROME_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Upload the Chrome extension
-        if: inputs.upload_chrome || inputs.submit_chrome
+        if: github.event_name == 'push' || inputs.upload_chrome || inputs.submit_chrome
         env:
           CHROME_ACCESS_TOKEN: ${{ steps.google-auth.outputs.access_token }}
           CHROME_EXTENSION_ARCHIVE: extensions/build/figbird-devtools-chrome.zip
           CHROME_EXTENSION_ID: ${{ vars.CHROME_EXTENSION_ID }}
           CHROME_PUBLISHER_ID: ${{ vars.CHROME_PUBLISHER_ID }}
-          CHROME_SUBMIT: ${{ inputs.submit_chrome }}
+          CHROME_SUBMIT: ${{ github.event_name == 'push' || inputs.submit_chrome }}
         run: node tasks/publish-chrome-devtools.js

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -7,12 +7,14 @@ on:
       - .github/workflows/devtools.yml
       - extensions/**
       - lib/**
+      - Makefile
       - package-lock.json
       - package.json
       - tasks/build-devtools.js
       - tasks/lint-firefox-devtools.js
       - tasks/package-devtools.js
       - tasks/publish-chrome-devtools.js
+      - tasks/release-devtools.js
   push:
     branches:
       - master
@@ -21,12 +23,14 @@ on:
       - .github/workflows/devtools.yml
       - extensions/**
       - lib/**
+      - Makefile
       - package-lock.json
       - package.json
       - tasks/build-devtools.js
       - tasks/lint-firefox-devtools.js
       - tasks/package-devtools.js
       - tasks/publish-chrome-devtools.js
+      - tasks/release-devtools.js
 
 permissions:
   contents: read

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: release-extensions
+
+release-extensions:
+	@node tasks/release-devtools.js

--- a/extensions/RELEASING.md
+++ b/extensions/RELEASING.md
@@ -8,11 +8,10 @@ Keep store ownership and automation under organization accounts. Do not use pers
 
 ## Prepare a release
 
-1. Increase the version in `extensions/version.json`. Browser extension versions can contain one to four dot-separated integers.
-2. Update the extension code and listing or privacy copy if its behavior changed.
-3. Run `npm test` and `npm run devtools:check`.
-4. QA the unpacked Chrome and Firefox builds using `extensions/README.md`.
-5. Merge the reviewed version change before running the release workflow.
+1. Update the extension code and listing or privacy copy if its behavior changed.
+2. Run `npm test` and `npm run devtools:check`.
+3. QA the unpacked Chrome and Firefox builds using `extensions/README.md`.
+4. Merge the reviewed extension changes.
 
 ## One-time publisher setup
 
@@ -51,19 +50,20 @@ Mozilla exposes the secret only when it is created. Store it directly in GitHub 
 
 ## Release both extensions
 
-After merging the version change, run:
+After merging the extension changes, run:
 
 ```sh
 make release-extensions
 ```
 
-The command releases the version on `origin/master`, not local or unmerged code. It checks the
-publisher configuration and version first, submits the Firefox extension for Mozilla signing,
-submits the private Chrome extension for review, and waits for the GitHub Actions workflow to
-finish. It then prints the Firefox release and Chrome publisher links.
+The command increases the patch component in `extensions/version.json`, creates a release branch,
+commits and pushes it, and opens a version-bump PR. It does not change the current working tree.
+Use `make release-extensions VERSION=0.2.0` to choose a different version.
 
-The command stops if the matching `devtools-v<version>` GitHub release already exists. Increase
-`extensions/version.json` and merge that change before releasing again.
+The command checks the publisher configuration and version before creating the PR. Approve and
+merge the PR to submit the Firefox extension for Mozilla signing and the private Chrome extension
+for review. The release workflow saves the signed Firefox XPI in the matching
+`devtools-v<version>` GitHub prerelease.
 
 To release only one browser, open **Actions → Release browser devtools → Run workflow** on the
 default branch and select the required inputs.

--- a/extensions/RELEASING.md
+++ b/extensions/RELEASING.md
@@ -49,9 +49,24 @@ Add these secrets to the protected `extension-release` GitHub environment:
 
 Mozilla exposes the secret only when it is created. Store it directly in GitHub Actions and rotate it if it is ever copied elsewhere.
 
-## Run the workflow
+## Release both extensions
 
-Open **Actions → Release browser devtools → Run workflow** on the default branch.
+After merging the version change, run:
+
+```sh
+make release-extensions
+```
+
+The command releases the version on `origin/master`, not local or unmerged code. It checks the
+publisher configuration and version first, submits the Firefox extension for Mozilla signing,
+submits the private Chrome extension for review, and waits for the GitHub Actions workflow to
+finish. It then prints the Firefox release and Chrome publisher links.
+
+The command stops if the matching `devtools-v<version>` GitHub release already exists. Increase
+`extensions/version.json` and merge that change before releasing again.
+
+To release only one browser, open **Actions → Release browser devtools → Run workflow** on the
+default branch and select the required inputs.
 
 - **Sign Firefox** submits the unlisted build and source archive to Mozilla, then saves the
   signed XPI as both a workflow artifact and a `devtools-v<version>` GitHub prerelease asset.

--- a/tasks/release-devtools.js
+++ b/tasks/release-devtools.js
@@ -1,0 +1,198 @@
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { setTimeout as wait } from 'node:timers/promises'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const environment = 'extension-release'
+const workflow = 'devtools-release.yml'
+
+try {
+  await release()
+} catch (error) {
+  console.error(`\n${error instanceof Error ? error.message : String(error)}`)
+  process.exitCode = 1
+}
+
+async function release() {
+  run('gh', ['auth', 'status', '--hostname', 'github.com'])
+  run('git', ['fetch', '--quiet', 'origin', 'master'])
+
+  const repository = capture('gh', [
+    'repo',
+    'view',
+    '--json',
+    'nameWithOwner',
+    '--jq',
+    '.nameWithOwner',
+  ])
+  const masterSha = capture('git', ['rev-parse', 'origin/master'])
+  const version = readMasterVersion()
+  const tag = `devtools-v${version}`
+  const secrets = listNames('secret', repository)
+  const variables = listVariables(repository)
+  const problems = [
+    ...missingNames('GitHub environment secret', secrets, ['AMO_JWT_ISSUER', 'AMO_JWT_SECRET']),
+    ...missingNames('GitHub environment variable', variables.keys(), [
+      'CHROME_EXTENSION_ID',
+      'CHROME_PUBLISHER_ID',
+      'CHROME_SERVICE_ACCOUNT',
+      'CHROME_WORKLOAD_IDENTITY_PROVIDER',
+    ]),
+  ]
+
+  const existingRelease = run('gh', ['release', 'view', tag, '--repo', repository], {
+    allowFailure: true,
+  })
+  if (existingRelease.status === 0) {
+    problems.push(
+      `GitHub release ${tag} already exists; increase extensions/version.json and merge it first`,
+    )
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `Cannot release Figbird Devtools ${version}:\n\n${problems
+        .map(problem => `- ${problem}`)
+        .join('\n')}\n\nSee extensions/RELEASING.md for setup instructions.`,
+    )
+  }
+
+  run('gh', ['workflow', 'view', workflow, '--repo', repository])
+  console.log(`Releasing Figbird Devtools ${version} from origin/master (${masterSha.slice(0, 7)})`)
+
+  const dispatchedAt = Date.now()
+  const dispatch = run('gh', [
+    'workflow',
+    'run',
+    workflow,
+    '--repo',
+    repository,
+    '--ref',
+    'master',
+    '-f',
+    'sign_firefox=true',
+    '-f',
+    'upload_chrome=false',
+    '-f',
+    'submit_chrome=true',
+  ])
+  const runDetails =
+    parseRunUrl(dispatch.stdout) ?? (await findDispatchedRun(repository, masterSha, dispatchedAt))
+
+  console.log(`Release workflow: ${runDetails.url}`)
+  const watched = run(
+    'gh',
+    ['run', 'watch', String(runDetails.id), '--repo', repository, '--compact', '--exit-status'],
+    { inherit: true },
+  )
+  if (watched.status !== 0) throw new Error(`Extension release failed: ${runDetails.url}`)
+
+  const publisherId = variables.get('CHROME_PUBLISHER_ID')
+  const extensionId = variables.get('CHROME_EXTENSION_ID')
+  console.log(`\nFirefox: https://github.com/${repository}/releases/tag/${tag}`)
+  console.log(
+    `Chrome: https://chrome.google.com/webstore/devconsole/${publisherId}/${extensionId}/edit/package`,
+  )
+  console.log('Chrome may remain under review after this command finishes.')
+}
+
+function readMasterVersion() {
+  const contents = capture('git', ['show', 'origin/master:extensions/version.json'])
+  const parsed = JSON.parse(contents)
+  if (typeof parsed.version !== 'string') {
+    throw new Error('origin/master extensions/version.json does not contain a version')
+  }
+  return parsed.version
+}
+
+function listNames(kind, repository) {
+  const output = capture('gh', [
+    kind,
+    'list',
+    '--env',
+    environment,
+    '--repo',
+    repository,
+    '--json',
+    'name',
+  ])
+  return new Set(JSON.parse(output).map(item => item.name))
+}
+
+function listVariables(repository) {
+  const output = capture('gh', [
+    'variable',
+    'list',
+    '--env',
+    environment,
+    '--repo',
+    repository,
+    '--json',
+    'name,value',
+  ])
+  return new Map(JSON.parse(output).map(item => [item.name, item.value]))
+}
+
+function missingNames(label, present, required) {
+  const available = new Set(present)
+  return required.filter(name => !available.has(name)).map(name => `missing ${label} ${name}`)
+}
+
+function parseRunUrl(output) {
+  const match = output.match(/https:\/\/github\.com\/[^\s]+\/actions\/runs\/(\d+)/)
+  return match ? { id: Number(match[1]), url: match[0] } : null
+}
+
+async function findDispatchedRun(repository, masterSha, dispatchedAt) {
+  const login = capture('gh', ['api', 'user', '--jq', '.login'])
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const output = capture('gh', [
+      'run',
+      'list',
+      '--repo',
+      repository,
+      '--workflow',
+      workflow,
+      '--commit',
+      masterSha,
+      '--event',
+      'workflow_dispatch',
+      '--user',
+      login,
+      '--limit',
+      '10',
+      '--json',
+      'createdAt,databaseId,url',
+    ])
+    const runs = JSON.parse(output)
+    const run = runs.find(item => Date.parse(item.createdAt) >= dispatchedAt - 5_000)
+    if (run) return { id: run.databaseId, url: run.url }
+    await wait(1_000)
+  }
+  throw new Error('Release was dispatched, but its workflow run could not be found')
+}
+
+function capture(command, args) {
+  const result = run(command, args)
+  return result.stdout.trim()
+}
+
+function run(command, args, { allowFailure = false, inherit = false } = {}) {
+  const result = spawnSync(command, args, {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: inherit ? 'inherit' : 'pipe',
+  })
+  if (result.error) {
+    if (result.error.code === 'ENOENT') {
+      throw new Error(`Required command not found: ${command}`)
+    }
+    throw result.error
+  }
+  if (result.status !== 0 && !allowFailure && !inherit) {
+    const detail = (result.stderr || result.stdout).trim()
+    throw new Error(`${command} ${args.join(' ')} failed${detail ? `:\n${detail}` : ''}`)
+  }
+  return result
+}

--- a/tasks/release-devtools.js
+++ b/tasks/release-devtools.js
@@ -1,20 +1,21 @@
 import { spawnSync } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { setTimeout as wait } from 'node:timers/promises'
 import { fileURLToPath } from 'node:url'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const environment = 'extension-release'
-const workflow = 'devtools-release.yml'
+const releaseWorkflow = 'devtools-release.yml'
 
 try {
-  await release()
+  await prepareRelease()
 } catch (error) {
   console.error(`\n${error instanceof Error ? error.message : String(error)}`)
   process.exitCode = 1
 }
 
-async function release() {
+async function prepareRelease() {
   run('gh', ['auth', 'status', '--hostname', 'github.com'])
   run('git', ['fetch', '--quiet', 'origin', 'master'])
 
@@ -26,14 +27,15 @@ async function release() {
     '--jq',
     '.nameWithOwner',
   ])
-  const masterSha = capture('git', ['rev-parse', 'origin/master'])
-  const version = readMasterVersion()
+  const currentVersion = readMasterVersion()
+  const version = requestedVersion(currentVersion)
   const tag = `devtools-v${version}`
+  const branch = `release/${tag}`
   const secrets = listNames('secret', repository)
-  const variables = listVariables(repository)
+  const variables = listNames('variable', repository)
   const problems = [
     ...missingNames('GitHub environment secret', secrets, ['AMO_JWT_ISSUER', 'AMO_JWT_SECRET']),
-    ...missingNames('GitHub environment variable', variables.keys(), [
+    ...missingNames('GitHub environment variable', variables, [
       'CHROME_EXTENSION_ID',
       'CHROME_PUBLISHER_ID',
       'CHROME_SERVICE_ACCOUNT',
@@ -41,60 +43,74 @@ async function release() {
     ]),
   ]
 
-  const existingRelease = run('gh', ['release', 'view', tag, '--repo', repository], {
-    allowFailure: true,
-  })
-  if (existingRelease.status === 0) {
-    problems.push(
-      `GitHub release ${tag} already exists; increase extensions/version.json and merge it first`,
-    )
+  if (
+    run('gh', ['release', 'view', tag, '--repo', repository], { allowFailure: true }).status === 0
+  ) {
+    problems.push(`GitHub release ${tag} already exists`)
+  }
+  if (
+    run('git', ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`], { allowFailure: true })
+      .status === 0
+  ) {
+    problems.push(`local branch ${branch} already exists`)
+  }
+  if (
+    run('git', ['ls-remote', '--exit-code', '--heads', 'origin', branch], { allowFailure: true })
+      .status === 0
+  ) {
+    problems.push(`remote branch ${branch} already exists`)
   }
 
   if (problems.length > 0) {
     throw new Error(
-      `Cannot release Figbird Devtools ${version}:\n\n${problems
+      `Cannot prepare Figbird Devtools ${version}:\n\n${problems
         .map(problem => `- ${problem}`)
         .join('\n')}\n\nSee extensions/RELEASING.md for setup instructions.`,
     )
   }
 
-  run('gh', ['workflow', 'view', workflow, '--repo', repository])
-  console.log(`Releasing Figbird Devtools ${version} from origin/master (${masterSha.slice(0, 7)})`)
+  run('gh', ['workflow', 'view', releaseWorkflow, '--repo', repository])
+  const pullRequest = await createVersionPullRequest({ branch, repository, version })
+  console.log(`\nFigbird Devtools ${version}: ${pullRequest}`)
+  console.log('Approve and merge this PR to release Firefox and submit Chrome for review.')
+}
 
-  const dispatchedAt = Date.now()
-  const dispatch = run('gh', [
-    'workflow',
-    'run',
-    workflow,
-    '--repo',
-    repository,
-    '--ref',
-    'master',
-    '-f',
-    'sign_firefox=true',
-    '-f',
-    'upload_chrome=false',
-    '-f',
-    'submit_chrome=true',
-  ])
-  const runDetails =
-    parseRunUrl(dispatch.stdout) ?? (await findDispatchedRun(repository, masterSha, dispatchedAt))
+async function createVersionPullRequest({ branch, repository, version }) {
+  const temporaryRoot = await mkdtemp(path.join(tmpdir(), 'figbird-devtools-release-'))
+  const worktree = path.join(temporaryRoot, 'worktree')
+  let addedWorktree = false
+  try {
+    run('git', ['worktree', 'add', '--quiet', '-b', branch, worktree, 'origin/master'])
+    addedWorktree = true
+    await writeFile(
+      path.join(worktree, 'extensions', 'version.json'),
+      `${JSON.stringify({ version }, null, 2)}\n`,
+    )
+    run('git', ['add', 'extensions/version.json'], { cwd: worktree })
+    run('git', ['commit', '-m', `Release Figbird Devtools ${version}`], { cwd: worktree })
+    run('git', ['push', '-u', 'origin', branch], { cwd: worktree })
 
-  console.log(`Release workflow: ${runDetails.url}`)
-  const watched = run(
-    'gh',
-    ['run', 'watch', String(runDetails.id), '--repo', repository, '--compact', '--exit-status'],
-    { inherit: true },
-  )
-  if (watched.status !== 0) throw new Error(`Extension release failed: ${runDetails.url}`)
-
-  const publisherId = variables.get('CHROME_PUBLISHER_ID')
-  const extensionId = variables.get('CHROME_EXTENSION_ID')
-  console.log(`\nFirefox: https://github.com/${repository}/releases/tag/${tag}`)
-  console.log(
-    `Chrome: https://chrome.google.com/webstore/devconsole/${publisherId}/${extensionId}/edit/package`,
-  )
-  console.log('Chrome may remain under review after this command finishes.')
+    const output = capture('gh', [
+      'pr',
+      'create',
+      '--repo',
+      repository,
+      '--base',
+      'master',
+      '--head',
+      branch,
+      '--title',
+      `Release Figbird Devtools ${version}`,
+      '--body',
+      `Bump the shared browser extension version to ${version}.\n\nMerging this PR automatically signs and publishes the Firefox XPI, then submits the private Chrome extension for review.`,
+    ])
+    return output.match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/)?.[0] ?? output
+  } finally {
+    if (addedWorktree) {
+      run('git', ['worktree', 'remove', '--force', worktree], { allowFailure: true })
+    }
+    await rm(temporaryRoot, { force: true, recursive: true })
+  }
 }
 
 function readMasterVersion() {
@@ -103,7 +119,49 @@ function readMasterVersion() {
   if (typeof parsed.version !== 'string') {
     throw new Error('origin/master extensions/version.json does not contain a version')
   }
+  validateVersion(parsed.version, 'Current')
   return parsed.version
+}
+
+function requestedVersion(currentVersion) {
+  const version = process.env.VERSION || incrementVersion(currentVersion)
+  validateVersion(version, 'Requested')
+  if (compareVersions(version, currentVersion) <= 0) {
+    throw new Error(`Requested extension version ${version} must be newer than ${currentVersion}`)
+  }
+  return version
+}
+
+function incrementVersion(version) {
+  const components = version.split('.').map(Number)
+  const last = components.length - 1
+  if (components[last] === 65_535) {
+    throw new Error(
+      `Cannot automatically increase ${version}; run make release-extensions VERSION=x.y.z`,
+    )
+  }
+  components[last]++
+  return components.join('.')
+}
+
+function validateVersion(version, label) {
+  const components = version.split('.')
+  const valid =
+    components.length >= 1 &&
+    components.length <= 4 &&
+    components.some(component => component !== '0') &&
+    components.every(component => /^(?:0|[1-9]\d*)$/.test(component) && Number(component) <= 65_535)
+  if (!valid) throw new Error(`${label} extension version is invalid: ${version}`)
+}
+
+function compareVersions(left, right) {
+  const a = left.split('.').map(Number)
+  const b = right.split('.').map(Number)
+  for (let index = 0; index < 4; index++) {
+    const difference = (a[index] ?? 0) - (b[index] ?? 0)
+    if (difference !== 0) return difference
+  }
+  return 0
 }
 
 function listNames(kind, repository) {
@@ -120,57 +178,8 @@ function listNames(kind, repository) {
   return new Set(JSON.parse(output).map(item => item.name))
 }
 
-function listVariables(repository) {
-  const output = capture('gh', [
-    'variable',
-    'list',
-    '--env',
-    environment,
-    '--repo',
-    repository,
-    '--json',
-    'name,value',
-  ])
-  return new Map(JSON.parse(output).map(item => [item.name, item.value]))
-}
-
 function missingNames(label, present, required) {
-  const available = new Set(present)
-  return required.filter(name => !available.has(name)).map(name => `missing ${label} ${name}`)
-}
-
-function parseRunUrl(output) {
-  const match = output.match(/https:\/\/github\.com\/[^\s]+\/actions\/runs\/(\d+)/)
-  return match ? { id: Number(match[1]), url: match[0] } : null
-}
-
-async function findDispatchedRun(repository, masterSha, dispatchedAt) {
-  const login = capture('gh', ['api', 'user', '--jq', '.login'])
-  for (let attempt = 0; attempt < 20; attempt++) {
-    const output = capture('gh', [
-      'run',
-      'list',
-      '--repo',
-      repository,
-      '--workflow',
-      workflow,
-      '--commit',
-      masterSha,
-      '--event',
-      'workflow_dispatch',
-      '--user',
-      login,
-      '--limit',
-      '10',
-      '--json',
-      'createdAt,databaseId,url',
-    ])
-    const runs = JSON.parse(output)
-    const run = runs.find(item => Date.parse(item.createdAt) >= dispatchedAt - 5_000)
-    if (run) return { id: run.databaseId, url: run.url }
-    await wait(1_000)
-  }
-  throw new Error('Release was dispatched, but its workflow run could not be found')
+  return required.filter(name => !present.has(name)).map(name => `missing ${label} ${name}`)
 }
 
 function capture(command, args) {
@@ -178,19 +187,13 @@ function capture(command, args) {
   return result.stdout.trim()
 }
 
-function run(command, args, { allowFailure = false, inherit = false } = {}) {
-  const result = spawnSync(command, args, {
-    cwd: root,
-    encoding: 'utf8',
-    stdio: inherit ? 'inherit' : 'pipe',
-  })
+function run(command, args, { allowFailure = false, cwd = root } = {}) {
+  const result = spawnSync(command, args, { cwd, encoding: 'utf8' })
   if (result.error) {
-    if (result.error.code === 'ENOENT') {
-      throw new Error(`Required command not found: ${command}`)
-    }
+    if (result.error.code === 'ENOENT') throw new Error(`Required command not found: ${command}`)
     throw result.error
   }
-  if (result.status !== 0 && !allowFailure && !inherit) {
+  if (result.status !== 0 && !allowFailure) {
     const detail = (result.stderr || result.stdout).trim()
     throw new Error(`${command} ${args.join(' ')} failed${detail ? `:\n${detail}` : ''}`)
   }


### PR DESCRIPTION
## What changed

- add `make release-extensions`
- calculate the next patch version automatically, with an optional `VERSION=x.y.z` override
- create the version bump in a temporary worktree, then commit, push, and open a release PR without changing the caller's checkout
- sign Firefox, publish its XPI, and submit Chrome automatically when the protected version PR merges
- check publisher configuration, duplicate versions, and release branches before writing anything
- document the release flow and include its files in devtools CI path filtering

## Validation

- `npm test` (292 tests)
- `npm run devtools:check`
- live preflight selected `0.1.1` and stopped without creating a branch while publisher setup is incomplete

## Setup still required

The `extension-release` environment still needs `AMO_JWT_ISSUER`, `AMO_JWT_SECRET`, `CHROME_SERVICE_ACCOUNT`, and `CHROME_WORKLOAD_IDENTITY_PROVIDER`.