### PR TITLE
Make DevTools release assets available immediately

### DIFF
--- a/.github/workflows/devtools-release.yml
+++ b/.github/workflows/devtools-release.yml
@@ -48,6 +48,23 @@ jobs:
             extensions/build/figbird-devtools-chrome.zip
             extensions/build/figbird-devtools-firefox-unsigned.zip
             extensions/build/figbird-devtools-source.zip
+      - name: Publish the Chrome extension archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version=$(node -p "require('./extensions/version.json').version")
+          tag="devtools-v${version}"
+          asset=extensions/build/figbird-devtools-chrome.zip
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" "$asset" --clobber
+          else
+            gh release create "$tag" "$asset" \
+              --prerelease \
+              --target "$GITHUB_SHA" \
+              --title "Figbird Devtools ${version}" \
+              --notes "Browser extension builds for developer distribution. Load the Chrome ZIP unpacked in developer mode, or install the Mozilla-signed Firefox XPI."
+          fi
       - name: Sign the unlisted Firefox extension
         if: github.event_name == 'push' || inputs.sign_firefox
         env:
@@ -81,15 +98,7 @@ jobs:
 
           version=$(node -p "require('./extensions/version.json').version")
           tag="devtools-v${version}"
-          if gh release view "$tag" >/dev/null 2>&1; then
-            gh release upload "$tag" "$asset" --clobber
-          else
-            gh release create "$tag" "$asset" \
-              --prerelease \
-              --target "$GITHUB_SHA" \
-              --title "Figbird Devtools ${version}" \
-              --notes "Mozilla-signed Firefox build for self-distribution. Download the XPI in Firefox and approve the installation prompt."
-          fi
+          gh release upload "$tag" "$asset" --clobber
       - id: google-auth
         if: github.event_name == 'push' || inputs.upload_chrome || inputs.submit_chrome
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -48,9 +48,16 @@ XPI produced by Mozilla, not the unsigned ZIP. A local build cannot create that 
 and `npm run devtools:build` recreates `extensions/build`, so do not keep signed artifacts
 there permanently.
 
-The release workflow uploads the Mozilla-signed file to the matching
-`devtools-v<version>` GitHub prerelease as `figbird-devtools-firefox-signed.xpi`. That release
-asset is the stable team download; the workflow artifact is retained as a build record.
+The release workflow uploads both installable builds to the matching
+`devtools-v<version>` GitHub prerelease:
+
+- `figbird-devtools-chrome.zip`, which team members unzip and load using Chrome's
+  **Load unpacked** action.
+- `figbird-devtools-firefox-signed.xpi`, which Firefox installs directly after an
+  installation prompt.
+
+These release assets are the stable team downloads; the workflow artifacts are retained as
+build records.
 
 The shared browser extension version lives in `extensions/version.json`. See
 `extensions/RELEASING.md` for publisher setup and release instructions.

--- a/extensions/RELEASING.md
+++ b/extensions/RELEASING.md
@@ -62,8 +62,10 @@ Use `make release-extensions VERSION=0.2.0` to choose a different version.
 
 The command checks the publisher configuration and version before creating the PR. Approve and
 merge the PR to submit the Firefox extension for Mozilla signing and the private Chrome extension
-for review. The release workflow saves the signed Firefox XPI in the matching
-`devtools-v<version>` GitHub prerelease.
+for review. The release workflow saves the Chrome ZIP and signed Firefox XPI in the matching
+`devtools-v<version>` GitHub prerelease. Team members can unzip the Chrome archive and load its
+folder from `chrome://extensions` using **Developer mode → Load unpacked** while store review is
+pending.
 
 To release only one browser, open **Actions → Release browser devtools → Run workflow** on the
 default branch and select the required inputs.
@@ -72,5 +74,8 @@ default branch and select the required inputs.
   signed XPI as both a workflow artifact and a `devtools-v<version>` GitHub prerelease asset.
 - **Upload Chrome** uploads the new ZIP but leaves it in the dashboard for inspection.
 - **Submit Chrome** uploads and submits it for private-store review. It also enables **Upload Chrome** automatically.
+
+Every workflow run also saves the Chrome ZIP in the versioned GitHub prerelease, independently
+of whether the Chrome Web Store upload or submission inputs are enabled.
 
 Use upload-only for the first automated rehearsal. Use submit only after the artifact has passed local QA. Store review can outlive the workflow; check the publisher dashboard if Mozilla selects the add-on for manual review.

--- a/tasks/publish-chrome-devtools.js
+++ b/tasks/publish-chrome-devtools.js
@@ -15,9 +15,9 @@ const upload = await request(`${apiRoot}/upload/v2/${item}:upload`, {
 
 console.log(`Uploaded Chrome extension ${upload.crxVersion ?? '(processing)'}`)
 
-if (upload.uploadState === 'UPLOAD_IN_PROGRESS') {
+if (isInProgressUploadState(upload.uploadState)) {
   await waitForUpload(item)
-} else if (upload.uploadState !== 'UPLOAD_SUCCESS') {
+} else if (!isSuccessfulUploadState(upload.uploadState)) {
   throw new Error(`Chrome upload failed with state ${String(upload.uploadState)}`)
 }
 
@@ -36,12 +36,20 @@ async function waitForUpload(itemName) {
   for (let attempt = 0; attempt < 24; attempt++) {
     await new Promise(resolve => setTimeout(resolve, 5_000))
     const status = await request(`${apiRoot}/v2/${itemName}:fetchStatus`)
-    if (status.lastAsyncUploadState === 'UPLOAD_SUCCESS') return
-    if (status.lastAsyncUploadState && status.lastAsyncUploadState !== 'UPLOAD_IN_PROGRESS') {
+    if (isSuccessfulUploadState(status.lastAsyncUploadState)) return
+    if (status.lastAsyncUploadState && !isInProgressUploadState(status.lastAsyncUploadState)) {
       throw new Error(`Chrome upload failed with state ${status.lastAsyncUploadState}`)
     }
   }
   throw new Error('Chrome upload was still processing after two minutes')
+}
+
+function isSuccessfulUploadState(state) {
+  return state === 'UPLOAD_SUCCESS' || state === 'SUCCEEDED'
+}
+
+function isInProgressUploadState(state) {
+  return state === 'UPLOAD_IN_PROGRESS' || state === 'IN_PROGRESS'
 }
 
 async function request(url, init = {}) {


### PR DESCRIPTION
Chrome users currently have to wait on private-store review even though the workflow has already built an installable archive. Publish that Chrome ZIP to the versioned GitHub prerelease before either store workflow runs, giving the team a stable developer-mode installation path immediately.

The Firefox signing step now adds its signed XPI to that same pre-created release. Chrome upload polling also accepts the current API state names (`IN_PROGRESS` and `SUCCEEDED`) alongside the legacy names, preventing successful uploads from being reported as failures.

Validated with the full `npm test` suite (314 tests).