### PR TITLE
Make query definitions portable across route boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@ writes settle.
 
 Query definitions are callable factories: `definition(args)` validates and binds concrete
 inputs into an inert request, preserving a Standard Schema's input and normalized output types.
-Core methods and React hooks consume those requests directly,
-while argumentless definitions can be passed as requests themselves, so routers never need
-to know Figbird's definition or argument shape.
+Core methods and React hooks share one exported `QueryInput` contract and runtime resolution
+path for builders, bound requests, and argumentless definitions, so routers never need to
+know Figbird's definition or argument shape.
 
 Realtime handling is safer across all APIs. Fetches and overlapping refetches no
 longer overwrite newer event or mutation data, while `realtime: 'disabled'` queries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@ writes settle.
 
 Query definitions are callable factories: `definition(args)` validates and binds concrete
 inputs into an inert request, preserving a Standard Schema's input and normalized output types.
-Core methods and React hooks share one exported `QueryInput` contract and runtime resolution
-path for builders, bound requests, and argumentless definitions, so routers never need to
-know Figbird's definition or argument shape.
+Core methods and React hooks share one `QueryInput` contract and runtime resolution path for
+builders, bound requests, and argumentless definitions. The exported `AnyQueryInput<Schema>`
+erases result types at adapter boundaries, so routers never need to know Figbird's definition,
+argument, or internal builder shape.
 
 Realtime handling is safer across all APIs. Fetches and overlapping refetches no
 longer overwrite newer event or mutation data, while `realtime: 'disabled'` queries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@ Writes can use `optimisticPatch` when the local projection differs from the serv
 Relational filters apply projected changes locally, then reconcile once after the record's
 writes settle.
 
-Query definitions can bind validated args into inert requests with
-`definition.withArgs(args)`. Core methods and React hooks consume those requests directly,
-so routers can forward route data without knowing Figbird's definition or argument shape.
+Query definitions are callable factories: `definition(args)` validates and binds concrete
+inputs into an inert request. Core methods and React hooks consume those requests directly,
+while argumentless definitions can be passed as requests themselves, so routers never need
+to know Figbird's definition or argument shape.
 
 Realtime handling is safer across all APIs. Fetches and overlapping refetches no
 longer overwrite newer event or mutation data, while `realtime: 'disabled'` queries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ Relational filters apply projected changes locally, then reconcile once after th
 writes settle.
 
 Query definitions are callable factories: `definition(args)` validates and binds concrete
-inputs into an inert request. Core methods and React hooks consume those requests directly,
+inputs into an inert request, preserving a Standard Schema's input and normalized output types.
+Core methods and React hooks consume those requests directly,
 while argumentless definitions can be passed as requests themselves, so routers never need
 to know Figbird's definition or argument shape.
 
@@ -67,7 +68,7 @@ Breaking:
   relationship helpers.
 - `figbird.query(desc)` → `figbird.queryDesc(desc)`
 - `figbird.mutate(desc)` → `figbird.mutateDesc(desc)`
-- `figbird.query(builder | definition, args?)` is now the non-React mirror of `useQuery`
+- `figbird.query(builder | request)` is now the non-React mirror of `useQuery`
 - Constructor option `eventBatchProcessingInterval` renamed to `eventBatchInterval`.
 - Removed `useService` and `useMethod` — services and custom methods live on `m.<service>` handles.
 - Removed orphaned exports: the `Item`/`Create`/`Update`/`Patch`/`Query`/`Methods`/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Writes can use `optimisticPatch` when the local projection differs from the serv
 Relational filters apply projected changes locally, then reconcile once after the record's
 writes settle.
 
+Query definitions can bind validated args into inert requests with
+`definition.withArgs(args)`. Core methods and React hooks consume those requests directly,
+so routers can forward route data without knowing Figbird's definition or argument shape.
+
 Realtime handling is safer across all APIs. Fetches and overlapping refetches no
 longer overwrite newer event or mutation data, while `realtime: 'disabled'` queries
 remain fixed snapshots. When an item being viewed is removed, `useGet` and `useQuery`

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -161,7 +161,7 @@ Omitted payload types default sensibly: `Partial<item>` for create and patch, `i
 - `.orderBy('title')` — autocompletes item fields without rejecting computed ones
 - `.related('author')` — relation names come from the schema; the result type assembles automatically, nesting included
 - `m.tasks.create(...)` — payloads and return types from the service definition; declared custom `methods` appear on the handle, fully typed
-- `useQuery(definition, args)` — args typed from the definition's build function (or validated by its Standard Schema)
+- `useQuery(definition(args))` — input typed from the definition's build function or Standard Schema
 
 ## Queries
 
@@ -320,12 +320,11 @@ const { data } = useQuery(q.issues.get(id), { skip: id == null })
 // data: Issue | undefined — the type reflects that a skipped query has no data
 ```
 
-With definitions, put the condition in the args instead — `null` skips the query
-without ever invoking the definition's build function, so no non-null assertion
-is needed to satisfy the args type:
+With definitions, conditionally bind the request — `null` skips the query without
+invoking the definition's build function, so no non-null assertion is needed:
 
 ```ts
-const { data } = useQuery(issueDetail, id ? { id } : null)
+const { data } = useQuery(id ? issueDetail({ id }) : null)
 ```
 
 ### Several queries at once
@@ -803,8 +802,7 @@ non-React code, and `prepare`/`prefetch` exist as instance methods).
 A query definition is an args-keyed query factory. Call it with concrete inputs when the
 query needs to cross an integration boundary, such as a router. The result is an inert,
 instance-independent request: it contains no cache state and can be forwarded as an opaque
-value. A component can consume the request directly, or use the legacy definition-plus-args
-form; both resolve to the **same cache entry**:
+value. Every consumer accepts that same request and resolves it to the **same cache entry**:
 
 ```ts
 export const issueDetail = defineQuery(({ id }: { id: number }) =>
@@ -817,7 +815,7 @@ const request = issueDetail({ id: 42 })
 const { data } = useQuery(request)
 ```
 
-Args are typed from the build function. When args arrive from an untrusted source like URL params or storage, pass a [Standard Schema](https://github.com/standard-schema/standard-schema) validator (zod, valibot, arktype…) as the middle argument. Calling the definition validates and normalizes immediately, turning silent cache-splits (`{ id: "42" }` vs `{ id: 42 }`) into loud failures:
+Without a schema, args are typed from the build function. When args arrive from an untrusted source like URL params or storage, pass a [Standard Schema](https://github.com/standard-schema/standard-schema) validator (zod, valibot, arktype…) as the middle argument. The callable definition accepts the schema's input type and the build function receives its validated output type. Calling the definition validates and normalizes immediately, turning silent cache-splits (`{ id: "42" }` vs `{ id: 42 }`) into loud failures:
 
 ```ts
 export const issueDetail = defineQuery(
@@ -846,8 +844,8 @@ const data = {
 }
 ```
 
-Preparation is an _earlier read_, not a different one. The component may call
-`useQuery(request)` or `useQuery(issueDetail, { id })`; both converge on the same cache key.
+Preparation is an _earlier read_, not a different one. The component calls
+`useQuery(request)` and converges on the same cache key.
 
 ### prefetch
 
@@ -1182,12 +1180,12 @@ export const issueDetail = defineQuery(({ id }: { id: number }) =>
 <Row onMouseEnter={() => prefetch(issueDetail({ id }))} />
 
 // 4. The screen just reads — warm visits render synchronously, no fallback
-const { data } = useQuery(issueDetail, { id })
+const { data } = useQuery(issueDetail({ id }))
 ```
 
 Because all three paths resolve to the same builder AST hash, there is no coordination to do.
 Preparation is simply an earlier read. The router does not need to understand Figbird's
-definition, args, or request shape; its data adapter receives the request as an opaque value.
+definition, input, or request shape; its data adapter receives the request as an opaque value.
 
 ## Using outside React
 
@@ -1205,8 +1203,8 @@ ref.getSnapshot()
 ref.refetch()
 unsub()
 
-// Definitions work too — same cache entry as useQuery(issueDetail, { id })
-figbird.query(issueDetail, { id: 42 })
+// Bound requests share the same cache entry as useQuery(issueDetail({ id: 42 }))
+figbird.query(issueDetail({ id: 42 }))
 
 // Writes — the m proxy works outside React too (it's not a hook anywhere)
 await figbird.m.tasks.patch(id, { done: true }) // optimistic by default
@@ -1382,7 +1380,7 @@ inline in render needs no dependency arrays. Also available as `figbird.q`.
 ```ts
 // Suspense (default)
 const { data, error, isFetching, refetch } = useQuery(builder)
-const { data } = useQuery(definition, args)
+const { data } = useQuery(definition(args))
 
 // Paginated builders widen the result
 const { data, loadMore, hasMore, isLoadingMore, loadMoreError, total } = useQuery(
@@ -1527,25 +1525,23 @@ const request = definition(args)
 Args-keyed query factory. A pure value, not tied to an instance. Calling it validates and
 normalizes concrete args into an inert `QueryRequest`, also independent of an instance.
 `query`, `prepare`, `prefetch`, `explain`, `useQuery`, and `useQueries` accept that request.
-Legacy definition-plus-args calls remain supported and share the same cache entry.
+Argumentless definitions can be passed directly without first creating a request.
 The `createHooks` kit returns a schema-typed version; the standalone export from
 `'figbird'` serves non-React code. See [Preparation](#preparation).
 
 ## figbird.prepare
 
 ```ts
-const { key, promise, release } = figbird.prepare(definition, args, { staleTime? })
 const { key, promise, release } = figbird.prepare(definition(args), { staleTime? })
 ```
 
-Starts a query and returns an awaitable lease, the router-grade primitive. `args` may be
-omitted when the definition's build function takes none. See [prepare](#prepare).
+Starts a query and returns an awaitable lease, the router-grade primitive. Argumentless
+definitions can be passed directly. See [prepare](#prepare).
 
 ## figbird.prefetch
 
 ```ts
-figbird.prefetch(definition, args, { staleTime? }) // staleTime defaults to 30s
-figbird.prefetch(definition(args), { staleTime? })
+figbird.prefetch(definition(args), { staleTime? }) // staleTime defaults to 30s
 ```
 
 Idempotent, fire-and-forget speculative warming with a self-releasing pin. See
@@ -1660,8 +1656,8 @@ const figbird = new Figbird({
 | Member                                            | Description                                                                                                                                                 |
 | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `q`                                               | The builder proxy — `q.issues.where(...)`. Requires a schema.                                                                                               |
-| `prepare(request, opts?)`                         | Awaitable query lease for routers. Also accepts the legacy `(definition, args, opts?)` form. See [figbird.prepare](#figbirdprepare).                                     |
-| `prefetch(request, opts?)`                        | Idempotent speculative warming. Also accepts the legacy `(definition, args, opts?)` form. See [figbird.prefetch](#figbirdprefetch).                                      |
+| `prepare(request, opts?)`                         | Awaitable query lease for routers. Argumentless definitions can be passed directly. See [figbird.prepare](#figbirdprepare).                                     |
+| `prefetch(request, opts?)`                        | Idempotent speculative warming. Argumentless definitions can be passed directly. See [figbird.prefetch](#figbirdprefetch).                                      |
 | `refetch(service?)`                               | Manual refetch escape hatch for changes Figbird can’t observe, such as custom methods without events or out-of-band writes. Call `figbird.refetch(...)`.                  |
 | `m`                                               | The instance’s write proxy: `figbird.m.issues.patch(...)`, or `figbird.m(service)` for dynamic names. In React, access the provider instance through `useMutations()`. See [m](#m). |
 | `createMutationQueue(config?)`                    | Explicitly owned serial writes across records or services. See [figbird.createMutationQueue](#figbirdcreatemutationqueue).                                |
@@ -1669,7 +1665,7 @@ const figbird = new Figbird({
 | `explain(...)`                                    | Static classification report — see [figbird.explain](#figbirdexplain).                                                                                      |
 | `inspect()`                                       | Live-query snapshot — see [figbird.inspect](#figbirdinspect).                                                                                               |
 | `events`                                          | Observability channel — see [figbird.events](#figbirdevents).                                                                                               |
-| `query(builder)`                                  | Live query ref for non-React use — the `useQuery` mirror; also accepts a bound request or `(definition, args)`. See [Using outside React](#using-outside-react).               |
+| `query(builder)`                                  | Live query ref for non-React use — the `useQuery` mirror; also accepts a bound request or argumentless definition. See [Using outside React](#using-outside-react).               |
 | `queryDesc(desc, config?)`                        | Descriptor-layer query — no schema required.                                                                                                                |
 | `mutateDesc(desc)` / `call(service, method, ...)` | Descriptor-layer mutation / custom-method call.                                                                                                             |
 | `getState()` / `subscribeToStateChanges(fn)`      | Raw internal state, including the cached entities themselves (`inspect()` omits items). Debug-grade — shapes may change between versions.                   |
@@ -1768,7 +1764,7 @@ for QA and packaging details.
 ## figbird.explain
 
 ```ts
-figbird.explain(builderOrDefinition, args?)
+figbird.explain(builderOrRequest)
 // → { nodes: [{ path, service, kind, class, reasons, realtime, via? }] }
 ```
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1526,6 +1526,8 @@ Args-keyed query factory. A pure value, not tied to an instance. Calling it vali
 normalizes concrete args into an inert `QueryRequest`, also independent of an instance.
 `query`, `prepare`, `prefetch`, `explain`, `useQuery`, and `useQueries` accept that request.
 Argumentless definitions can be passed directly without first creating a request.
+These three forms share the exported `QueryInput` type, which adapter packages can use
+without reproducing Figbird's input union.
 The `createHooks` kit returns a schema-typed version; the standalone export from
 `'figbird'` serves non-React code. See [Preparation](#preparation).
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -792,32 +792,32 @@ names always mean the built-in: a schema method named `create`/`update`/`patch`/
 
 ## Preparation
 
-Four pieces make preparation work: `defineQuery` declares an args-keyed query; `withArgs`
-binds route inputs into an inert request; `prepare` starts it early with an explicit lease;
+Three pieces make preparation work: `defineQuery` creates a callable factory that binds
+route inputs into an inert request; `prepare` starts it early with an explicit lease;
 `prefetch` warms it speculatively. These APIs come
 from your `createHooks` kit (a standalone `defineQuery` is also exported from `'figbird'` for
 non-React code, and `prepare`/`prefetch` exist as instance methods).
 
 ### defineQuery
 
-A query definition is an args-keyed query factory. Bind concrete inputs with `withArgs()`
-when the query needs to cross an integration boundary, such as a router. The result is an
-inert, instance-independent request: it contains no cache state and can be forwarded as an
-opaque value. A component can consume the request directly, or use the legacy
-definition-plus-args form; both resolve to the **same cache entry**:
+A query definition is an args-keyed query factory. Call it with concrete inputs when the
+query needs to cross an integration boundary, such as a router. The result is an inert,
+instance-independent request: it contains no cache state and can be forwarded as an opaque
+value. A component can consume the request directly, or use the legacy definition-plus-args
+form; both resolve to the **same cache entry**:
 
 ```ts
 export const issueDetail = defineQuery(({ id }: { id: number }) =>
   q.issues.get(id).related('creator').related('comments'),
 )
 
-const request = issueDetail.withArgs({ id: 42 })
+const request = issueDetail({ id: 42 })
 
 // component
 const { data } = useQuery(request)
 ```
 
-Args are typed from the build function. When args arrive from an untrusted source like URL params or storage, pass a [Standard Schema](https://github.com/standard-schema/standard-schema) validator (zod, valibot, arktype…) as the middle argument. `withArgs()` validates and normalizes immediately, turning silent cache-splits (`{ id: "42" }` vs `{ id: 42 }`) into loud failures:
+Args are typed from the build function. When args arrive from an untrusted source like URL params or storage, pass a [Standard Schema](https://github.com/standard-schema/standard-schema) validator (zod, valibot, arktype…) as the middle argument. Calling the definition validates and normalizes immediately, turning silent cache-splits (`{ id: "42" }` vs `{ id: 42 }`) into loud failures:
 
 ```ts
 export const issueDetail = defineQuery(
@@ -825,7 +825,7 @@ export const issueDetail = defineQuery(
   ({ id }) => q.issues.get(id).related('comments'),
 )
 
-const request = issueDetail.withArgs({ id: '42' }) // coerces "42" → 42 now
+const request = issueDetail({ id: '42' }) // coerces "42" → 42 now
 prepare(request)
 ```
 
@@ -835,7 +835,10 @@ prepare(request)
 
 ```ts
 // The router only carries opaque requests. Its data adapter decides how to prepare them.
-queries: ({ params }) => [issueDetail.withArgs({ id: Number(params.id) })]
+queries: ({ params }) => [issueDetail({ id: Number(params.id) })]
+
+// Argumentless definitions need no route resolver and are forwarded as-is.
+queries: [customFieldsQuery, rolesQuery]
 
 const data = {
   prepare: request => figbird.prepare(request),
@@ -851,13 +854,13 @@ Preparation is an _earlier read_, not a different one. The component may call
 `prefetch()` is the idempotent, fire-and-forget sibling of `prepare()`, built for "the user will probably need this" moments like hover or viewport entry:
 
 ```tsx
-<Row onMouseEnter={() => prefetch(issueDetail.withArgs({ id: issue.id }))} />
+<Row onMouseEnter={() => prefetch(issueDetail({ id: issue.id }))} />
 ```
 
 Safe to call at any frequency: if the query was prefetched within `staleTime` (default 30s) it's a no-op. Otherwise it fetches and holds an internal pin that auto-releases after `staleTime`. The data stays cached either way, so a later `useQuery` gets a warm, synchronous read with no Suspense fallback. If the user clicks through, the component's own subscription takes over seamlessly.
 
 ```ts
-prefetch(issueDetail.withArgs({ id }), { staleTime: 60_000 })
+prefetch(issueDetail({ id }), { staleTime: 60_000 })
 ```
 
 Rule of thumb: `prepare()` when you need to _await_ readiness or control the lease; `prefetch()` when you just want things warm.
@@ -1172,11 +1175,11 @@ export const issueDetail = defineQuery(({ id }: { id: number }) =>
 {
   path: '/issues/:id',
   resolver: () => import('./pages/IssueDetail/screen'),
-  queries: ({ params }) => [issueDetail.withArgs({ id: Number(params.id) })],
+  queries: ({ params }) => [issueDetail({ id: Number(params.id) })],
 }
 
 // 3. Hover starts the same queries even earlier — clicking is then a warm read
-<Row onMouseEnter={() => prefetch(issueDetail.withArgs({ id }))} />
+<Row onMouseEnter={() => prefetch(issueDetail({ id }))} />
 
 // 4. The screen just reads — warm visits render synchronously, no fallback
 const { data } = useQuery(issueDetail, { id })
@@ -1518,11 +1521,11 @@ defineQuery(argsSchema, build) // Standard Schema-validated args
 defineQuery(name, build) // optional name — labels errors and devtools, never identity
 defineQuery(name, argsSchema, build)
 
-const request = definition.withArgs(args)
+const request = definition(args)
 ```
 
-Args-keyed query factory. A pure value, not tied to an instance. `withArgs()` validates
-and normalizes concrete args into an inert `QueryRequest`, also independent of an instance.
+Args-keyed query factory. A pure value, not tied to an instance. Calling it validates and
+normalizes concrete args into an inert `QueryRequest`, also independent of an instance.
 `query`, `prepare`, `prefetch`, `explain`, `useQuery`, and `useQueries` accept that request.
 Legacy definition-plus-args calls remain supported and share the same cache entry.
 The `createHooks` kit returns a schema-typed version; the standalone export from
@@ -1532,7 +1535,7 @@ The `createHooks` kit returns a schema-typed version; the standalone export from
 
 ```ts
 const { key, promise, release } = figbird.prepare(definition, args, { staleTime? })
-const { key, promise, release } = figbird.prepare(definition.withArgs(args), { staleTime? })
+const { key, promise, release } = figbird.prepare(definition(args), { staleTime? })
 ```
 
 Starts a query and returns an awaitable lease, the router-grade primitive. `args` may be
@@ -1542,7 +1545,7 @@ omitted when the definition's build function takes none. See [prepare](#prepare)
 
 ```ts
 figbird.prefetch(definition, args, { staleTime? }) // staleTime defaults to 30s
-figbird.prefetch(definition.withArgs(args), { staleTime? })
+figbird.prefetch(definition(args), { staleTime? })
 ```
 
 Idempotent, fire-and-forget speculative warming with a self-releasing pin. See

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -839,8 +839,8 @@ queries: ({ params }) => [issueDetail({ id: Number(params.id) })]
 queries: [customFieldsQuery, rolesQuery]
 
 const data = {
-  prepare: request => figbird.prepare(request),
-  prefetch: request => figbird.prefetch(request),
+  prepare: (request: AnyQueryInput<typeof schema>) => figbird.prepare(request),
+  prefetch: (request: AnyQueryInput<typeof schema>) => figbird.prefetch(request),
 }
 ```
 
@@ -1526,8 +1526,9 @@ Args-keyed query factory. A pure value, not tied to an instance. Calling it vali
 normalizes concrete args into an inert `QueryRequest`, also independent of an instance.
 `query`, `prepare`, `prefetch`, `explain`, `useQuery`, and `useQueries` accept that request.
 Argumentless definitions can be passed directly without first creating a request.
-These three forms share the exported `QueryInput` type, which adapter packages can use
-without reproducing Figbird's input union.
+These three forms share the generic `QueryInput` contract. Adapter packages can use
+`AnyQueryInput<Schema>` to erase the result type at their integration boundary without
+reproducing Figbird's input union or importing internal builder types.
 The `createHooks` kit returns a schema-typed version; the standalone export from
 `'figbird'` serves non-React code. See [Preparation](#preparation).
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -792,25 +792,32 @@ names always mean the built-in: a schema method named `create`/`update`/`patch`/
 
 ## Preparation
 
-Three pieces make preparation work: `defineQuery` gives a query a stable, args-keyed identity;
-`prepare` starts it early with an explicit lease; `prefetch` warms it speculatively. All three come
+Four pieces make preparation work: `defineQuery` declares an args-keyed query; `withArgs`
+binds route inputs into an inert request; `prepare` starts it early with an explicit lease;
+`prefetch` warms it speculatively. These APIs come
 from your `createHooks` kit (a standalone `defineQuery` is also exported from `'figbird'` for
 non-React code, and `prepare`/`prefetch` exist as instance methods).
 
 ### defineQuery
 
-A named query is an args-keyed query factory. The same definition read from a component, prepared by a router, or prefetched on hover resolves to the **same cache entry**:
+A query definition is an args-keyed query factory. Bind concrete inputs with `withArgs()`
+when the query needs to cross an integration boundary, such as a router. The result is an
+inert, instance-independent request: it contains no cache state and can be forwarded as an
+opaque value. A component can consume the request directly, or use the legacy
+definition-plus-args form; both resolve to the **same cache entry**:
 
 ```ts
 export const issueDetail = defineQuery(({ id }: { id: number }) =>
   q.issues.get(id).related('creator').related('comments'),
 )
 
+const request = issueDetail.withArgs({ id: 42 })
+
 // component
-const { data } = useQuery(issueDetail, { id: 42 })
+const { data } = useQuery(request)
 ```
 
-Args are typed from the build function. When args arrive from an untrusted source like URL params or storage, pass a [Standard Schema](https://github.com/standard-schema/standard-schema) validator (zod, valibot, arktype…) as the middle argument. It runs at every call site and throws `QueryArgsError` on bad input, turning silent cache-splits (`{ id: "42" }` vs `{ id: 42 }`) into loud failures:
+Args are typed from the build function. When args arrive from an untrusted source like URL params or storage, pass a [Standard Schema](https://github.com/standard-schema/standard-schema) validator (zod, valibot, arktype…) as the middle argument. `withArgs()` validates and normalizes immediately, turning silent cache-splits (`{ id: "42" }` vs `{ id: 42 }`) into loud failures:
 
 ```ts
 export const issueDetail = defineQuery(
@@ -818,7 +825,8 @@ export const issueDetail = defineQuery(
   ({ id }) => q.issues.get(id).related('comments'),
 )
 
-prepare(issueDetail, { id: '42' }) // coerces "42" → 42 before building
+const request = issueDetail.withArgs({ id: '42' }) // coerces "42" → 42 now
+prepare(request)
 ```
 
 ### prepare
@@ -826,28 +834,30 @@ prepare(issueDetail, { id: '42' }) // coerces "42" → 42 before building
 `prepare()` is the router's primitive: it starts a query and returns an explicit lease, with a `promise` that resolves when the data is ready and a `release()` to drop the pin keeping it alive. Routers await route-critical data before committing a navigation; the destination screen then reads the same cache entry synchronously:
 
 ```ts
-// route definition — the `prepare:` key is the router's convention; the calls inside
-// are Figbird's prepare(). Metadata like `priority` belongs to the router, not Figbird.
-prepare: ({ params }) => [
-  { ...prepare(issueDetail, { id: Number(params.id) }), priority: 'route' },
-  { ...prepare(issueComments, { id: Number(params.id) }), priority: 'defer' },
-]
+// The router only carries opaque requests. Its data adapter decides how to prepare them.
+queries: ({ params }) => [issueDetail.withArgs({ id: Number(params.id) })]
+
+const data = {
+  prepare: request => figbird.prepare(request),
+  prefetch: request => figbird.prefetch(request),
+}
 ```
 
-Preparation is an _earlier read_, not a different one. The component still calls `useQuery(issueDetail, { id })`.
+Preparation is an _earlier read_, not a different one. The component may call
+`useQuery(request)` or `useQuery(issueDetail, { id })`; both converge on the same cache key.
 
 ### prefetch
 
 `prefetch()` is the idempotent, fire-and-forget sibling of `prepare()`, built for "the user will probably need this" moments like hover or viewport entry:
 
 ```tsx
-<Row onMouseEnter={() => prefetch(issueDetail, { id: issue.id })} />
+<Row onMouseEnter={() => prefetch(issueDetail.withArgs({ id: issue.id }))} />
 ```
 
 Safe to call at any frequency: if the query was prefetched within `staleTime` (default 30s) it's a no-op. Otherwise it fetches and holds an internal pin that auto-releases after `staleTime`. The data stays cached either way, so a later `useQuery` gets a warm, synchronous read with no Suspense fallback. If the user clicks through, the component's own subscription takes over seamlessly.
 
 ```ts
-prefetch(issueDetail, { id }, { staleTime: 60_000 })
+prefetch(issueDetail.withArgs({ id }), { staleTime: 60_000 })
 ```
 
 Rule of thumb: `prepare()` when you need to _await_ readiness or control the lease; `prefetch()` when you just want things warm.
@@ -1152,7 +1162,7 @@ One more pattern from the same family: when navigating between details of the sa
 The pattern that makes navigations feel instant is starting everything the destination needs, data _and_ code, before the screen renders, in parallel:
 
 ```ts
-// 1. Named queries live in an eagerly-loaded module
+// 1. Query definitions live in an eagerly-loaded module
 export const issueDetail = defineQuery(({ id }: { id: number }) =>
   q.issues.get(id).related('creator').related('labels'),
 )
@@ -1162,17 +1172,19 @@ export const issueDetail = defineQuery(({ id }: { id: number }) =>
 {
   path: '/issues/:id',
   resolver: () => import('./pages/IssueDetail/screen'),
-  prepare: ({ params }) => [prepare(issueDetail, { id: Number(params.id) })],
+  queries: ({ params }) => [issueDetail.withArgs({ id: Number(params.id) })],
 }
 
 // 3. Hover starts the same queries even earlier — clicking is then a warm read
-<Row onMouseEnter={() => prefetch(issueDetail, { id })} />
+<Row onMouseEnter={() => prefetch(issueDetail.withArgs({ id }))} />
 
 // 4. The screen just reads — warm visits render synchronously, no fallback
 const { data } = useQuery(issueDetail, { id })
 ```
 
-Because all three paths resolve to the same cache entry (the definition + args hash), there is no coordination to do. Preparation is simply an earlier read.
+Because all three paths resolve to the same builder AST hash, there is no coordination to do.
+Preparation is simply an earlier read. The router does not need to understand Figbird's
+definition, args, or request shape; its data adapter receives the request as an opaque value.
 
 ## Using outside React
 
@@ -1505,10 +1517,14 @@ defineQuery(build)
 defineQuery(argsSchema, build) // Standard Schema-validated args
 defineQuery(name, build) // optional name — labels errors and devtools, never identity
 defineQuery(name, argsSchema, build)
+
+const request = definition.withArgs(args)
 ```
 
-Args-keyed query factory. A pure value, not tied to an instance; `prepare`,
-`prefetch`, and `useQuery` against the same definition and args share one cache entry.
+Args-keyed query factory. A pure value, not tied to an instance. `withArgs()` validates
+and normalizes concrete args into an inert `QueryRequest`, also independent of an instance.
+`query`, `prepare`, `prefetch`, `explain`, `useQuery`, and `useQueries` accept that request.
+Legacy definition-plus-args calls remain supported and share the same cache entry.
 The `createHooks` kit returns a schema-typed version; the standalone export from
 `'figbird'` serves non-React code. See [Preparation](#preparation).
 
@@ -1516,6 +1532,7 @@ The `createHooks` kit returns a schema-typed version; the standalone export from
 
 ```ts
 const { key, promise, release } = figbird.prepare(definition, args, { staleTime? })
+const { key, promise, release } = figbird.prepare(definition.withArgs(args), { staleTime? })
 ```
 
 Starts a query and returns an awaitable lease, the router-grade primitive. `args` may be
@@ -1525,6 +1542,7 @@ omitted when the definition's build function takes none. See [prepare](#prepare)
 
 ```ts
 figbird.prefetch(definition, args, { staleTime? }) // staleTime defaults to 30s
+figbird.prefetch(definition.withArgs(args), { staleTime? })
 ```
 
 Idempotent, fire-and-forget speculative warming with a self-releasing pin. See
@@ -1639,8 +1657,8 @@ const figbird = new Figbird({
 | Member                                            | Description                                                                                                                                                 |
 | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `q`                                               | The builder proxy — `q.issues.where(...)`. Requires a schema.                                                                                               |
-| `prepare(definition, args)`                       | Awaitable query lease for routers. Call it on the explicit instance: `figbird.prepare(...)`. See [figbird.prepare](#figbirdprepare).                                     |
-| `prefetch(definition, args, opts?)`               | Idempotent speculative warming. Call it on the explicit instance: `figbird.prefetch(...)`. See [figbird.prefetch](#figbirdprefetch).                                      |
+| `prepare(request, opts?)`                         | Awaitable query lease for routers. Also accepts the legacy `(definition, args, opts?)` form. See [figbird.prepare](#figbirdprepare).                                     |
+| `prefetch(request, opts?)`                        | Idempotent speculative warming. Also accepts the legacy `(definition, args, opts?)` form. See [figbird.prefetch](#figbirdprefetch).                                      |
 | `refetch(service?)`                               | Manual refetch escape hatch for changes Figbird can’t observe, such as custom methods without events or out-of-band writes. Call `figbird.refetch(...)`.                  |
 | `m`                                               | The instance’s write proxy: `figbird.m.issues.patch(...)`, or `figbird.m(service)` for dynamic names. In React, access the provider instance through `useMutations()`. See [m](#m). |
 | `createMutationQueue(config?)`                    | Explicitly owned serial writes across records or services. See [figbird.createMutationQueue](#figbirdcreatemutationqueue).                                |
@@ -1648,7 +1666,7 @@ const figbird = new Figbird({
 | `explain(...)`                                    | Static classification report — see [figbird.explain](#figbirdexplain).                                                                                      |
 | `inspect()`                                       | Live-query snapshot — see [figbird.inspect](#figbirdinspect).                                                                                               |
 | `events`                                          | Observability channel — see [figbird.events](#figbirdevents).                                                                                               |
-| `query(builder)`                                  | Live query ref for non-React use — the `useQuery` mirror; also accepts `(definition, args)`. See [Using outside React](#using-outside-react).               |
+| `query(builder)`                                  | Live query ref for non-React use — the `useQuery` mirror; also accepts a bound request or `(definition, args)`. See [Using outside React](#using-outside-react).               |
 | `queryDesc(desc, config?)`                        | Descriptor-layer query — no schema required.                                                                                                                |
 | `mutateDesc(desc)` / `call(service, method, ...)` | Descriptor-layer mutation / custom-method call.                                                                                                             |
 | `getState()` / `subscribeToStateChanges(fn)`      | Raw internal state, including the cached entities themselves (`inspect()` omits items). Debug-grade — shapes may change between versions.                   |

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -476,7 +476,7 @@ export class Figbird<
     )
     // query() owns definition resolution (validate → build → intern), so the
     // "definition + args collapses to one cache entry" contract lives in one place.
-    return this.#prepareRequest(query.withArgs(args), options)
+    return this.#prepareRequest(query(args), options)
   }
 
   #prepareRequest(
@@ -542,7 +542,7 @@ export class Figbird<
       argsOrOptions,
       maybeOptions,
     )
-    this.#prefetchRequest(query.withArgs(args), options)
+    this.#prefetchRequest(query(args), options)
   }
 
   #prefetchRequest(

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -27,10 +27,12 @@ import {
 } from './queryBuilder.js'
 import {
   isQueryDefinition,
+  isQueryRequest,
   splitDefinitionRest,
   type ArgsAndOptions,
   type PreparedQuery,
   type QueryDefinition,
+  type QueryRequest,
 } from './queryDefinition.js'
 import { explainQuery, type ExplainReport, type QueryNodeClass } from './queryClassification.js'
 export type { ExplainNode, ExplainReport } from './queryClassification.js'
@@ -117,7 +119,9 @@ export type { InFlightMutation, MutationActivity } from './mutationTracker.js'
 export {
   defineQuery,
   isQueryDefinition,
+  isQueryRequest,
   QUERY_DEFINITION_BRAND,
+  QUERY_REQUEST_BRAND,
   QueryArgsError,
   splitDefinitionRest,
   validateQueryArgs,
@@ -128,6 +132,7 @@ export type {
   DefineQuery,
   PreparedQuery,
   QueryDefinition,
+  QueryRequest,
   StandardSchemaV1,
 } from './queryDefinition.js'
 export { RelationalQueryRef } from './relationalQuery.js'
@@ -310,7 +315,7 @@ export class Figbird<
 
   /**
    * Materialize a query and return its live reference — the non-React mirror of
-   * `useQuery`. Accepts a builder, or a definition plus args. The returned
+   * `useQuery`. Accepts a builder, a bound request, or a definition plus args. The returned
    * RelationalQueryRef manages sub-queries and assembles related data.
    *
    * @example
@@ -356,9 +361,18 @@ export class Figbird<
     AdapterFindMeta<A>,
     AdapterQuery<A>
   >
+  query<Args, B extends AnyQueryBuilder<S>>(
+    request: QueryRequest<Args, B>,
+  ): RelationalQueryRef<
+    QueryBuilderResult<B>,
+    S,
+    AdapterParams<A>,
+    AdapterFindMeta<A>,
+    AdapterQuery<A>
+  >
   query<B extends AnyQueryBuilder<S>>(
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-    queryOrBuilder: B | QueryDefinition<unknown, B>,
+    queryOrBuilder: B | QueryDefinition<unknown, B> | QueryRequest<unknown, B>,
     args?: unknown,
   ): RelationalQueryRef<
     QueryBuilderResult<B>,
@@ -374,10 +388,17 @@ export class Figbird<
           'Pass schema to Figbird constructor: new Figbird({ schema, adapter })',
       )
     }
-    const definition = isQueryDefinition(queryOrBuilder) ? queryOrBuilder : null
-    const builder: B = definition
-      ? definition.build(definition.validate(args))
-      : (queryOrBuilder as B)
+    const request = isQueryRequest(queryOrBuilder) ? queryOrBuilder : null
+    const definition = request
+      ? request.definition
+      : isQueryDefinition(queryOrBuilder)
+        ? queryOrBuilder
+        : null
+    const builder: B = request
+      ? request.definition.build(request.args)
+      : definition
+        ? definition.build(definition.validate(args))
+        : (queryOrBuilder as B)
     if (!queryBuilderUsesSchema(builder, this.schema)) {
       throw new Error('The query builder uses a different schema from this Figbird instance')
     }
@@ -436,11 +457,18 @@ export class Figbird<
     query: QueryDefinition<Args, B>,
     ...rest: ArgsAndOptions<Args, { staleTime?: number }>
   ): PreparedQuery
+  prepare<Args, B extends AnyQueryBuilder<S>>(
+    request: QueryRequest<Args, B>,
+    options?: { staleTime?: number },
+  ): PreparedQuery
   prepare(
-    query: QueryDefinition<unknown, AnyQueryBuilder<S>>,
+    query: QueryDefinition<unknown, AnyQueryBuilder<S>> | QueryRequest<unknown, AnyQueryBuilder<S>>,
     argsOrOptions?: unknown,
     maybeOptions?: { staleTime?: number },
   ): PreparedQuery {
+    if (isQueryRequest(query)) {
+      return this.#prepareRequest(query, argsOrOptions as { staleTime?: number } | undefined)
+    }
     const { args, options } = splitDefinitionRest<{ staleTime?: number }>(
       query,
       argsOrOptions,
@@ -448,7 +476,14 @@ export class Figbird<
     )
     // query() owns definition resolution (validate → build → intern), so the
     // "definition + args collapses to one cache entry" contract lives in one place.
-    const ref = this.query(query, args as never)
+    return this.#prepareRequest(query.withArgs(args), options)
+  }
+
+  #prepareRequest(
+    request: QueryRequest<unknown, AnyQueryBuilder<S>>,
+    options?: { staleTime?: number },
+  ): PreparedQuery {
+    const ref = this.query(request)
     // No-op listener — purely a pin. The promise drives readiness; release() drops the pin.
     // While pinned, subsequent useQuery subscribers join the same ref. When everyone has
     // released and unsubscribed, RelationalQueryRef cleans up and evicts the cache entry.
@@ -489,18 +524,33 @@ export class Figbird<
     query: QueryDefinition<Args, B>,
     ...rest: ArgsAndOptions<Args, { staleTime?: number }>
   ): void
+  prefetch<Args, B extends AnyQueryBuilder<S>>(
+    request: QueryRequest<Args, B>,
+    options?: { staleTime?: number },
+  ): void
   prefetch(
-    query: QueryDefinition<unknown, AnyQueryBuilder<S>>,
+    query: QueryDefinition<unknown, AnyQueryBuilder<S>> | QueryRequest<unknown, AnyQueryBuilder<S>>,
     argsOrOptions?: unknown,
     maybeOptions?: { staleTime?: number },
   ): void {
+    if (isQueryRequest(query)) {
+      this.#prefetchRequest(query, argsOrOptions as { staleTime?: number } | undefined)
+      return
+    }
     const { args, options } = splitDefinitionRest<{ staleTime?: number }>(
       query,
       argsOrOptions,
       maybeOptions,
     )
+    this.#prefetchRequest(query.withArgs(args), options)
+  }
+
+  #prefetchRequest(
+    request: QueryRequest<unknown, AnyQueryBuilder<S>>,
+    options?: { staleTime?: number },
+  ): void {
     const staleTime = options?.staleTime ?? 30_000
-    const ref = this.query(query, args as never)
+    const ref = this.query(request)
     const hash = ref.hash()
 
     const now = Date.now()
@@ -857,19 +907,25 @@ export class Figbird<
    * assert a query's class in tests, or to power devtools.
    */
   explain<B extends AnyQueryBuilder<S>>(builder: B): ExplainReport
+  explain<Args, B extends AnyQueryBuilder<S>>(request: QueryRequest<Args, B>): ExplainReport
   explain<Args>(
     query: QueryDefinition<Args, AnyQueryBuilder<S>>,
     ...rest: ArgsAndOptions<Args, never>
   ): ExplainReport
   explain(
-    queryOrBuilder: AnyQueryBuilder<S> | QueryDefinition<unknown, AnyQueryBuilder<S>>,
+    queryOrBuilder:
+      | AnyQueryBuilder<S>
+      | QueryDefinition<unknown, AnyQueryBuilder<S>>
+      | QueryRequest<unknown, AnyQueryBuilder<S>>,
     args?: unknown,
   ): ExplainReport {
     // Resolved without interning — explain never materializes a query. The walk
     // itself lives in queryClassification.ts, next to the plans it reports on.
-    const builder = isQueryDefinition(queryOrBuilder)
-      ? queryOrBuilder.build(queryOrBuilder.validate(args))
-      : queryOrBuilder
+    const builder = isQueryRequest(queryOrBuilder)
+      ? queryOrBuilder.definition.build(queryOrBuilder.args)
+      : isQueryDefinition(queryOrBuilder)
+        ? queryOrBuilder.build(queryOrBuilder.validate(args))
+        : queryOrBuilder
     const nodes = explainQuery(
       builder.toAST(),
       this.schema?.relationships,

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -125,6 +125,14 @@ export type {
   QueryRequest,
   StandardSchemaV1,
 } from './queryDefinition.js'
+
+/**
+ * Query input with its result type intentionally erased for integration boundaries
+ * such as router data adapters. Use `QueryInput<B, Args>` when preserving a specific
+ * builder's result type matters.
+ */
+export type AnyQueryInput<S extends Schema = AnySchema> = QueryInput<AnyQueryBuilder<S>>
+
 export { RelationalQueryRef } from './relationalQuery.js'
 export type { RelationalPaginationState, RelationalQueryState } from './relationalQuery.js'
 

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -28,8 +28,6 @@ import {
 import {
   isQueryDefinition,
   isQueryRequest,
-  splitDefinitionRest,
-  type ArgsAndOptions,
   type PreparedQuery,
   type QueryDefinition,
   type QueryRequest,
@@ -123,12 +121,9 @@ export {
   QUERY_DEFINITION_BRAND,
   QUERY_REQUEST_BRAND,
   QueryArgsError,
-  splitDefinitionRest,
   validateQueryArgs,
 } from './queryDefinition.js'
 export type {
-  ArgsAndOptions,
-  ArgsAndRequiredOptions,
   DefineQuery,
   PreparedQuery,
   QueryDefinition,
@@ -315,7 +310,7 @@ export class Figbird<
 
   /**
    * Materialize a query and return its live reference — the non-React mirror of
-   * `useQuery`. Accepts a builder, a bound request, or a definition plus args. The returned
+   * `useQuery`. Accepts a builder, a bound request, or an argumentless definition. The returned
    * RelationalQueryRef manages sub-queries and assembles related data.
    *
    * @example
@@ -338,31 +333,12 @@ export class Figbird<
    * // Refetch
    * qRef.refetch()
    *
-   * // Definition form — same cache entry as useQuery(issueDetail, { id })
-   * const ref = figbird.query(issueDetail, { id: 42 })
+   * // Bound request form — same cache entry as useQuery(issueDetail({ id: 42 }))
+   * const ref = figbird.query(issueDetail({ id: 42 }))
    * ```
    */
-  query<B extends AnyQueryBuilder<S>>(
-    builder: B,
-  ): RelationalQueryRef<
-    QueryBuilderResult<B>,
-    S,
-    AdapterParams<A>,
-    AdapterFindMeta<A>,
-    AdapterQuery<A>
-  >
   query<Args, B extends AnyQueryBuilder<S>>(
-    query: QueryDefinition<Args, B>,
-    ...rest: ArgsAndOptions<Args, never>
-  ): RelationalQueryRef<
-    QueryBuilderResult<B>,
-    S,
-    AdapterParams<A>,
-    AdapterFindMeta<A>,
-    AdapterQuery<A>
-  >
-  query<Args, B extends AnyQueryBuilder<S>>(
-    request: QueryRequest<Args, B>,
+    queryOrBuilder: B | QueryRequest<Args, B> | QueryDefinition<void, B, void>,
   ): RelationalQueryRef<
     QueryBuilderResult<B>,
     S,
@@ -372,8 +348,7 @@ export class Figbird<
   >
   query<B extends AnyQueryBuilder<S>>(
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-    queryOrBuilder: B | QueryDefinition<unknown, B> | QueryRequest<unknown, B>,
-    args?: unknown,
+    queryOrBuilder: B | QueryDefinition<void, B, void> | QueryRequest<unknown, B>,
   ): RelationalQueryRef<
     QueryBuilderResult<B>,
     S,
@@ -389,15 +364,10 @@ export class Figbird<
       )
     }
     const request = isQueryRequest(queryOrBuilder) ? queryOrBuilder : null
-    const definition = request
-      ? request.definition
-      : isQueryDefinition(queryOrBuilder)
-        ? queryOrBuilder
-        : null
     const builder: B = request
       ? request.definition.build(request.args)
-      : definition
-        ? definition.build(definition.validate(args))
+      : isQueryDefinition(queryOrBuilder)
+        ? queryOrBuilder.build(queryOrBuilder.validate(undefined))
         : (queryOrBuilder as B)
     if (!queryBuilderUsesSchema(builder, this.schema)) {
       throw new Error('The query builder uses a different schema from this Figbird instance')
@@ -427,18 +397,20 @@ export class Figbird<
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any
       this.#relationalQueryCache.set(hash, ref as RelationalQueryRef<any, S, any, any, any>)
     }
+    const definition =
+      request?.definition ?? (isQueryDefinition(queryOrBuilder) ? queryOrBuilder : null)
     ref.setDisplayName(definition?.name)
     return ref
   }
 
   /**
    * Pre-warm a query before any component reads it. Returns a `PreparedQuery` handle whose
-   * `promise` resolves when the same `useQuery(query, args)` would have data ready and
+   * `promise` resolves when the same `useQuery(request)` would have data ready and
    * rejects with the error a Suspense read would throw. Holds the cache entry alive until
    * `release()` is called or the underlying ref's last subscriber unmounts.
    *
    * Designed for router preparation, hover prefetch, and parents that can see child needs
-   * earlier than the child itself. The component still reads via `useQuery(query, args)` —
+   * earlier than the child itself. The component still reads via `useQuery(request)` —
    * preparation is an earlier read, not a different read.
    *
    * @example
@@ -448,42 +420,21 @@ export class Figbird<
    *   path: '/issues/:id',
    *   resolver: () => import('./pages/IssueDetail/screen'),
    *   prepare: ({ figbird, params }) => [
-   *     { ...figbird.prepare(issueDetail, { id: Number(params.id) }), priority: 'route' },
+   *     { ...figbird.prepare(issueDetail({ id: Number(params.id) })), priority: 'route' },
    *   ],
    * })
    * ```
    */
   prepare<Args, B extends AnyQueryBuilder<S>>(
-    query: QueryDefinition<Args, B>,
-    ...rest: ArgsAndOptions<Args, { staleTime?: number }>
-  ): PreparedQuery
-  prepare<Args, B extends AnyQueryBuilder<S>>(
-    request: QueryRequest<Args, B>,
+    request: QueryRequest<Args, B> | QueryDefinition<void, B, void>,
     options?: { staleTime?: number },
   ): PreparedQuery
   prepare(
-    query: QueryDefinition<unknown, AnyQueryBuilder<S>> | QueryRequest<unknown, AnyQueryBuilder<S>>,
-    argsOrOptions?: unknown,
-    maybeOptions?: { staleTime?: number },
-  ): PreparedQuery {
-    if (isQueryRequest(query)) {
-      return this.#prepareRequest(query, argsOrOptions as { staleTime?: number } | undefined)
-    }
-    const { args, options } = splitDefinitionRest<{ staleTime?: number }>(
-      query,
-      argsOrOptions,
-      maybeOptions,
-    )
-    // query() owns definition resolution (validate → build → intern), so the
-    // "definition + args collapses to one cache entry" contract lives in one place.
-    return this.#prepareRequest(query(args), options)
-  }
-
-  #prepareRequest(
-    request: QueryRequest<unknown, AnyQueryBuilder<S>>,
+    query:
+      QueryDefinition<void, AnyQueryBuilder<S>, void> | QueryRequest<unknown, AnyQueryBuilder<S>>,
     options?: { staleTime?: number },
   ): PreparedQuery {
-    const ref = this.query(request)
+    const ref = this.query(query)
     // No-op listener — purely a pin. The promise drives readiness; release() drops the pin.
     // While pinned, subsequent useQuery subscribers join the same ref. When everyone has
     // released and unsubscribed, RelationalQueryRef cleans up and evicts the cache entry.
@@ -517,40 +468,20 @@ export class Figbird<
    *
    * @example
    * ```ts
-   * <Row onMouseEnter={() => figbird.prefetch(issueDetail, { id: issue.id })} />
+   * <Row onMouseEnter={() => figbird.prefetch(issueDetail({ id: issue.id }))} />
    * ```
    */
   prefetch<Args, B extends AnyQueryBuilder<S>>(
-    query: QueryDefinition<Args, B>,
-    ...rest: ArgsAndOptions<Args, { staleTime?: number }>
-  ): void
-  prefetch<Args, B extends AnyQueryBuilder<S>>(
-    request: QueryRequest<Args, B>,
+    request: QueryRequest<Args, B> | QueryDefinition<void, B, void>,
     options?: { staleTime?: number },
   ): void
   prefetch(
-    query: QueryDefinition<unknown, AnyQueryBuilder<S>> | QueryRequest<unknown, AnyQueryBuilder<S>>,
-    argsOrOptions?: unknown,
-    maybeOptions?: { staleTime?: number },
-  ): void {
-    if (isQueryRequest(query)) {
-      this.#prefetchRequest(query, argsOrOptions as { staleTime?: number } | undefined)
-      return
-    }
-    const { args, options } = splitDefinitionRest<{ staleTime?: number }>(
-      query,
-      argsOrOptions,
-      maybeOptions,
-    )
-    this.#prefetchRequest(query(args), options)
-  }
-
-  #prefetchRequest(
-    request: QueryRequest<unknown, AnyQueryBuilder<S>>,
+    query:
+      QueryDefinition<void, AnyQueryBuilder<S>, void> | QueryRequest<unknown, AnyQueryBuilder<S>>,
     options?: { staleTime?: number },
   ): void {
+    const ref = this.query(query)
     const staleTime = options?.staleTime ?? 30_000
-    const ref = this.query(request)
     const hash = ref.hash()
 
     const now = Date.now()
@@ -906,25 +837,21 @@ export class Figbird<
    * Use it to answer "why did adding `.limit(30)` change realtime behavior", to
    * assert a query's class in tests, or to power devtools.
    */
-  explain<B extends AnyQueryBuilder<S>>(builder: B): ExplainReport
-  explain<Args, B extends AnyQueryBuilder<S>>(request: QueryRequest<Args, B>): ExplainReport
-  explain<Args>(
-    query: QueryDefinition<Args, AnyQueryBuilder<S>>,
-    ...rest: ArgsAndOptions<Args, never>
+  explain<Args, B extends AnyQueryBuilder<S>>(
+    query: B | QueryRequest<Args, B> | QueryDefinition<void, B, void>,
   ): ExplainReport
   explain(
     queryOrBuilder:
       | AnyQueryBuilder<S>
-      | QueryDefinition<unknown, AnyQueryBuilder<S>>
+      | QueryDefinition<void, AnyQueryBuilder<S>, void>
       | QueryRequest<unknown, AnyQueryBuilder<S>>,
-    args?: unknown,
   ): ExplainReport {
     // Resolved without interning — explain never materializes a query. The walk
     // itself lives in queryClassification.ts, next to the plans it reports on.
     const builder = isQueryRequest(queryOrBuilder)
       ? queryOrBuilder.definition.build(queryOrBuilder.args)
       : isQueryDefinition(queryOrBuilder)
-        ? queryOrBuilder.build(queryOrBuilder.validate(args))
+        ? queryOrBuilder.build(queryOrBuilder.validate(undefined))
         : queryOrBuilder
     const nodes = explainQuery(
       builder.toAST(),

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -25,13 +25,7 @@ import {
   type QueryBuilderProxy,
   type QueryBuilderResult,
 } from './queryBuilder.js'
-import {
-  isQueryDefinition,
-  isQueryRequest,
-  type PreparedQuery,
-  type QueryDefinition,
-  type QueryRequest,
-} from './queryDefinition.js'
+import { resolveQueryInput, type PreparedQuery, type QueryInput } from './queryDefinition.js'
 import { explainQuery, type ExplainReport, type QueryNodeClass } from './queryClassification.js'
 export type { ExplainNode, ExplainReport } from './queryClassification.js'
 import { QueryRef } from './queryRef.js'
@@ -127,6 +121,7 @@ export type {
   DefineQuery,
   PreparedQuery,
   QueryDefinition,
+  QueryInput,
   QueryRequest,
   StandardSchemaV1,
 } from './queryDefinition.js'
@@ -338,17 +333,7 @@ export class Figbird<
    * ```
    */
   query<Args, B extends AnyQueryBuilder<S>>(
-    queryOrBuilder: B | QueryRequest<Args, B> | QueryDefinition<void, B, void>,
-  ): RelationalQueryRef<
-    QueryBuilderResult<B>,
-    S,
-    AdapterParams<A>,
-    AdapterFindMeta<A>,
-    AdapterQuery<A>
-  >
-  query<B extends AnyQueryBuilder<S>>(
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-    queryOrBuilder: B | QueryDefinition<void, B, void> | QueryRequest<unknown, B>,
+    queryOrBuilder: QueryInput<B, Args>,
   ): RelationalQueryRef<
     QueryBuilderResult<B>,
     S,
@@ -363,12 +348,7 @@ export class Figbird<
           'Pass schema to Figbird constructor: new Figbird({ schema, adapter })',
       )
     }
-    const request = isQueryRequest(queryOrBuilder) ? queryOrBuilder : null
-    const builder: B = request
-      ? request.definition.build(request.args)
-      : isQueryDefinition(queryOrBuilder)
-        ? queryOrBuilder.build(queryOrBuilder.validate(undefined))
-        : (queryOrBuilder as B)
+    const { builder, name } = resolveQueryInput(queryOrBuilder)
     if (!queryBuilderUsesSchema(builder, this.schema)) {
       throw new Error('The query builder uses a different schema from this Figbird instance')
     }
@@ -397,9 +377,7 @@ export class Figbird<
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any
       this.#relationalQueryCache.set(hash, ref as RelationalQueryRef<any, S, any, any, any>)
     }
-    const definition =
-      request?.definition ?? (isQueryDefinition(queryOrBuilder) ? queryOrBuilder : null)
-    ref.setDisplayName(definition?.name)
+    ref.setDisplayName(name)
     return ref
   }
 
@@ -426,12 +404,7 @@ export class Figbird<
    * ```
    */
   prepare<Args, B extends AnyQueryBuilder<S>>(
-    request: QueryRequest<Args, B> | QueryDefinition<void, B, void>,
-    options?: { staleTime?: number },
-  ): PreparedQuery
-  prepare(
-    query:
-      QueryDefinition<void, AnyQueryBuilder<S>, void> | QueryRequest<unknown, AnyQueryBuilder<S>>,
+    query: QueryInput<B, Args>,
     options?: { staleTime?: number },
   ): PreparedQuery {
     const ref = this.query(query)
@@ -472,12 +445,7 @@ export class Figbird<
    * ```
    */
   prefetch<Args, B extends AnyQueryBuilder<S>>(
-    request: QueryRequest<Args, B> | QueryDefinition<void, B, void>,
-    options?: { staleTime?: number },
-  ): void
-  prefetch(
-    query:
-      QueryDefinition<void, AnyQueryBuilder<S>, void> | QueryRequest<unknown, AnyQueryBuilder<S>>,
+    query: QueryInput<B, Args>,
     options?: { staleTime?: number },
   ): void {
     const ref = this.query(query)
@@ -837,22 +805,10 @@ export class Figbird<
    * Use it to answer "why did adding `.limit(30)` change realtime behavior", to
    * assert a query's class in tests, or to power devtools.
    */
-  explain<Args, B extends AnyQueryBuilder<S>>(
-    query: B | QueryRequest<Args, B> | QueryDefinition<void, B, void>,
-  ): ExplainReport
-  explain(
-    queryOrBuilder:
-      | AnyQueryBuilder<S>
-      | QueryDefinition<void, AnyQueryBuilder<S>, void>
-      | QueryRequest<unknown, AnyQueryBuilder<S>>,
-  ): ExplainReport {
+  explain<Args, B extends AnyQueryBuilder<S>>(queryOrBuilder: QueryInput<B, Args>): ExplainReport {
     // Resolved without interning — explain never materializes a query. The walk
     // itself lives in queryClassification.ts, next to the plans it reports on.
-    const builder = isQueryRequest(queryOrBuilder)
-      ? queryOrBuilder.definition.build(queryOrBuilder.args)
-      : isQueryDefinition(queryOrBuilder)
-        ? queryOrBuilder.build(queryOrBuilder.validate(undefined))
-        : queryOrBuilder
+    const { builder } = resolveQueryInput(queryOrBuilder)
     const nodes = explainQuery(
       builder.toAST(),
       this.schema?.relationships,

--- a/lib/core/queryDefinition.ts
+++ b/lib/core/queryDefinition.ts
@@ -12,30 +12,7 @@
 export const QUERY_DEFINITION_BRAND: unique symbol = Symbol.for('figbird.queryDefinition')
 export const QUERY_REQUEST_BRAND: unique symbol = Symbol.for('figbird.queryRequest')
 
-/**
- * A concrete query definition with validated, normalized arguments. Requests are
- * inert and instance-independent, so routers can carry them as opaque route data.
- */
-export interface QueryRequest<Args, B> {
-  readonly [QUERY_REQUEST_BRAND]: true
-  readonly definition: QueryDefinition<Args, B>
-  readonly args: Args
-}
-
-/**
- * An args-keyed query factory produced by `defineQuery`. Definitions are inert — they
- * hold no cache state and no instance dependency. The cache key is derived from the
- * underlying builder's AST hash, which means `prepare(def(args))` and
- * `useQuery(def, args)` collapse to the same `RelationalQueryRef`.
- *
- * Calling the definition validates at the binding site and returns an inert request.
- * Legacy definition-plus-args calls validate when consumed. Validation throws
- * `QueryArgsError` on failure; on success the (possibly normalized) value feeds into
- * `build`, so the cache key reflects normalized args rather than raw input.
- */
-export interface QueryDefinition<Args, B> {
-  /** Validate and bind args into an inert request accepted by query consumers. */
-  (args: Args): QueryRequest<Args, B>
+interface QueryDefinitionCore<Args, B> {
   readonly [QUERY_DEFINITION_BRAND]: true
   /** Optional label for errors/devtools — empty string when unnamed. Never identity. */
   readonly name: string
@@ -44,49 +21,40 @@ export interface QueryDefinition<Args, B> {
 }
 
 /**
- * Trailing parameters for definition-consuming APIs (`prepare`, `prefetch`,
- * `useQuery`): `args` is required when the definition's build function declares them;
- * zero-arg definitions (`QueryDefinition<void, B>`) skip the args slot entirely, so
- * options come second-positionally — `useQuery(def, { suspense: false })`, no middle
- * `undefined`.
+ * A concrete query definition with validated, normalized arguments. Requests are
+ * inert and instance-independent, so routers can carry them as opaque route data.
  */
-export type ArgsAndOptions<Args, Options> = [Args] extends [void]
-  ? [options?: Options]
-  : [args: Args, options?: Options]
+export interface QueryRequest<Args, B> {
+  readonly [QUERY_REQUEST_BRAND]: true
+  /** The originating definition's input is already bound and therefore hidden. */
+  readonly definition: QueryDefinitionCore<Args, B>
+  readonly args: Args
+}
 
 /**
- * Like `ArgsAndOptions`, but the options are required — used by overloads that
- * discriminate on an option literal (e.g. `{ suspense: false }`).
+ * An args-keyed query factory produced by `defineQuery`. Definitions are inert — they
+ * hold no cache state and no instance dependency. The cache key is derived from the
+ * underlying builder's AST hash, which means `prepare(def(args))` and
+ * `useQuery(def(args))` collapse to the same `RelationalQueryRef`.
+ *
+ * Calling the definition validates at the binding site and returns an inert request.
+ * Validation throws `QueryArgsError` on failure; on success the (possibly normalized)
+ * value feeds into `build`, so the cache key reflects normalized args rather than raw input.
  */
-export type ArgsAndRequiredOptions<Args, Options> = [Args] extends [void]
-  ? [options: Options]
-  : [args: Args, options: Options]
-
-/**
- * Runtime companion to `ArgsAndOptions`: split a definition call's trailing values
- * into args and options. A definition whose build function declares no parameters
- * takes options in the first slot; the legacy `(undefined, options)` spelling is
- * tolerated. @internal
- */
-export function splitDefinitionRest<Options>(
-  definition: QueryDefinition<unknown, unknown>,
-  first: unknown,
-  second: unknown,
-): { args: unknown; options: Options | undefined } {
-  if (definition.build.length === 0) {
-    return { args: undefined, options: (first ?? second) as Options | undefined }
-  }
-  return { args: first, options: second as Options | undefined }
+export interface QueryDefinition<Args, B, Input = Args> extends QueryDefinitionCore<Args, B> {
+  /** Validate and bind args into an inert request accepted by query consumers. */
+  (args: Input): QueryRequest<Args, B>
 }
 
 /**
  * Type guard for `QueryDefinition`. Useful in router prepare resolvers and overloaded
  * hook signatures that accept either a definition or a builder.
  */
-export function isQueryDefinition(value: unknown): value is QueryDefinition<unknown, unknown> {
+export function isQueryDefinition(
+  value: unknown,
+): value is QueryDefinition<unknown, unknown, never> {
   return (
-    (typeof value === 'object' || typeof value === 'function') &&
-    value !== null &&
+    typeof value === 'function' &&
     (value as { [QUERY_DEFINITION_BRAND]?: unknown })[QUERY_DEFINITION_BRAND] === true
   )
 }
@@ -119,7 +87,7 @@ export interface StandardSchemaV1<Input = unknown, Output = Input> {
   }
 }
 
-// Companion namespace — `import type` consumers can read InferOutput / Result / Issue.
+// Companion namespace — `import type` consumers can read InferInput / InferOutput / Result / Issue.
 // oxlint-disable-next-line @typescript-eslint/no-namespace
 export namespace StandardSchemaV1 {
   export interface Issue {
@@ -134,13 +102,15 @@ export namespace StandardSchemaV1 {
     readonly issues: ReadonlyArray<Issue>
   }
   export type Result<Output> = SuccessResult<Output> | FailureResult
+  export type InferInput<S extends StandardSchemaV1> =
+    S extends StandardSchemaV1<infer Input, unknown> ? Input : never
   export type InferOutput<S extends StandardSchemaV1> =
     S extends StandardSchemaV1<unknown, infer Output> ? Output : never
 }
 
 /**
- * Thrown when a `QueryDefinition`'s `argsSchema` rejects the args passed to
- * `figbird.prepare(def, args)` or `useQuery(def, args)`. Surfaces the definition name
+ * Thrown when a `QueryDefinition`'s `argsSchema` rejects the input passed to the
+ * callable definition. Surfaces the definition name
  * (so error reporting tells you *which* query was misconfigured) plus the raw issues
  * the validator produced.
  *
@@ -177,7 +147,7 @@ function formatStandardSchemaIssues(issues: ReadonlyArray<StandardSchemaV1.Issue
 /**
  * Run a Standard Schema's `validate` synchronously against `args`. Returns the
  * validated/normalized value, or throws `QueryArgsError` on failure or async result.
- * Internal helper — `prepare` and `useQuery` (definition + args overload) call it.
+ * Internal helper used when a callable definition binds its input into a request.
  */
 export function validateQueryArgs<T>(
   queryName: string,
@@ -209,14 +179,14 @@ export interface DefineQuery<TBuilder = unknown> {
   <TSchema extends StandardSchemaV1, B extends TBuilder>(
     argsSchema: TSchema,
     build: (args: StandardSchemaV1.InferOutput<TSchema>) => B,
-  ): QueryDefinition<StandardSchemaV1.InferOutput<TSchema>, B>
+  ): QueryDefinition<StandardSchemaV1.InferOutput<TSchema>, B, StandardSchemaV1.InferInput<TSchema>>
   <B extends TBuilder>(name: string, build: () => B): QueryDefinition<void, B>
   <Args, B extends TBuilder>(name: string, build: (args: Args) => B): QueryDefinition<Args, B>
   <TSchema extends StandardSchemaV1, B extends TBuilder>(
     name: string,
     argsSchema: TSchema,
     build: (args: StandardSchemaV1.InferOutput<TSchema>) => B,
-  ): QueryDefinition<StandardSchemaV1.InferOutput<TSchema>, B>
+  ): QueryDefinition<StandardSchemaV1.InferOutput<TSchema>, B, StandardSchemaV1.InferInput<TSchema>>
 }
 
 /**
@@ -226,16 +196,16 @@ export interface DefineQuery<TBuilder = unknown> {
  * `createHooks(schema)` in app code; this standalone export serves core-only and
  * non-React consumers.
  *
- * Args are typed from the build function. Pass a Standard Schema validator before the
- * build function when args arrive from untrusted sources (URL params, storage) — it
- * runs when the definition binds a request, or at legacy definition-plus-args call
- * sites, and throws `QueryArgsError`.
+ * Without a schema, args are typed from the build function. With a Standard Schema,
+ * the callable definition accepts its input type, while the build function receives
+ * its validated output type. Validation runs when the definition binds a request and
+ * throws `QueryArgsError`.
  *
  * The name is optional metadata, never identity (identity is the AST hash): it labels
  * `QueryArgsError` messages and devtools. Skip it unless you want those labels.
  *
- * A zero-param build produces a `QueryDefinition<void, B>`, whose consumers
- * (`prepare`, `prefetch`, `useQuery`) may omit the `args` argument entirely.
+ * A zero-param build produces a `QueryDefinition<void, B>` that consumers can use
+ * directly without first binding a request.
  */
 export const defineQuery: DefineQuery = ((
   a: string | StandardSchemaV1 | ((args: unknown) => unknown),
@@ -254,7 +224,7 @@ export const defineQuery: DefineQuery = ((
     [QUERY_REQUEST_BRAND]: true,
     definition,
     args: validate(args),
-  })) as QueryDefinition<unknown, unknown>
+  })) as unknown as QueryDefinition<unknown, unknown>
   Object.defineProperties(definition, {
     [QUERY_DEFINITION_BRAND]: { value: true },
     name: { value: name, configurable: true },
@@ -265,13 +235,13 @@ export const defineQuery: DefineQuery = ((
 }) as DefineQuery
 
 /**
- * Handle returned by `figbird.prepare(definition, args)` — an explicit lease on a
+ * Handle returned by `figbird.prepare(definition(args))` — an explicit lease on a
  * query. `promise` resolves when the data is ready (rejects with what a Suspense read
  * would throw); `release()` drops the pin that keeps the underlying ref alive — when
  * no other subscriber remains, the ref tears down and the cache entry is evicted.
  *
  * Routers commonly attach their own metadata (e.g. a blocking/deferred priority) by
- * spreading: `{ ...figbird.prepare(def, args), priority: 'route' }` — that vocabulary
+ * spreading: `{ ...figbird.prepare(def(args)), priority: 'route' }` — that vocabulary
  * belongs to the router, not to figbird.
  */
 export interface PreparedQuery {

--- a/lib/core/queryDefinition.ts
+++ b/lib/core/queryDefinition.ts
@@ -25,22 +25,22 @@ export interface QueryRequest<Args, B> {
 /**
  * An args-keyed query factory produced by `defineQuery`. Definitions are inert — they
  * hold no cache state and no instance dependency. The cache key is derived from the
- * underlying builder's AST hash, which means `prepare(def.withArgs(args))` and
+ * underlying builder's AST hash, which means `prepare(def(args))` and
  * `useQuery(def, args)` collapse to the same `RelationalQueryRef`.
  *
- * `withArgs` validates at the binding site. Legacy definition-plus-args calls validate
- * when consumed. Validation throws `QueryArgsError` on failure; on success the
- * (possibly normalized) value feeds into `build`, so the cache key reflects normalized
- * args rather than raw input.
+ * Calling the definition validates at the binding site and returns an inert request.
+ * Legacy definition-plus-args calls validate when consumed. Validation throws
+ * `QueryArgsError` on failure; on success the (possibly normalized) value feeds into
+ * `build`, so the cache key reflects normalized args rather than raw input.
  */
 export interface QueryDefinition<Args, B> {
+  /** Validate and bind args into an inert request accepted by query consumers. */
+  (args: Args): QueryRequest<Args, B>
   readonly [QUERY_DEFINITION_BRAND]: true
   /** Optional label for errors/devtools — empty string when unnamed. Never identity. */
   readonly name: string
   build(args: Args): B
   validate(args: unknown): Args
-  /** Validate and bind args into an inert request accepted anywhere the definition is. */
-  withArgs(args: Args): QueryRequest<Args, B>
 }
 
 /**
@@ -85,13 +85,13 @@ export function splitDefinitionRest<Options>(
  */
 export function isQueryDefinition(value: unknown): value is QueryDefinition<unknown, unknown> {
   return (
-    typeof value === 'object' &&
+    (typeof value === 'object' || typeof value === 'function') &&
     value !== null &&
     (value as { [QUERY_DEFINITION_BRAND]?: unknown })[QUERY_DEFINITION_BRAND] === true
   )
 }
 
-/** Type guard for a concrete query produced by `definition.withArgs(args)`. */
+/** Type guard for a concrete query produced by calling a query definition. */
 export function isQueryRequest(value: unknown): value is QueryRequest<unknown, unknown> {
   return (
     typeof value === 'object' &&
@@ -228,8 +228,8 @@ export interface DefineQuery<TBuilder = unknown> {
  *
  * Args are typed from the build function. Pass a Standard Schema validator before the
  * build function when args arrive from untrusted sources (URL params, storage) — it
- * runs when `withArgs()` binds a request, or at legacy definition-plus-args call sites,
- * and throws `QueryArgsError`.
+ * runs when the definition binds a request, or at legacy definition-plus-args call
+ * sites, and throws `QueryArgsError`.
  *
  * The name is optional metadata, never identity (identity is the AST hash): it labels
  * `QueryArgsError` messages and devtools. Skip it unless you want those labels.
@@ -246,21 +246,21 @@ export const defineQuery: DefineQuery = ((
   const [x, y] = typeof a === 'string' ? [b, c] : [a, b]
   const argsSchema = y ? (x as StandardSchemaV1) : null
   const build = (y ?? x) as (args: unknown) => unknown
-  const definition: QueryDefinition<unknown, unknown> = {
-    [QUERY_DEFINITION_BRAND]: true,
-    name,
-    build,
-    validate: argsSchema
-      ? (args: unknown) => validateQueryArgs(name || '(anonymous)', argsSchema, args)
-      : (args: unknown) => args,
-    withArgs(args: unknown) {
-      return {
-        [QUERY_REQUEST_BRAND]: true,
-        definition,
-        args: definition.validate(args),
-      }
-    },
-  }
+  const validate = argsSchema
+    ? (args: unknown) => validateQueryArgs(name || '(anonymous)', argsSchema, args)
+    : (args: unknown) => args
+  let definition: QueryDefinition<unknown, unknown>
+  definition = ((args: unknown) => ({
+    [QUERY_REQUEST_BRAND]: true,
+    definition,
+    args: validate(args),
+  })) as QueryDefinition<unknown, unknown>
+  Object.defineProperties(definition, {
+    [QUERY_DEFINITION_BRAND]: { value: true },
+    name: { value: name, configurable: true },
+    build: { value: build },
+    validate: { value: validate },
+  })
   return definition
 }) as DefineQuery
 

--- a/lib/core/queryDefinition.ts
+++ b/lib/core/queryDefinition.ts
@@ -47,6 +47,22 @@ export interface QueryDefinition<Args, B, Input = Args> extends QueryDefinitionC
 }
 
 /**
+ * Every query shape accepted by Figbird's read APIs: a builder, a bound request,
+ * or an argumentless definition. Adapter packages can depend on this contract
+ * without reproducing Figbird's input union.
+ */
+export type QueryInput<B, Args = unknown> =
+  B | QueryRequest<Args, B> | QueryDefinition<void, B, void>
+
+/** Extract the underlying builder from any supported query input. */
+export type QueryInputBuilder<T> =
+  T extends QueryRequest<unknown, infer B>
+    ? B
+    : T extends QueryDefinition<void, infer B, void>
+      ? B
+      : T
+
+/**
  * Type guard for `QueryDefinition`. Useful in router prepare resolvers and overloaded
  * hook signatures that accept either a definition or a builder.
  */
@@ -66,6 +82,32 @@ export function isQueryRequest(value: unknown): value is QueryRequest<unknown, u
     value !== null &&
     (value as { [QUERY_REQUEST_BRAND]?: unknown })[QUERY_REQUEST_BRAND] === true
   )
+}
+
+interface ResolvedQueryInput<B> {
+  builder: B
+  name: string | undefined
+}
+
+/** Resolve every public query input through one runtime path. @internal */
+export function resolveQueryInput<Args, B>(input: QueryInput<B, Args>): ResolvedQueryInput<B> {
+  if (isQueryRequest(input)) {
+    // The runtime brand proves the shape; retain the caller's generic builder and args.
+    const request = input as QueryRequest<Args, B>
+    return {
+      builder: request.definition.build(request.args),
+      name: request.definition.name,
+    }
+  }
+  if (isQueryDefinition(input)) {
+    // Only argumentless definitions are members of QueryInput.
+    const definition = input as QueryDefinition<void, B, void>
+    return {
+      builder: definition.build(definition.validate(undefined)),
+      name: definition.name,
+    }
+  }
+  return { builder: input as B, name: undefined }
 }
 
 /**

--- a/lib/core/queryDefinition.ts
+++ b/lib/core/queryDefinition.ts
@@ -10,17 +10,28 @@
  * without depending on the constructor surface.
  */
 export const QUERY_DEFINITION_BRAND: unique symbol = Symbol.for('figbird.queryDefinition')
+export const QUERY_REQUEST_BRAND: unique symbol = Symbol.for('figbird.queryRequest')
+
+/**
+ * A concrete query definition with validated, normalized arguments. Requests are
+ * inert and instance-independent, so routers can carry them as opaque route data.
+ */
+export interface QueryRequest<Args, B> {
+  readonly [QUERY_REQUEST_BRAND]: true
+  readonly definition: QueryDefinition<Args, B>
+  readonly args: Args
+}
 
 /**
  * An args-keyed query factory produced by `defineQuery`. Definitions are inert — they
  * hold no cache state and no instance dependency. The cache key is derived from the
- * underlying builder's AST hash, which means `prepare(def, args)` and `useQuery(def, args)`
- * collapse to the same `RelationalQueryRef`.
+ * underlying builder's AST hash, which means `prepare(def.withArgs(args))` and
+ * `useQuery(def, args)` collapse to the same `RelationalQueryRef`.
  *
- * `prepare` and `useQuery` run `validate` at the call site before invoking `build`.
- * Validation throws `QueryArgsError` on failure; on success the (possibly normalized)
- * value returned by `validate` is what feeds into `build`, so the cache key reflects
- * the normalized args rather than the raw input.
+ * `withArgs` validates at the binding site. Legacy definition-plus-args calls validate
+ * when consumed. Validation throws `QueryArgsError` on failure; on success the
+ * (possibly normalized) value feeds into `build`, so the cache key reflects normalized
+ * args rather than raw input.
  */
 export interface QueryDefinition<Args, B> {
   readonly [QUERY_DEFINITION_BRAND]: true
@@ -28,6 +39,8 @@ export interface QueryDefinition<Args, B> {
   readonly name: string
   build(args: Args): B
   validate(args: unknown): Args
+  /** Validate and bind args into an inert request accepted anywhere the definition is. */
+  withArgs(args: Args): QueryRequest<Args, B>
 }
 
 /**
@@ -75,6 +88,15 @@ export function isQueryDefinition(value: unknown): value is QueryDefinition<unkn
     typeof value === 'object' &&
     value !== null &&
     (value as { [QUERY_DEFINITION_BRAND]?: unknown })[QUERY_DEFINITION_BRAND] === true
+  )
+}
+
+/** Type guard for a concrete query produced by `definition.withArgs(args)`. */
+export function isQueryRequest(value: unknown): value is QueryRequest<unknown, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { [QUERY_REQUEST_BRAND]?: unknown })[QUERY_REQUEST_BRAND] === true
   )
 }
 
@@ -206,7 +228,8 @@ export interface DefineQuery<TBuilder = unknown> {
  *
  * Args are typed from the build function. Pass a Standard Schema validator before the
  * build function when args arrive from untrusted sources (URL params, storage) — it
- * runs at every `prepare()`/`useQuery()` call site and throws `QueryArgsError`.
+ * runs when `withArgs()` binds a request, or at legacy definition-plus-args call sites,
+ * and throws `QueryArgsError`.
  *
  * The name is optional metadata, never identity (identity is the AST hash): it labels
  * `QueryArgsError` messages and devtools. Skip it unless you want those labels.
@@ -223,14 +246,22 @@ export const defineQuery: DefineQuery = ((
   const [x, y] = typeof a === 'string' ? [b, c] : [a, b]
   const argsSchema = y ? (x as StandardSchemaV1) : null
   const build = (y ?? x) as (args: unknown) => unknown
-  return {
+  const definition: QueryDefinition<unknown, unknown> = {
     [QUERY_DEFINITION_BRAND]: true,
     name,
     build,
     validate: argsSchema
       ? (args: unknown) => validateQueryArgs(name || '(anonymous)', argsSchema, args)
       : (args: unknown) => args,
+    withArgs(args: unknown) {
+      return {
+        [QUERY_REQUEST_BRAND]: true,
+        definition,
+        args: definition.validate(args),
+      }
+    },
   }
+  return definition
 }) as DefineQuery
 
 /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,7 +15,6 @@ export {
 } from './core/figbird.js'
 
 export type {
-  ArgsAndOptions,
   CreateMutationOptions,
   DefineQuery,
   EventType,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -38,6 +38,7 @@ export type {
   MutationsProxy,
   PreparedQuery,
   QueryDefinition,
+  QueryInput,
   QueryRequest,
   ReconnectJitter,
   RetryDelay,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,6 +15,7 @@ export {
 } from './core/figbird.js'
 
 export type {
+  AnyQueryInput,
   CreateMutationOptions,
   DefineQuery,
   EventType,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,12 +4,14 @@ export {
   Figbird,
   defineQuery,
   QUERY_DEFINITION_BRAND,
+  QUERY_REQUEST_BRAND,
   QueryArgsError,
   isFetching,
   isIdle,
   isLoading,
   isPending,
   isQueryDefinition,
+  isQueryRequest,
 } from './core/figbird.js'
 
 export type {
@@ -37,6 +39,7 @@ export type {
   MutationsProxy,
   PreparedQuery,
   QueryDefinition,
+  QueryRequest,
   ReconnectJitter,
   RetryDelay,
   StandardSchemaV1,

--- a/lib/react/useQueries.ts
+++ b/lib/react/useQueries.ts
@@ -42,10 +42,15 @@ export interface UseQueriesOptions {
   staleTime?: number
 }
 
-type QueryInput<S extends Schema> = AnyQueryBuilder<S> | QueryRequest<unknown, AnyQueryBuilder<S>>
+type QueryInput<S extends Schema> =
+  | AnyQueryBuilder<S>
+  // A heterogeneous tuple needs to erase each request's args while retaining its builder.
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  | QueryRequest<any, AnyQueryBuilder<S>>
 
 type QueryInputBuilder<T> =
-  T extends QueryRequest<unknown, infer B> ? B : T extends AnyQueryBuilder ? T : never
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends QueryRequest<any, infer B> ? B : T extends AnyQueryBuilder ? T : never
 
 /**
  * The `useQueries` call surface — declared once and shared by the root export

--- a/lib/react/useQueries.ts
+++ b/lib/react/useQueries.ts
@@ -24,7 +24,7 @@
  */
 
 import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react'
-import type { RelationalQueryState } from '../core/figbird.js'
+import { isQueryRequest, type QueryRequest, type RelationalQueryState } from '../core/figbird.js'
 import { suspensePromiseAll } from '../core/relationalQuery.js'
 import type { AnyQueryBuilder, QueryBuilderKind, QueryBuilderResult } from '../core/queryBuilder.js'
 import type { Schema } from '../core/schema.js'
@@ -42,6 +42,11 @@ export interface UseQueriesOptions {
   staleTime?: number
 }
 
+type QueryInput<S extends Schema> = AnyQueryBuilder<S> | QueryRequest<unknown, AnyQueryBuilder<S>>
+
+type QueryInputBuilder<T> =
+  T extends QueryRequest<unknown, infer B> ? B : T extends AnyQueryBuilder ? T : never
+
 /**
  * The `useQueries` call surface — declared once and shared by the root export
  * (schema-agnostic) and the `createHooks` kit (bound to a schema), like `UseQueryHook`.
@@ -56,10 +61,15 @@ export interface UseQueriesOptions {
  */
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 export interface UseQueriesHook<S extends Schema = any> {
-  <Bs extends readonly AnyQueryBuilder<S>[]>(
-    queries: readonly [...Bs],
+  <Queries extends readonly QueryInput<S>[]>(
+    queries: readonly [...Queries],
     options?: UseQueriesOptions,
-  ): { [K in keyof Bs]: SuspenseQueryResult<QueryBuilderResult<Bs[K]>, QueryBuilderKind<Bs[K]>> }
+  ): {
+    [K in keyof Queries]: SuspenseQueryResult<
+      QueryBuilderResult<QueryInputBuilder<Queries[K]>>,
+      QueryBuilderKind<QueryInputBuilder<Queries[K]>>
+    >
+  }
 }
 
 /**
@@ -73,7 +83,7 @@ export interface UseQueriesHook<S extends Schema = any> {
  * data. See `UseQueriesHook` for the per-element contract.
  */
 export const useQueries: UseQueriesHook = ((
-  queries: readonly AnyQueryBuilder[],
+  queries: readonly QueryInput<Schema>[],
   options?: UseQueriesOptions,
 ): unknown => useQueriesImpl(useFigbird(), queries, options)) as UseQueriesHook
 
@@ -82,7 +92,7 @@ export const useQueries: UseQueriesHook = ((
  */
 export function useQueriesImpl(
   figbird: FigbirdLike,
-  queries: readonly AnyQueryBuilder[],
+  queries: readonly QueryInput<Schema>[],
   options: UseQueriesOptions = {},
 ): unknown {
   const { staleTime } = options
@@ -93,7 +103,9 @@ export function useQueriesImpl(
   // its identity element-wise: the subscription and snapshot cache key off actual
   // ref changes, and an evicted-then-re-interned ref is a new instance that
   // correctly busts the pin.
-  const refs = useStableArray(queries.map(query => figbird.query(query)))
+  const refs = useStableArray(
+    queries.map(query => (isQueryRequest(query) ? figbird.query(query) : figbird.query(query))),
+  )
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {

--- a/lib/react/useQueries.ts
+++ b/lib/react/useQueries.ts
@@ -24,7 +24,8 @@
  */
 
 import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react'
-import type { QueryDefinition, QueryRequest, RelationalQueryState } from '../core/figbird.js'
+import type { RelationalQueryState } from '../core/figbird.js'
+import type { QueryInput, QueryInputBuilder } from '../core/queryDefinition.js'
 import { suspensePromiseAll } from '../core/relationalQuery.js'
 import type { AnyQueryBuilder, QueryBuilderKind, QueryBuilderResult } from '../core/queryBuilder.js'
 import type { Schema } from '../core/schema.js'
@@ -42,22 +43,8 @@ export interface UseQueriesOptions {
   staleTime?: number
 }
 
-type QueryInput<S extends Schema> =
-  | AnyQueryBuilder<S>
-  // A heterogeneous tuple needs to erase each request's args while retaining its builder.
-  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-  | QueryRequest<any, AnyQueryBuilder<S>>
-  | QueryDefinition<void, AnyQueryBuilder<S>, void>
-
-type QueryInputBuilder<T> =
-  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-  T extends QueryRequest<any, infer B>
-    ? B
-    : T extends QueryDefinition<void, infer B, void>
-      ? B
-      : T extends AnyQueryBuilder
-        ? T
-        : never
+/** A heterogeneous tuple erases each request's args while retaining its builder. */
+type SchemaQueryInput<S extends Schema> = QueryInput<AnyQueryBuilder<S>>
 
 /**
  * The `useQueries` call surface — declared once and shared by the root export
@@ -73,7 +60,7 @@ type QueryInputBuilder<T> =
  */
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 export interface UseQueriesHook<S extends Schema = any> {
-  <Queries extends readonly QueryInput<S>[]>(
+  <Queries extends readonly SchemaQueryInput<S>[]>(
     queries: readonly [...Queries],
     options?: UseQueriesOptions,
   ): {
@@ -95,7 +82,7 @@ export interface UseQueriesHook<S extends Schema = any> {
  * data. See `UseQueriesHook` for the per-element contract.
  */
 export const useQueries: UseQueriesHook = ((
-  queries: readonly QueryInput<Schema>[],
+  queries: readonly SchemaQueryInput<Schema>[],
   options?: UseQueriesOptions,
 ): unknown => useQueriesImpl(useFigbird(), queries, options)) as UseQueriesHook
 
@@ -104,7 +91,7 @@ export const useQueries: UseQueriesHook = ((
  */
 export function useQueriesImpl(
   figbird: FigbirdLike,
-  queries: readonly QueryInput<Schema>[],
+  queries: readonly SchemaQueryInput<Schema>[],
   options: UseQueriesOptions = {},
 ): unknown {
   const { staleTime } = options

--- a/lib/react/useQueries.ts
+++ b/lib/react/useQueries.ts
@@ -24,7 +24,7 @@
  */
 
 import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react'
-import { isQueryRequest, type QueryRequest, type RelationalQueryState } from '../core/figbird.js'
+import type { QueryDefinition, QueryRequest, RelationalQueryState } from '../core/figbird.js'
 import { suspensePromiseAll } from '../core/relationalQuery.js'
 import type { AnyQueryBuilder, QueryBuilderKind, QueryBuilderResult } from '../core/queryBuilder.js'
 import type { Schema } from '../core/schema.js'
@@ -47,10 +47,17 @@ type QueryInput<S extends Schema> =
   // A heterogeneous tuple needs to erase each request's args while retaining its builder.
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   | QueryRequest<any, AnyQueryBuilder<S>>
+  | QueryDefinition<void, AnyQueryBuilder<S>, void>
 
 type QueryInputBuilder<T> =
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-  T extends QueryRequest<any, infer B> ? B : T extends AnyQueryBuilder ? T : never
+  T extends QueryRequest<any, infer B>
+    ? B
+    : T extends QueryDefinition<void, infer B, void>
+      ? B
+      : T extends AnyQueryBuilder
+        ? T
+        : never
 
 /**
  * The `useQueries` call surface — declared once and shared by the root export
@@ -108,9 +115,7 @@ export function useQueriesImpl(
   // its identity element-wise: the subscription and snapshot cache key off actual
   // ref changes, and an evicted-then-re-interned ref is a new instance that
   // correctly busts the pin.
-  const refs = useStableArray(
-    queries.map(query => (isQueryRequest(query) ? figbird.query(query) : figbird.query(query))),
-  )
+  const refs = useStableArray(queries.map(query => figbird.query(query)))
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {

--- a/lib/react/useQuery.ts
+++ b/lib/react/useQuery.ts
@@ -23,10 +23,12 @@ import { useCallback, useMemo, useSyncExternalStore } from 'react'
 import type { AnyQueryBuilder, QueryBuilderKind, QueryBuilderResult } from '../core/queryBuilder.js'
 import {
   isQueryDefinition,
+  isQueryRequest,
   splitDefinitionRest,
   type ArgsAndOptions,
   type ArgsAndRequiredOptions,
   type QueryDefinition,
+  type QueryRequest,
   type RelationalPaginationState,
   type RelationalQueryState,
 } from '../core/figbird.js'
@@ -96,6 +98,9 @@ export interface QueryRefLike<T> {
 /** The slice of a Figbird instance the query hooks need. @internal */
 export interface FigbirdLike {
   query<B extends AnyQueryBuilder>(builder: B): QueryRefLike<QueryBuilderResult<B>>
+  query<Args, B extends AnyQueryBuilder>(
+    request: QueryRequest<Args, B>,
+  ): QueryRefLike<QueryBuilderResult<B>>
   query<Args, B extends AnyQueryBuilder>(
     definition: QueryDefinition<Args, B>,
     args: Args,
@@ -193,6 +198,11 @@ export interface UseQueryHook<S extends Schema = any> {
     query: B,
     options: UseQueryOptions & { suspense: false },
   ): RelationalQueryResult<QueryBuilderResult<B>, QueryBuilderKind<B>>
+  // Bound request, non-suspense
+  <Args, B extends AnyQueryBuilder<S>>(
+    request: QueryRequest<Args, B>,
+    options: UseQueryOptions & { suspense: false },
+  ): RelationalQueryResult<QueryBuilderResult<B>, QueryBuilderKind<B>>
   // Definition, non-suspense — args omittable when the definition takes none
   <Args, B extends AnyQueryBuilder<S>>(
     definition: QueryDefinition<Args, B>,
@@ -201,6 +211,11 @@ export interface UseQueryHook<S extends Schema = any> {
   // Builder
   <B extends AnyQueryBuilder<S>, O extends UseQueryOptions = Record<string, never>>(
     query: B,
+    options?: O,
+  ): SuspenseQueryResult<SkipAware<QueryBuilderResult<B>, O>, QueryBuilderKind<B>>
+  // Bound request
+  <Args, B extends AnyQueryBuilder<S>, O extends UseQueryOptions = Record<string, never>>(
+    request: QueryRequest<Args, B>,
     options?: O,
   ): SuspenseQueryResult<SkipAware<QueryBuilderResult<B>, O>, QueryBuilderKind<B>>
   // Definition — args omittable when the definition takes none
@@ -258,7 +273,12 @@ export function useQueryImpl(
 ): unknown {
   let qRef: QueryRefLike<unknown> | null = null
   let options: UseQueryOptions
-  if (isQueryDefinition(queryOrDefinition)) {
+  if (isQueryRequest(queryOrDefinition)) {
+    options = (argsOrOptions as UseQueryOptions | undefined) ?? {}
+    if (!options.skip) {
+      qRef = figbird.query(queryOrDefinition as QueryRequest<unknown, AnyQueryBuilder>)
+    }
+  } else if (isQueryDefinition(queryOrDefinition)) {
     const definition = queryOrDefinition
     // `null` args skip the query — the definition's build function is never invoked
     // (it may dereference its args), so the condition lives in the args themselves:

--- a/lib/react/useQuery.ts
+++ b/lib/react/useQuery.ts
@@ -22,11 +22,6 @@
 import { useCallback, useMemo, useSyncExternalStore } from 'react'
 import type { AnyQueryBuilder, QueryBuilderKind, QueryBuilderResult } from '../core/queryBuilder.js'
 import {
-  isQueryDefinition,
-  isQueryRequest,
-  splitDefinitionRest,
-  type ArgsAndOptions,
-  type ArgsAndRequiredOptions,
   type QueryDefinition,
   type QueryRequest,
   type RelationalPaginationState,
@@ -97,13 +92,8 @@ export interface QueryRefLike<T> {
 
 /** The slice of a Figbird instance the query hooks need. @internal */
 export interface FigbirdLike {
-  query<B extends AnyQueryBuilder>(builder: B): QueryRefLike<QueryBuilderResult<B>>
   query<Args, B extends AnyQueryBuilder>(
-    request: QueryRequest<Args, B>,
-  ): QueryRefLike<QueryBuilderResult<B>>
-  query<Args, B extends AnyQueryBuilder>(
-    definition: QueryDefinition<Args, B>,
-    args: Args,
+    queryOrBuilder: B | QueryRequest<Args, B> | QueryDefinition<void, B, void>,
   ): QueryRefLike<QueryBuilderResult<B>>
 }
 
@@ -187,54 +177,27 @@ export type SkipAware<T, O extends UseQueryOptions> = [O] extends [{ skip: false
     : T
 
 /**
- * The `useQuery` call surface — builder/definition × suspense/non-suspense. Declared
+ * The `useQuery` call surface — query input × suspense/non-suspense. Declared
  * once and shared by the root export (schema-agnostic) and the `createHooks` kit
  * (bound to a schema), so the two can never drift.
  */
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 export interface UseQueryHook<S extends Schema = any> {
-  // Builder, non-suspense — returns the tagged union, never throws
-  <B extends AnyQueryBuilder<S>>(
-    query: B,
+  <Args, B extends AnyQueryBuilder<S>>(
+    query: B | QueryRequest<Args, B> | QueryDefinition<void, B, void>,
     options: UseQueryOptions & { suspense: false },
   ): RelationalQueryResult<QueryBuilderResult<B>, QueryBuilderKind<B>>
-  // Bound request, non-suspense
-  <Args, B extends AnyQueryBuilder<S>>(
-    request: QueryRequest<Args, B>,
-    options: UseQueryOptions & { suspense: false },
-  ): RelationalQueryResult<QueryBuilderResult<B>, QueryBuilderKind<B>>
-  // Definition, non-suspense — args omittable when the definition takes none
-  <Args, B extends AnyQueryBuilder<S>>(
-    definition: QueryDefinition<Args, B>,
-    ...rest: ArgsAndRequiredOptions<Args, UseQueryOptions & { suspense: false }>
-  ): RelationalQueryResult<QueryBuilderResult<B>, QueryBuilderKind<B>>
-  // Builder
-  <B extends AnyQueryBuilder<S>, O extends UseQueryOptions = Record<string, never>>(
-    query: B,
+  <Args, B extends AnyQueryBuilder<S>, O extends UseQueryOptions = Record<string, never>>(
+    query: B | QueryRequest<Args, B> | QueryDefinition<void, B, void>,
     options?: O,
   ): SuspenseQueryResult<SkipAware<QueryBuilderResult<B>, O>, QueryBuilderKind<B>>
-  // Bound request
-  <Args, B extends AnyQueryBuilder<S>, O extends UseQueryOptions = Record<string, never>>(
-    request: QueryRequest<Args, B>,
-    options?: O,
-  ): SuspenseQueryResult<SkipAware<QueryBuilderResult<B>, O>, QueryBuilderKind<B>>
-  // Definition — args omittable when the definition takes none
-  <Args, B extends AnyQueryBuilder<S>, O extends UseQueryOptions = Record<string, never>>(
-    definition: QueryDefinition<Args, B>,
-    ...rest: ArgsAndOptions<Args, O>
-  ): SuspenseQueryResult<SkipAware<QueryBuilderResult<B>, O>, QueryBuilderKind<B>>
-  // Definition, nullable args — `null` skips the query without invoking the build
-  // function, so the skip condition lives in the args: `useQuery(def, id ? { id } : null)`.
-  // Non-suspense variant:
+  // A nullable bound request is the conditional-query form: `useQuery(id ? detail({ id }) : null)`.
   <Args, B extends AnyQueryBuilder<S>>(
-    definition: QueryDefinition<Args, B>,
-    args: Args | null,
+    request: QueryRequest<Args, B> | null,
     options: UseQueryOptions & { suspense: false },
   ): RelationalQueryResult<QueryBuilderResult<B>, QueryBuilderKind<B>>
-  // Suspense variant — data widens with `undefined` exactly like `skip`:
   <Args, B extends AnyQueryBuilder<S>, O extends UseQueryOptions = Record<string, never>>(
-    definition: QueryDefinition<Args, B>,
-    args: Args | null,
+    request: QueryRequest<Args, B> | null,
     options?: O,
   ): SuspenseQueryResult<QueryBuilderResult<B> | undefined, QueryBuilderKind<B>>
 }
@@ -253,12 +216,8 @@ export interface UseQueryHook<S extends Schema = any> {
  * across a param change, wrap the param state update in `startTransition` — React keeps
  * the previous render committed while the new data resolves.
  */
-export const useQuery: UseQueryHook = ((
-  queryOrDefinition: unknown,
-  argsOrOptions?: unknown,
-  maybeOptions?: UseQueryOptions,
-): unknown =>
-  useQueryImpl(useFigbird(), queryOrDefinition, argsOrOptions, maybeOptions)) as UseQueryHook
+export const useQuery: UseQueryHook = ((query: unknown, options?: UseQueryOptions): unknown =>
+  useQueryImpl(useFigbird(), query, options)) as UseQueryHook
 
 /**
  * Instance-taking dispatch behind the context-bound `useQuery`. Resolves the
@@ -267,49 +226,20 @@ export const useQuery: UseQueryHook = ((
  */
 export function useQueryImpl(
   figbird: FigbirdLike,
-  queryOrDefinition: unknown,
-  argsOrOptions?: unknown,
-  maybeOptions?: UseQueryOptions,
+  query: unknown,
+  options: UseQueryOptions = {},
 ): unknown {
   let qRef: QueryRefLike<unknown> | null = null
-  let options: UseQueryOptions
-  if (isQueryRequest(queryOrDefinition)) {
-    options = (argsOrOptions as UseQueryOptions | undefined) ?? {}
-    if (!options.skip) {
-      qRef = figbird.query(queryOrDefinition as QueryRequest<unknown, AnyQueryBuilder>)
-    }
-  } else if (isQueryDefinition(queryOrDefinition)) {
-    const definition = queryOrDefinition
-    // `null` args skip the query — the definition's build function is never invoked
-    // (it may dereference its args), so the condition lives in the args themselves:
-    // `useQuery(issueDetail, id ? { id } : null)`. Checked on the raw argument,
-    // before splitDefinitionRest's zero-arg option folding, so a literal `null`
-    // first slot means skip for zero-arg definitions too.
-    if (argsOrOptions === null) {
-      options = maybeOptions ?? {}
-    } else {
-      // Zero-arg definitions take options in the args slot (see ArgsAndOptions).
-      const { args, options: split } = splitDefinitionRest<UseQueryOptions>(
-        definition,
-        argsOrOptions,
-        maybeOptions,
-      )
-      options = split ?? {}
-      if (!options.skip) {
-        // figbird.query() owns definition resolution (validate → build → intern) —
-        // the hook never builds a builder itself.
-        qRef = figbird.query(definition as QueryDefinition<unknown, AnyQueryBuilder>, args)
-      }
-    }
-  } else {
-    options = (argsOrOptions as UseQueryOptions | undefined) ?? {}
-    if (!options.skip) {
-      qRef = figbird.query(queryOrDefinition as AnyQueryBuilder)
-    }
+  if (!options.skip && query !== null) {
+    qRef = figbird.query(
+      query as
+        | AnyQueryBuilder
+        | QueryRequest<unknown, AnyQueryBuilder>
+        | QueryDefinition<void, AnyQueryBuilder, void>,
+    )
   }
-  // Both branches end at the same single hook call, so the hook sequence is stable
-  // across renders (a call site never flips between definition and builder), and
-  // identical when args flip null <-> real or `skip` toggles.
+  // Every input shape ends at the same single hook call, so the hook sequence is stable
+  // when a request flips null <-> real or `skip` toggles.
   return useQueryForRef(qRef, options)
 }
 
@@ -340,8 +270,8 @@ export function projectSuspenseResult<T>(
  * The shared hook body. `qRef` is reference-stable across renders while subscribed
  * because `figbird.query()` interns refs by AST hash — no memoization here. (If the
  * ref was evicted between renders, this picks up the freshly interned instance
- * instead of pinning the stale one.) A null `qRef` is a skipped query: `skip: true`,
- * or a null-args definition whose build function never ran.
+ * instead of pinning the stale one.) A null `qRef` is a skipped query: either
+ * `skip: true` or a nullable request whose factory was never called.
  */
 function useQueryForRef<T>(qRef: QueryRefLike<T> | null, options: UseQueryOptions): unknown {
   const { suspense = true, staleTime } = options

--- a/lib/react/useQuery.ts
+++ b/lib/react/useQuery.ts
@@ -22,7 +22,7 @@
 import { useCallback, useMemo, useSyncExternalStore } from 'react'
 import type { AnyQueryBuilder, QueryBuilderKind, QueryBuilderResult } from '../core/queryBuilder.js'
 import {
-  type QueryDefinition,
+  type QueryInput,
   type QueryRequest,
   type RelationalPaginationState,
   type RelationalQueryState,
@@ -93,7 +93,7 @@ export interface QueryRefLike<T> {
 /** The slice of a Figbird instance the query hooks need. @internal */
 export interface FigbirdLike {
   query<Args, B extends AnyQueryBuilder>(
-    queryOrBuilder: B | QueryRequest<Args, B> | QueryDefinition<void, B, void>,
+    queryOrBuilder: QueryInput<B, Args>,
   ): QueryRefLike<QueryBuilderResult<B>>
 }
 
@@ -184,11 +184,11 @@ export type SkipAware<T, O extends UseQueryOptions> = [O] extends [{ skip: false
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 export interface UseQueryHook<S extends Schema = any> {
   <Args, B extends AnyQueryBuilder<S>>(
-    query: B | QueryRequest<Args, B> | QueryDefinition<void, B, void>,
+    query: QueryInput<B, Args>,
     options: UseQueryOptions & { suspense: false },
   ): RelationalQueryResult<QueryBuilderResult<B>, QueryBuilderKind<B>>
   <Args, B extends AnyQueryBuilder<S>, O extends UseQueryOptions = Record<string, never>>(
-    query: B | QueryRequest<Args, B> | QueryDefinition<void, B, void>,
+    query: QueryInput<B, Args>,
     options?: O,
   ): SuspenseQueryResult<SkipAware<QueryBuilderResult<B>, O>, QueryBuilderKind<B>>
   // A nullable bound request is the conditional-query form: `useQuery(id ? detail({ id }) : null)`.
@@ -231,12 +231,7 @@ export function useQueryImpl(
 ): unknown {
   let qRef: QueryRefLike<unknown> | null = null
   if (!options.skip && query !== null) {
-    qRef = figbird.query(
-      query as
-        | AnyQueryBuilder
-        | QueryRequest<unknown, AnyQueryBuilder>
-        | QueryDefinition<void, AnyQueryBuilder, void>,
-    )
+    qRef = figbird.query(query as QueryInput<AnyQueryBuilder>)
   }
   // Every input shape ends at the same single hook call, so the hook sequence is stable
   // when a request flips null <-> real or `skip` toggles.

--- a/test/args-schema.test.ts
+++ b/test/args-schema.test.ts
@@ -38,9 +38,11 @@ function makeFigbird() {
 // A tiny hand-rolled Standard Schema implementation. Not a real validator — it just
 // proves figbird relies only on the `~standard` interface and not on any specific
 // runtime library. Real consumers would pass zod/valibot/arktype/etc.
+type ObjectSchemaInput<T> = { [K in keyof T]: unknown }
+
 function objectSchema<T>(validators: {
   [K in keyof T]: (value: unknown, key: string) => T[K]
-}): StandardSchemaV1<unknown, T> {
+}): StandardSchemaV1<ObjectSchemaInput<T>, T> {
   return {
     '~standard': {
       version: 1,
@@ -88,7 +90,7 @@ test('defineQuery creates validated, inert requests with normalized args', t => 
   t.is(issueDetail.name, 'issueDetail')
   t.is(typeof issueDetail.build, 'function')
   t.is(typeof issueDetail.validate, 'function')
-  const request = issueDetail({ id: '7' } as never)
+  const request = issueDetail({ id: '7' })
   t.true(isQueryRequest(request))
   t.is(request.definition, issueDetail)
   t.deepEqual(request.args, { id: 7 })
@@ -99,7 +101,7 @@ test('calling a definition throws QueryArgsError on invalid args', t => {
   const issueDetail = defineQuery('issueDetail', objectSchema({ id: positiveInt }), ({ id }) =>
     figbird.q.issues.get(id),
   )
-  const err = t.throws(() => issueDetail({ id: 'abc' } as never), {
+  const err = t.throws(() => issueDetail({ id: 'abc' }), {
     instanceOf: QueryArgsError,
   })
   t.is(err.queryName, 'issueDetail')
@@ -114,17 +116,17 @@ test('calling a definition normalizes args before build', t => {
     figbird.q.issues.get(id),
   )
   // Normalized: '7' string coerces to 7. Both produce the same builder hash.
-  const fromString = figbird.query(issueDetail({ id: '7' } as never))
+  const fromString = figbird.query(issueDetail({ id: '7' }))
   const fromNumber = figbird.query(issueDetail({ id: 7 }))
   t.is(fromString.hash(), fromNumber.hash())
 })
 
-test('figbird.prepare runs schema validation and throws on invalid args', t => {
+test('binding a request runs schema validation before prepare', t => {
   const figbird = makeFigbird()
   const issueDetail = defineQuery('issueDetail', objectSchema({ id: positiveInt }), ({ id }) =>
     figbird.q.issues.get(id),
   )
-  const err = t.throws(() => figbird.prepare(issueDetail, { id: -1 } as never), {
+  const err = t.throws(() => issueDetail({ id: -1 }), {
     instanceOf: QueryArgsError,
   })
   t.is(err.queryName, 'issueDetail')
@@ -135,7 +137,7 @@ test('figbird.prepare uses normalized args so prepared and direct calls share th
   const issueDetail = defineQuery('issueDetail', objectSchema({ id: positiveInt }), ({ id }) =>
     figbird.q.issues.get(id),
   )
-  const prepared = figbird.prepare(issueDetail({ id: '1' } as never))
+  const prepared = figbird.prepare(issueDetail({ id: '1' }))
   // The same cache entry is hit when args normalize to the same value.
   const directRef = figbird.query(issueDetail({ id: 1 }))
   t.is(prepared.key, directRef.hash())

--- a/test/args-schema.test.ts
+++ b/test/args-schema.test.ts
@@ -88,18 +88,18 @@ test('defineQuery creates validated, inert requests with normalized args', t => 
   t.is(issueDetail.name, 'issueDetail')
   t.is(typeof issueDetail.build, 'function')
   t.is(typeof issueDetail.validate, 'function')
-  const request = issueDetail.withArgs({ id: '7' } as never)
+  const request = issueDetail({ id: '7' } as never)
   t.true(isQueryRequest(request))
   t.is(request.definition, issueDetail)
   t.deepEqual(request.args, { id: 7 })
 })
 
-test('withArgs throws QueryArgsError on invalid args', t => {
+test('calling a definition throws QueryArgsError on invalid args', t => {
   const figbird = makeFigbird()
   const issueDetail = defineQuery('issueDetail', objectSchema({ id: positiveInt }), ({ id }) =>
     figbird.q.issues.get(id),
   )
-  const err = t.throws(() => issueDetail.withArgs({ id: 'abc' } as never), {
+  const err = t.throws(() => issueDetail({ id: 'abc' } as never), {
     instanceOf: QueryArgsError,
   })
   t.is(err.queryName, 'issueDetail')
@@ -108,14 +108,14 @@ test('withArgs throws QueryArgsError on invalid args', t => {
   t.is(err.issues.length, 1)
 })
 
-test('withArgs normalizes args before build', t => {
+test('calling a definition normalizes args before build', t => {
   const figbird = makeFigbird()
   const issueDetail = defineQuery('issueDetail', objectSchema({ id: positiveInt }), ({ id }) =>
     figbird.q.issues.get(id),
   )
   // Normalized: '7' string coerces to 7. Both produce the same builder hash.
-  const fromString = figbird.query(issueDetail.withArgs({ id: '7' } as never))
-  const fromNumber = figbird.query(issueDetail.withArgs({ id: 7 }))
+  const fromString = figbird.query(issueDetail({ id: '7' } as never))
+  const fromNumber = figbird.query(issueDetail({ id: 7 }))
   t.is(fromString.hash(), fromNumber.hash())
 })
 
@@ -135,9 +135,9 @@ test('figbird.prepare uses normalized args so prepared and direct calls share th
   const issueDetail = defineQuery('issueDetail', objectSchema({ id: positiveInt }), ({ id }) =>
     figbird.q.issues.get(id),
   )
-  const prepared = figbird.prepare(issueDetail.withArgs({ id: '1' } as never))
+  const prepared = figbird.prepare(issueDetail({ id: '1' } as never))
   // The same cache entry is hit when args normalize to the same value.
-  const directRef = figbird.query(issueDetail.withArgs({ id: 1 }))
+  const directRef = figbird.query(issueDetail({ id: 1 }))
   t.is(prepared.key, directRef.hash())
   prepared.release()
 })

--- a/test/args-schema.test.ts
+++ b/test/args-schema.test.ts
@@ -1,6 +1,12 @@
 import test from 'ava'
 import { FeathersAdapter } from '../lib/adapters/feathers'
-import { defineQuery, Figbird, QueryArgsError, type StandardSchemaV1 } from '../lib/core/figbird'
+import {
+  defineQuery,
+  Figbird,
+  isQueryRequest,
+  QueryArgsError,
+  type StandardSchemaV1,
+} from '../lib/core/figbird'
 import { createSchema, service } from '../lib/core/schema'
 import { mockFeathers } from './helpers'
 
@@ -74,7 +80,7 @@ const positiveInt = (raw: unknown, key: string): number => {
   throw new Error(`${key} must be a positive integer`)
 }
 
-test('defineQuery attaches a validate function', t => {
+test('defineQuery creates validated, inert requests with normalized args', t => {
   const figbird = makeFigbird()
   const issueDetail = defineQuery('issueDetail', objectSchema({ id: positiveInt }), ({ id }) =>
     figbird.q.issues.get(id),
@@ -82,29 +88,34 @@ test('defineQuery attaches a validate function', t => {
   t.is(issueDetail.name, 'issueDetail')
   t.is(typeof issueDetail.build, 'function')
   t.is(typeof issueDetail.validate, 'function')
-  t.deepEqual(issueDetail.validate({ id: 7 }), { id: 7 })
+  const request = issueDetail.withArgs({ id: '7' } as never)
+  t.true(isQueryRequest(request))
+  t.is(request.definition, issueDetail)
+  t.deepEqual(request.args, { id: 7 })
 })
 
-test('schema validation throws QueryArgsError on invalid args', t => {
+test('withArgs throws QueryArgsError on invalid args', t => {
   const figbird = makeFigbird()
   const issueDetail = defineQuery('issueDetail', objectSchema({ id: positiveInt }), ({ id }) =>
     figbird.q.issues.get(id),
   )
-  const err = t.throws(() => issueDetail.validate({ id: 'abc' }), { instanceOf: QueryArgsError })
+  const err = t.throws(() => issueDetail.withArgs({ id: 'abc' } as never), {
+    instanceOf: QueryArgsError,
+  })
   t.is(err.queryName, 'issueDetail')
   t.true(err.message.includes('issueDetail'))
   t.true(err.message.includes('id'))
   t.is(err.issues.length, 1)
 })
 
-test('schema validation normalizes args before build', t => {
+test('withArgs normalizes args before build', t => {
   const figbird = makeFigbird()
   const issueDetail = defineQuery('issueDetail', objectSchema({ id: positiveInt }), ({ id }) =>
     figbird.q.issues.get(id),
   )
   // Normalized: '7' string coerces to 7. Both produce the same builder hash.
-  const fromString = issueDetail.build(issueDetail.validate({ id: '7' }))
-  const fromNumber = issueDetail.build(issueDetail.validate({ id: 7 }))
+  const fromString = figbird.query(issueDetail.withArgs({ id: '7' } as never))
+  const fromNumber = figbird.query(issueDetail.withArgs({ id: 7 }))
   t.is(fromString.hash(), fromNumber.hash())
 })
 
@@ -124,10 +135,9 @@ test('figbird.prepare uses normalized args so prepared and direct calls share th
   const issueDetail = defineQuery('issueDetail', objectSchema({ id: positiveInt }), ({ id }) =>
     figbird.q.issues.get(id),
   )
-  const prepared = figbird.prepare(issueDetail, { id: '1' } as never)
+  const prepared = figbird.prepare(issueDetail.withArgs({ id: '1' } as never))
   // The same cache entry is hit when args normalize to the same value.
-  const directBuilder = issueDetail.build(issueDetail.validate({ id: 1 }))
-  const directRef = figbird.query(directBuilder)
+  const directRef = figbird.query(issueDetail.withArgs({ id: 1 }))
   t.is(prepared.key, directRef.hash())
   prepared.release()
 })

--- a/test/fixtures/figbird-methods-inference.ts
+++ b/test/fixtures/figbird-methods-inference.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable @typescript-eslint/no-unused-vars */
-import type { FeathersClient } from '../../lib'
-import { FeathersAdapter, Figbird, createSchema, service } from '../../lib'
+import type { AnyQueryInput, FeathersClient } from '../../lib'
+import { FeathersAdapter, Figbird, createSchema, defineQuery, service } from '../../lib'
 
 // Define a simple Person model
 interface Person {
@@ -24,6 +24,19 @@ const schema = createSchema({
 const feathers = {} as FeathersClient
 const adapter = new FeathersAdapter(feathers)
 const figbird = new Figbird({ schema, adapter })
+
+// Router adapters can name the erased public boundary without importing internal
+// builder types. Every supported input form forwards directly to Figbird.
+export const prepareRouteQuery = (query: AnyQueryInput<typeof schema>) => figbird.prepare(query)
+
+const personDetail = defineQuery(({ id }: { id: string }) => figbird.q['api/people'].get(id))
+const allPeople = defineQuery(() => figbird.q['api/people'])
+
+prepareRouteQuery(figbird.q['api/people'])
+prepareRouteQuery(personDetail({ id: '1' }))
+prepareRouteQuery(allPeople)
+
+export type PreparedRouteQuery = ReturnType<typeof prepareRouteQuery>
 
 // Helper to extract subscribe fn type without leaking the full class type (TS6 TS4094)
 function subscribeFn<Fn extends (...args: never[]) => unknown>(q: { subscribe: Fn }): Fn {

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -2860,7 +2860,7 @@ test('defineQuery + prepare: prepare and useQuery share the same cache entry', a
   )
 
   // Bind route params before handing the inert request to a router data adapter.
-  const request = issueDetail.withArgs({ id: 1 })
+  const request = issueDetail({ id: 1 })
   const prepared = figbird.prepare(request)
   t.truthy(prepared.key)
 
@@ -2930,7 +2930,7 @@ test('explain: classifies nodes with structured reasons', t => {
       .related('creator'),
   )
 
-  const report = figbird.explain(issuesByTitle.withArgs({ title: 'foo' }))
+  const report = figbird.explain(issuesByTitle({ title: 'foo' }))
 
   const root = report.nodes.find(n => n.path === '(root)')!
   t.is(root.class, 'server-authoritative')

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -2907,9 +2907,9 @@ test('defineQuery + prepare: prepare key is stable for identical args', t => {
     figbird.q.issues.get(id),
   )
 
-  const a = figbird.prepare(issueDetail, { id: 1 })
-  const b = figbird.prepare(issueDetail, { id: 1 })
-  const c = figbird.prepare(issueDetail, { id: 2 })
+  const a = figbird.prepare(issueDetail({ id: 1 }))
+  const b = figbird.prepare(issueDetail({ id: 1 }))
+  const c = figbird.prepare(issueDetail({ id: 2 }))
 
   t.is(a.key, b.key, 'identical args must share a cache key')
   t.not(a.key, c.key, 'different args must produce different cache keys')
@@ -3192,12 +3192,12 @@ test('prepare and prefetch install staleTime before materializing a warm query',
     q.issues.get(id).related('creator'),
   )
 
-  const first = figbird.prepare(issueDetail, { id: 1 }, { staleTime: 60_000 })
+  const first = figbird.prepare(issueDetail({ id: 1 }), { staleTime: 60_000 })
   await first.promise
   first.release()
   await new Promise(resolve => setTimeout(resolve, 10))
 
-  const second = figbird.prepare(issueDetail, { id: 1 }, { staleTime: 60_000 })
+  const second = figbird.prepare(issueDetail({ id: 1 }), { staleTime: 60_000 })
   await second.promise
   await new Promise(resolve => setTimeout(resolve, 10))
 
@@ -3206,7 +3206,7 @@ test('prepare and prefetch install staleTime before materializing a warm query',
   second.release()
   await new Promise(resolve => setTimeout(resolve, 10))
 
-  figbird.prefetch(issueDetail, { id: 1 }, { staleTime: 60_000 })
+  figbird.prefetch(issueDetail({ id: 1 }), { staleTime: 60_000 })
   await new Promise(resolve => setTimeout(resolve, 10))
   t.is(feathers.service('issues').counts.get, 1, 'prefetch must respect fresh root data')
   t.is(feathers.service('users').counts.find, 1, 'prefetch must respect fresh relation data')
@@ -3219,14 +3219,14 @@ test('staleTime: stricter subscriber revalidates an already-live relational quer
   )
 
   // A speculative read keeps the relational ref alive with a lenient freshness window.
-  figbird.prefetch(issueDetail, { id: 1 }, { staleTime: 60_000 })
+  figbird.prefetch(issueDetail({ id: 1 }), { staleTime: 60_000 })
   await new Promise(resolve => setTimeout(resolve, 10))
   t.is(feathers.service('issues').counts.get, 1)
   t.is(feathers.service('users').counts.find, 1)
 
   // A normal subscriber has staleTime 0. Even though it joins the already-live
   // relational ref, its stricter tolerance must propagate to the root and relation refs.
-  const ref = figbird.query(issueDetail, { id: 1 })
+  const ref = figbird.query(issueDetail({ id: 1 }))
   const unsub = ref.subscribe(() => {})
   await new Promise(resolve => setTimeout(resolve, 10))
 
@@ -3242,9 +3242,9 @@ test('prefetch: idempotent within staleTime and warms the cache for a later read
   )
 
   // Hover-spam: repeated calls within staleTime must not re-trigger fetches.
-  figbird.prefetch(issueDetail, { id: 1 })
-  figbird.prefetch(issueDetail, { id: 1 })
-  figbird.prefetch(issueDetail, { id: 1 })
+  figbird.prefetch(issueDetail({ id: 1 }))
+  figbird.prefetch(issueDetail({ id: 1 }))
+  figbird.prefetch(issueDetail({ id: 1 }))
   await new Promise(resolve => setTimeout(resolve, 10))
 
   // `.get(id)` fetches via the resource verb, so count `get` calls.
@@ -3288,8 +3288,8 @@ test('defineQuery: typed-args form (no validator, no name) builds and prepares',
   const issueDetail = defineQuery(({ id }: { id: number }) => figbird.q.issues.get(id))
   t.is(issueDetail.name, '')
 
-  const a = figbird.prepare(issueDetail, { id: 1 })
-  const b = figbird.prepare(issueDetail, { id: 1 })
+  const a = figbird.prepare(issueDetail({ id: 1 }))
+  const b = figbird.prepare(issueDetail({ id: 1 }))
   t.is(a.key, b.key, 'same args must map to the same cache key')
   t.false('priority' in a, 'prepare handles carry no router vocabulary')
 
@@ -3297,20 +3297,17 @@ test('defineQuery: typed-args form (no validator, no name) builds and prepares',
   b.release()
 })
 
-test('defineQuery: zero-arg definition takes options in the args slot', async t => {
+test('defineQuery: argumentless definitions are direct query inputs', async t => {
   const { App, figbird } = createApp()
   const { render, unmount, flush, $ } = dom()
 
   const allIssues = defineQuery(() => figbird.q.issues)
 
-  // prepare(def, options) — no middle undefined.
   const prepared = figbird.prepare(allIssues, { staleTime: 60_000 })
   await prepared.promise
 
-  // prefetch(def, options) — same shape.
   figbird.prefetch(allIssues, { staleTime: 60_000 })
 
-  // useQuery(def, options) — options land straight after the definition, both modes.
   function NonSuspense() {
     const result = useQuery(allIssues, { suspense: false })
     return <div className='count'>{result.status === 'success' ? result.data.length : '…'}</div>
@@ -3322,15 +3319,6 @@ test('defineQuery: zero-arg definition takes options in the args slot', async t 
   )
   await flush()
   t.is($('.count')!.innerHTML, '3')
-
-  // The old (undefined, options) spelling is still tolerated at runtime.
-  const legacy = (figbird.prepare as (...a: unknown[]) => { key: string; release: () => void })(
-    allIssues,
-    undefined,
-    { staleTime: 60_000 },
-  )
-  t.is(legacy.key, prepared.key, 'legacy (undefined, options) hits the same cache entry')
-  legacy.release()
 
   prepared.release()
   unmount()
@@ -3980,10 +3968,10 @@ test('chained one: realtime on intermediate and destination re-resolves the edge
 })
 
 // ============================================================================
-// Null-args skip for definitions
+// Nullable request skip
 // ============================================================================
 
-test('useQuery definition: null args skip without invoking build or fetching', async t => {
+test('useQuery: null request skips without invoking the factory or fetching', async t => {
   const { App, figbird, feathers } = createApp()
   const { render, unmount, flush, $ } = dom()
 
@@ -3994,7 +3982,7 @@ test('useQuery definition: null args skip without invoking build or fetching', a
   })
 
   function Issue({ id }: { id: number | null }) {
-    const { data } = useQuery(issueDetail, id ? { id } : null)
+    const { data } = useQuery(id ? issueDetail({ id }) : null)
     return <div className='detail'>{data?.title ?? 'none'}</div>
   }
 
@@ -4008,13 +3996,13 @@ test('useQuery definition: null args skip without invoking build or fetching', a
   await flush()
 
   t.is($('.detail')?.innerHTML, 'none')
-  t.is(buildCalls, 0, 'build is never invoked for null args')
+  t.is(buildCalls, 0, 'factory is never invoked for a null request')
   t.is(feathers.service('issues').counts.get, 0, 'nothing fetched')
 
   unmount()
 })
 
-test('useQuery definition: args flipping from null to real starts the query', async t => {
+test('useQuery: request flipping from null to real starts the query', async t => {
   const { App, figbird } = createApp()
   const { render, unmount, flush, $, act } = dom()
 
@@ -4024,7 +4012,7 @@ test('useQuery definition: args flipping from null to real starts the query', as
   function Issue() {
     const [id, _setId] = React.useState<number | null>(null)
     setId = _setId
-    const { data } = useQuery(issueDetail, id ? { id } : null)
+    const { data } = useQuery(id ? issueDetail({ id }) : null)
     return <div className='detail'>{data?.title ?? 'none'}</div>
   }
 
@@ -4135,14 +4123,14 @@ test('suspense: remounting after a cold error refetches and recovers', async t =
   unmount()
 })
 
-test('useQuery definition: null skips zero-arg definitions too', async t => {
+test('useQuery: a null argumentless request skips the query', async t => {
   const { App, figbird, feathers } = createApp()
   const { render, unmount, flush, $ } = dom()
 
   const allIssues = defineQuery(() => figbird.q.issues)
 
   function Issues({ enabled }: { enabled: boolean }) {
-    const { data } = useQuery(allIssues, enabled ? undefined : null)
+    const { data } = useQuery(enabled ? allIssues() : null)
     return <div className='all'>{data ? data.length : 'skipped'}</div>
   }
 

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -2859,8 +2859,9 @@ test('defineQuery + prepare: prepare and useQuery share the same cache entry', a
     figbird.q.issues.get(id).related('comments'),
   )
 
-  // Prepare the query before any component reads it.
-  const prepared = figbird.prepare(issueDetail, { id: 1 })
+  // Bind route params before handing the inert request to a router data adapter.
+  const request = issueDetail.withArgs({ id: 1 })
+  const prepared = figbird.prepare(request)
   t.truthy(prepared.key)
 
   await prepared.promise
@@ -2869,7 +2870,7 @@ test('defineQuery + prepare: prepare and useQuery share the same cache entry', a
   const beforeRender = feathers.service('issues').counts.find
 
   function IssueView() {
-    const { data } = useQuery(issueDetail, { id: 1 })
+    const { data } = useQuery(request)
     return (
       <div className='issue'>
         <span className='title'>{data?.title}</span>
@@ -2920,15 +2921,16 @@ test('defineQuery + prepare: prepare key is stable for identical args', t => {
 
 test('explain: classifies nodes with structured reasons', t => {
   const { figbird } = createApp()
-
-  const report = figbird.explain(
+  const issuesByTitle = defineQuery(({ title }: { title: string }) =>
     figbird.q.issues
-      .where({ title: { $regex: 'foo' } })
+      .where({ title: { $regex: title } })
       .orderBy('id', 'desc')
       .limit(30)
       .related('comments')
       .related('creator'),
   )
+
+  const report = figbird.explain(issuesByTitle.withArgs({ title: 'foo' }))
 
   const root = report.nodes.find(n => n.path === '(root)')!
   t.is(root.class, 'server-authoritative')

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -3306,7 +3306,11 @@ test('defineQuery: argumentless definitions are direct query inputs', async t =>
   const prepared = figbird.prepare(allIssues, { staleTime: 60_000 })
   await prepared.promise
 
+  const builderPrepared = figbird.prepare(figbird.q.issues, { staleTime: 60_000 })
+  t.is(builderPrepared.key, prepared.key)
+
   figbird.prefetch(allIssues, { staleTime: 60_000 })
+  figbird.prefetch(figbird.q.issues, { staleTime: 60_000 })
 
   function NonSuspense() {
     const result = useQuery(allIssues, { suspense: false })
@@ -3321,6 +3325,7 @@ test('defineQuery: argumentless definitions are direct query inputs', async t =>
   t.is($('.count')!.innerHTML, '3')
 
   prepared.release()
+  builderPrepared.release()
   unmount()
 })
 

--- a/test/type-inference.test.ts
+++ b/test/type-inference.test.ts
@@ -194,6 +194,7 @@ test('Figbird methods infer types from schema (query, subscribe, mutate)', t => 
   const findSubscribeStateType = getTypeAtPosition(fixturePath, 'FindSubscribeState')
   const getSubscribeStateType = getTypeAtPosition(fixturePath, 'GetSubscribeState')
   const createResultType = getTypeAtPosition(fixturePath, 'CreateResult')
+  const preparedRouteQueryType = getTypeAtPosition(fixturePath, 'PreparedRouteQuery')
 
   // Query subscribe param should carry QueryState with inferred data + Feathers meta
   t.is(
@@ -207,6 +208,7 @@ test('Figbird methods infer types from schema (query, subscribe, mutate)', t => 
 
   // Mutate create should resolve to Person
   t.is(createResultType, 'Person')
+  t.is(preparedRouteQueryType, 'import("figbird").PreparedQuery')
 })
 
 test('optional query definitions are inferred', t => {

--- a/test/usequeries.test.tsx
+++ b/test/usequeries.test.tsx
@@ -60,6 +60,7 @@ test('useQueries: fetches all queries in parallel under a single suspension', as
   const openIssues = defineQuery(({ status }: { status: string }) =>
     figbird.q.issues.where({ status }),
   )
+  const allUsers = defineQuery(() => figbird.q.users)
 
   // Record when each service's find is *issued* and delay resolution, so a
   // sequential waterfall would be observable: with per-query suspension, `users`
@@ -76,7 +77,7 @@ test('useQueries: fetches all queries in parallel under a single suspension', as
   }
 
   function Dashboard() {
-    const [issues, users] = useQueries([openIssues({ status: 'open' }), figbird.q.users])
+    const [issues, users] = useQueries([openIssues({ status: 'open' }), allUsers])
     // Type-inference assertions — the tuple element types flow from each builder.
     const issueRows: Issue[] = issues.data
     const userRows: User[] = users.data

--- a/test/usequeries.test.tsx
+++ b/test/usequeries.test.tsx
@@ -76,7 +76,7 @@ test('useQueries: fetches all queries in parallel under a single suspension', as
   }
 
   function Dashboard() {
-    const [issues, users] = useQueries([openIssues.withArgs({ status: 'open' }), figbird.q.users])
+    const [issues, users] = useQueries([openIssues({ status: 'open' }), figbird.q.users])
     // Type-inference assertions — the tuple element types flow from each builder.
     const issueRows: Issue[] = issues.data
     const userRows: User[] = users.data

--- a/test/usequeries.test.tsx
+++ b/test/usequeries.test.tsx
@@ -1,6 +1,6 @@
 import test from 'ava'
 import React from 'react'
-import { createSchema, createHooks, service, useQueries } from '../lib'
+import { createSchema, createHooks, defineQuery, service, useQueries } from '../lib'
 import { createTestApp, dom } from './helpers'
 
 interface Issue {
@@ -57,6 +57,9 @@ const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(r
 test('useQueries: fetches all queries in parallel under a single suspension', async t => {
   const { render, unmount, flush, $ } = dom()
   const { App, figbird, feathers } = createApp()
+  const openIssues = defineQuery(({ status }: { status: string }) =>
+    figbird.q.issues.where({ status }),
+  )
 
   // Record when each service's find is *issued* and delay resolution, so a
   // sequential waterfall would be observable: with per-query suspension, `users`
@@ -73,7 +76,7 @@ test('useQueries: fetches all queries in parallel under a single suspension', as
   }
 
   function Dashboard() {
-    const [issues, users] = useQueries([figbird.q.issues, figbird.q.users])
+    const [issues, users] = useQueries([openIssues.withArgs({ status: 'open' }), figbird.q.users])
     // Type-inference assertions — the tuple element types flow from each builder.
     const issueRows: Issue[] = issues.data
     const userRows: User[] = users.data


### PR DESCRIPTION
React Space Router 1.0 owns route admission and deliberately treats every value returned by `queries` as opaque. Figbird therefore needs a portable value that its data adapter can interpret after admission, without importing router types or teaching the router about Figbird arguments.

`defineQuery` is now a callable definition: `issueDetail(input)` validates immediately and returns an inert, instance-independent `QueryRequest`. Standard Schema input and normalized output stay distinct in the type system, so route strings can be accepted and normalized builders still receive their precise output types.

The API intentionally has one parameterized-query form rather than compatibility overloads: parameterized definitions must be bound before use. Argumentless definitions remain directly consumable, enabling static declarations such as `queries: [customFieldsQuery, rolesQuery]`.

Every read API accepts the same generic `QueryInput` contract—builders, bound requests, or argumentless definitions—and resolves it through one core path. Router adapters use `AnyQueryInput<Schema>` to intentionally erase result types without importing internal builder types, while `query`, `prepare`, `prefetch`, `explain`, `useQuery`, and `useQueries` retain precise inference at their normal call sites.
