### PR TITLE
Bring the demo onto the bound route query API

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -16,7 +16,7 @@
         "@socket.io/component-emitter": "^3.1.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-space-router": "^1.0.0-pre.7",
+        "react-space-router": "^1.0.0-pre.8",
         "socket.io": "^4.8.0",
         "socket.io-client": "^4.8.0"
       },
@@ -2149,12 +2149,12 @@
       }
     },
     "node_modules/react-space-router": {
-      "version": "1.0.0-pre.7",
-      "resolved": "https://registry.npmjs.org/react-space-router/-/react-space-router-1.0.0-pre.7.tgz",
-      "integrity": "sha512-qBqa7DD+FwschEE57JVs36LpwjgSgbR1p17r99vUPMBTeammcBLxGJ/Ndtxt+xqXEix8NvhmLhcmGYVTvEou1g==",
+      "version": "1.0.0-pre.8",
+      "resolved": "https://registry.npmjs.org/react-space-router/-/react-space-router-1.0.0-pre.8.tgz",
+      "integrity": "sha512-tCmiTXx5eQbgk4mOWTicfyqL6UEWrDz90xJX32MObT+giOadkR928fSgX3NNxqRWNmUVkwectaey8+CbWhERCQ==",
       "license": "ISC",
       "dependencies": {
-        "space-router": "^2.0.0"
+        "space-router": "^2.1.0"
       },
       "peerDependencies": {
         "react": ">=18"
@@ -2328,9 +2328,9 @@
       }
     },
     "node_modules/space-router": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/space-router/-/space-router-2.0.0.tgz",
-      "integrity": "sha512-yBMjsaoY47NdlfancgbWw/8WZ23QPPhb9sYdQP0JgLh2lXiobv1roPCyNn8TACyL2sTPAKAqh/zAybQMLM61fA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/space-router/-/space-router-2.1.0.tgz",
+      "integrity": "sha512-R5CtixEFBIZdZ8rqLhJl+qw4OXvnQ2ljwnYwnk3yz0+DrQtiGANK8XHwqRHZcXR0lUL64Tk2/KVZbZuH/X2PJA==",
       "license": "ISC",
       "engines": {
         "node": ">=18"

--- a/demo/package.json
+++ b/demo/package.json
@@ -17,7 +17,7 @@
     "@socket.io/component-emitter": "^3.1.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-space-router": "^1.0.0-pre.7",
+    "react-space-router": "^1.0.0-pre.8",
     "socket.io": "^4.8.0",
     "socket.io-client": "^4.8.0"
   },

--- a/demo/src/components/ActivityPanel.tsx
+++ b/demo/src/components/ActivityPanel.tsx
@@ -5,7 +5,7 @@
 
 import { useMemo, type ReactNode } from 'react'
 import { Link } from 'react-space-router'
-import { q, useQuery } from '../figbird'
+import { q, useQueries } from '../figbird'
 import { Explain } from './Explain'
 import { StatusDot } from './ui'
 
@@ -16,9 +16,11 @@ interface ActivityEntry {
 }
 
 export function ActivityPanel() {
-  const { data: comments } = useQuery(q.comments.orderBy('id', 'desc').limit(10).related('author'))
-  const { data: reactions } = useQuery(q.reactions.orderBy('id', 'desc').limit(6).related('user'))
-  const { data: issues, isFetching } = useQuery(q.issues.orderBy('updatedAt', 'desc').limit(6))
+  const [{ data: comments }, { data: reactions }, { data: issues, isFetching }] = useQueries([
+    q.comments.orderBy('id', 'desc').limit(10).related('author'),
+    q.reactions.orderBy('id', 'desc').limit(6).related('user'),
+    q.issues.orderBy('updatedAt', 'desc').limit(6),
+  ])
 
   const entries = useMemo<ActivityEntry[]>(() => {
     const out: ActivityEntry[] = []
@@ -77,16 +79,21 @@ export function ActivityPanel() {
         <span className='eyebrow'>Activity</span>
         <StatusDot active={isFetching} />
         <Explain
-          label='Cross-service feed'
-          query={`q.comments.orderBy('id', 'desc').limit(10)
-  .related('author')
-q.reactions.orderBy('id', 'desc').limit(6)
-  .related('user')
-q.issues.orderBy('updatedAt', 'desc').limit(6)`}
+          label='Parallel cross-service feed'
+          query={`const [comments, reactions, issues] =
+  useQueries([
+    q.comments.orderBy('id', 'desc').limit(10)
+      .related('author'),
+    q.reactions.orderBy('id', 'desc').limit(6)
+      .related('user'),
+    q.issues.orderBy('updatedAt', 'desc').limit(6),
+  ])`}
         >
-          Three independent queries — comments, reactions, issues — merged by timestamp in the
-          component. Each stays realtime on its own service; a teammate's comment lands here, in the
-          list's comment count, and in the open issue simultaneously, from one socket event.
+          <code>useQueries</code> starts all three independent roots before suspending, so this
+          boundary waits once instead of fetching comments, reactions, and issues serially. The
+          results are merged by timestamp in the component. Each stays realtime on its own service;
+          a teammate's comment lands here, in the list's comment count, and in the open issue
+          simultaneously, from one socket event.
         </Explain>
       </header>
       <ul className='activity-list'>

--- a/demo/src/components/NewIssueModal.tsx
+++ b/demo/src/components/NewIssueModal.tsx
@@ -6,7 +6,7 @@
 import { Suspense, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-space-router'
-import { q, useMutations, useQuery } from '../figbird'
+import { q, useMutations, useQueries } from '../figbird'
 import { Explain } from './Explain'
 
 export function NewIssueModal({ onClose }: { onClose: () => void }) {
@@ -33,8 +33,7 @@ export function NewIssueModal({ onClose }: { onClose: () => void }) {
 function NewIssueForm({ onClose }: { onClose: () => void }) {
   const m = useMutations()
   const navigate = useNavigate()
-  const { data: teams } = useQuery(q.teams)
-  const { data: users } = useQuery(q.users)
+  const [{ data: teams }, { data: users }] = useQueries([q.teams, q.users])
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
   const [teamId, setTeamId] = useState(teams[0]?.id ?? 1)

--- a/demo/src/figbird.ts
+++ b/demo/src/figbird.ts
@@ -161,21 +161,20 @@ export const figbird = new Figbird({ schema, adapter })
 
 // Pure, schema-bound React API. FigbirdProvider supplies the runtime instance;
 // useMutations returns its typed write proxy inside components.
-export const { useQuery, q, useMutations, defineQuery, useAction, useMutating, useMutationQueue } =
-  createHooks(schema)
+export const {
+  useQuery,
+  useQueries,
+  q,
+  useMutations,
+  defineQuery,
+  useAction,
+  useMutating,
+  useMutationQueue,
+} = createHooks(schema)
 
 // Reference data: preload the complete sets once — realtime maintains them, and every
 // later read against these services (filters, sorts, windows, relation fetches) is
 // answered locally from the materialized cache with no roundtrip.
-figbird.prepare(
-  defineQuery('allUsers', () => q.users.all()),
-  undefined,
-)
-figbird.prepare(
-  defineQuery('allTeams', () => q.teams.all()),
-  undefined,
-)
-figbird.prepare(
-  defineQuery('allLabels', () => q.labels.all()),
-  undefined,
-)
+figbird.prepare(defineQuery('allUsers', () => q.users.all()))
+figbird.prepare(defineQuery('allTeams', () => q.teams.all()))
+figbird.prepare(defineQuery('allLabels', () => q.labels.all()))

--- a/demo/src/pages/IssueDetail/Comments.tsx
+++ b/demo/src/pages/IssueDetail/Comments.tsx
@@ -34,7 +34,7 @@ interface CommentThread {
 }
 
 export function CommentsPanel({ issueId }: { issueId: number }) {
-  const { data: comments, isFetching } = useQuery(issueCommentsQuery, { id: issueId })
+  const { data: comments, isFetching } = useQuery(issueCommentsQuery({ id: issueId }))
   const [replyTo, setReplyTo] = useState<number | null>(null)
 
   const threads = useMemo<CommentThread[]>(() => {
@@ -70,7 +70,7 @@ export function CommentsPanel({ issueId }: { issueId: number }) {
 
 // fired by the route, in parallel with
 // this screen's lazy chunk:
-prepare(issueCommentsQuery, { id })`}
+prepare(issueCommentsQuery({ id }))`}
         >
           The route warmed this exact query before the screen's code even downloaded, so the thread
           usually renders without a fallback. It's deliberately unwindowed — figbird classifies it{' '}

--- a/demo/src/pages/IssueDetail/Tasks.tsx
+++ b/demo/src/pages/IssueDetail/Tasks.tsx
@@ -41,7 +41,7 @@ function nextClientTaskId(): number {
 }
 
 export function TasksPanel({ issueId, users }: { issueId: number; users: User[] }) {
-  const { data: tasks } = useQuery(issueTasksQuery, { id: issueId })
+  const { data: tasks } = useQuery(issueTasksQuery({ id: issueId }))
   const queue = useMutationQueue(issueTaskQueue, `issue:${issueId}:tasks`)
   const [focusTaskId, setFocusTaskId] = useState<number | null>(null)
 

--- a/demo/src/pages/IssueDetail/queries.ts
+++ b/demo/src/pages/IssueDetail/queries.ts
@@ -7,7 +7,7 @@
  */
 
 import { defineQuery, q } from '../../figbird'
-import type { QueryDescriptor, RoutePrepareContext } from 'react-space-router'
+import type { RoutePrepareContext } from 'react-space-router'
 
 // Args here come from typed code (the route coerces the URL param first),
 // so the plain typed-args form is enough. Pass a zod/valibot/arktype schema as the
@@ -42,13 +42,9 @@ export const issueTasksQuery = defineQuery(({ id }: { id: number }) =>
   q.tasks.where({ issueId: id }).orderBy('position', 'asc').related('assignee'),
 )
 
-export function issueDetailRouteQueries({ params }: RoutePrepareContext): QueryDescriptor[] {
+export function issueDetailRouteQueries({ params }: RoutePrepareContext) {
   const id = Number(params.id)
   if (!Number.isFinite(id)) return []
 
-  return [
-    [issueDetailQuery, { id }],
-    [issueTasksQuery, { id }],
-    [issueCommentsQuery, { id }],
-  ]
+  return [issueDetailQuery({ id }), issueTasksQuery({ id }), issueCommentsQuery({ id })]
 }

--- a/demo/src/pages/IssueDetail/screen.tsx
+++ b/demo/src/pages/IssueDetail/screen.tsx
@@ -14,7 +14,7 @@
  */
 
 import { useNavigate, useRoute } from 'react-space-router'
-import { q, useAction, useMutating, useMutations, useQuery } from '../../figbird'
+import { q, useAction, useMutating, useMutations, useQueries, useQuery } from '../../figbird'
 import { Explain } from '../../components/Explain'
 import { StatusDot } from '../../components/ui'
 import { CommentsPanel } from './Comments'
@@ -54,13 +54,15 @@ function IssueDetailLoaded({ issueId }: { issueId: number }) {
   const navigate = useNavigate()
   // The route's queries declaration warmed this exact query before the chunk arrived. The Suspense
   // boundary above (keyed by issueId) renders its skeleton if we're still cold.
-  const { data: issue, error, isFetching, refetch } = useQuery(issueDetailQuery, { id: issueId })
+  const { data: issue, error, isFetching, refetch } = useQuery(issueDetailQuery({ id: issueId }))
 
   // Cycled through by the toolbar actions — queried rather than mirrored from the
   // server seed, so they can't silently drift when the seed changes.
-  const { data: users } = useQuery(q.users)
-  const { data: teams } = useQuery(q.teams)
-  const { data: labels } = useQuery(q.labels)
+  const [{ data: users }, { data: teams }, { data: labels }] = useQueries([
+    q.users,
+    q.teams,
+    q.labels,
+  ])
 
   // One action per button: each owns its pending label; the bodies close over
   // the current issue, so no arguments need threading. Writes go through `m` —
@@ -153,8 +155,9 @@ function IssueDetailLoaded({ issueId }: { issueId: number }) {
 // and row-hover prefetch, in parallel with
 // this screen's lazy chunk:
 queries: ({ params }) => [
-  [issueDetailQuery, { id: +params.id }],
-  [issueCommentsQuery, { id: +params.id }],
+  issueDetailQuery({ id: +params.id }),
+  issueTasksQuery({ id: +params.id }),
+  issueCommentsQuery({ id: +params.id }),
 ]`}
           >
             One <code>.get(id)</code> query assembles the whole graph — issue, people, team, labels


### PR DESCRIPTION
React Space Router `pre.8` now treats route data requests as opaque, with Figbird's bound query requests carrying validated arguments across that boundary. The demo still showed the old `[query, args]` descriptor API, so it no longer represented the integration we intend applications to copy.

This brings route preparation and hover prefetch onto the same bound requests consumed by the screen. It also demonstrates `useQueries` where one Suspense boundary owns several independent roots, while keeping related data expressed as a single relational query.

Validated with the demo TypeScript check and production build, plus Figbird's lint, formatting, and full 349-test suite.
