### PR TITLE
Add useWindowQuery and virtualized archive demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Transient fetch failures retry up to three times with exponential backoff before
 - **Optimistic mutations** — declared once per surface, rolled back on failure everywhere
 - **Ordered autosave queues** — buffer and merge edits across related records without losing optimism
 - **Prepare & prefetch** — routers and hover handlers warm the exact queries screens will read
+- **Virtualized windows** — bounded relational pages follow any list virtualizer's visible range
 - **Full TypeScript** — define a schema once, get inference through builders, relations, and mutations
 
 ## Documentation

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -14,6 +14,7 @@
         "@feathersjs/socketio": "^5.0.0",
         "@feathersjs/socketio-client": "^5.0.0",
         "@socket.io/component-emitter": "^3.1.0",
+        "@tanstack/react-virtual": "^3.14.9",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-space-router": "^1.0.0-pre.8",
@@ -1361,6 +1362,33 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/demo/package.json
+++ b/demo/package.json
@@ -15,6 +15,7 @@
     "@feathersjs/socketio": "^5.0.0",
     "@feathersjs/socketio-client": "^5.0.0",
     "@socket.io/component-emitter": "^3.1.0",
+    "@tanstack/react-virtual": "^3.14.9",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-space-router": "^1.0.0-pre.8",

--- a/demo/server.mjs
+++ b/demo/server.mjs
@@ -94,6 +94,23 @@ class SlowMemoryService extends MemoryService {
   }
 }
 
+class ArchiveMemoryService extends SlowMemoryService {
+  find(params = {}) {
+    const { $search, ...query } = params.query ?? {}
+    if (typeof $search !== 'string' || $search.trim() === '') {
+      return super.find(params)
+    }
+    const term = $search.trim().toLocaleLowerCase()
+    const matchingIds = Object.values(this.store)
+      .filter(row => row.title.toLocaleLowerCase().includes(term))
+      .map(row => row.id)
+    return super.find({
+      ...params,
+      query: { ...query, id: { $in: matchingIds } },
+    })
+  }
+}
+
 const app = feathers()
 
 app.configure(
@@ -114,7 +131,7 @@ const users = new SlowMemoryService({ multi: false, paginate: false }, { speed: 
 const teams = new SlowMemoryService({ multi: false, paginate: false }, { speed: 0.6 })
 const labels = new SlowMemoryService({ multi: false, paginate: false }, { speed: 0.6 })
 const issues = new SlowMemoryService({ multi: false, paginate: { default: 50, max: 200 } })
-const archivedIssues = new SlowMemoryService(
+const archivedIssues = new ArchiveMemoryService(
   { multi: false, paginate: { default: 50, max: 200 } },
   { speed: 0.9 },
 )

--- a/demo/server.mjs
+++ b/demo/server.mjs
@@ -1,8 +1,8 @@
 /**
  * Tiny Feathers server for the figbird demo.
  *
- * Exposes services over Socket.IO: issues, tasks, comments, users, teams,
- * labels, issue-label joins, reactions.
+ * Exposes services over Socket.IO: issues, archived issues, tasks, comments,
+ * users, teams, labels, issue-label joins, reactions.
  *
  * Simulated conditions are a *dial*, not a tax:
  *   - Network latency has three profiles — fast (default, LAN-ish), realistic
@@ -114,6 +114,10 @@ const users = new SlowMemoryService({ multi: false, paginate: false }, { speed: 
 const teams = new SlowMemoryService({ multi: false, paginate: false }, { speed: 0.6 })
 const labels = new SlowMemoryService({ multi: false, paginate: false }, { speed: 0.6 })
 const issues = new SlowMemoryService({ multi: false, paginate: { default: 50, max: 200 } })
+const archivedIssues = new SlowMemoryService(
+  { multi: false, paginate: { default: 50, max: 200 } },
+  { speed: 0.9 },
+)
 const comments = new SlowMemoryService(
   { multi: false, paginate: { default: 50, max: 500 } },
   { speed: 1.2 },
@@ -135,12 +139,23 @@ app.use('users', users)
 app.use('teams', teams)
 app.use('labels', labels)
 app.use('issues', issues)
+app.use('archivedIssues', archivedIssues)
 app.use('comments', comments)
 app.use('tasks', tasks)
 app.use('issueLabels', issueLabels)
 app.use('reactions', reactions)
 
-const allServices = [users, teams, labels, issues, comments, tasks, issueLabels, reactions]
+const allServices = [
+  users,
+  teams,
+  labels,
+  issues,
+  archivedIssues,
+  comments,
+  tasks,
+  issueLabels,
+  reactions,
+]
 
 const clearStores = () => {
   for (const svc of allServices) {
@@ -153,6 +168,8 @@ const clearStores = () => {
 // ----- Seed -----
 
 const SEED_BASE_TIME = Date.parse('2026-06-30T12:00:00.000Z')
+const ARCHIVE_SIZE = 5000
+const ARCHIVE_ID_BASE = 100_000
 
 const TITLE_LEADS = [
   'Hover state on primary button is off',
@@ -348,6 +365,39 @@ const seed = async () => {
         }
       }
       commentId++
+    }
+  }
+
+  // A deliberately deep, immutable archive for the virtualization demo. Keeping
+  // this on a separate service prevents 5,000 stress-test rows from changing the
+  // behavior of the normal Issues and Teams screens. Archive ids live in their
+  // own range so their label junction rows can share `issueLabels` safely.
+  for (let i = 1; i <= ARCHIVE_SIZE; i++) {
+    const id = ARCHIVE_ID_BASE + i
+    const lead = TITLE_LEADS[(i * 7) % TITLE_LEADS.length]
+    const assigneeId = pick(userIds)
+    archivedIssues.store[id] = {
+      id,
+      title: `${lead} — archived case ${String(i).padStart(4, '0')}`,
+      assigneeId,
+      teamId: users.store[assigneeId].teamId,
+      deletedAt: new Date(SEED_BASE_TIME - i * 37 * 60_000).toISOString(),
+      deletionReason: pick([
+        'Duplicate report',
+        'Resolved elsewhere',
+        'Imported by mistake',
+        'No longer reproducible',
+      ]),
+    }
+
+    // Every archived row has one-to-three labels, exercising the two-hop many
+    // relation on every page rather than only on a lucky subset of rows.
+    const chosen = new Set()
+    const labelCount = 1 + Math.floor(rng() * 3)
+    while (chosen.size < labelCount) chosen.add(pick(labelIds))
+    for (const labelId of chosen) {
+      issueLabels.store[issueLabelId] = { id: issueLabelId, issueId: id, labelId }
+      issueLabelId++
     }
   }
 

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -13,6 +13,7 @@ import { NewIssueModal } from './components/NewIssueModal'
 import { figbird } from './figbird'
 import { issueDetailRouteQueries } from './pages/IssueDetail/queries'
 import { TeamsPage } from './pages/Teams/screen'
+import { ArchivePage } from './pages/Archive/screen'
 import { DetailSkeleton, SkeletonRows } from './components/ui'
 
 function EmptyDetail() {
@@ -89,7 +90,7 @@ function NavTab({ href, label }: { href: string; label: string }) {
 function Workspace({ children }: { children?: ReactNode }) {
   const route = useRoute()
   const path = route?.pathname ?? '/'
-  const isFull = path.startsWith('/teams')
+  const isFull = path.startsWith('/teams') || path.startsWith('/archive')
   // Keyed Suspense boundary for issue detail: each id starts cold so the destination
   // shows its own skeleton instead of leaking the previous issue's data while the
   // new one loads.
@@ -102,6 +103,7 @@ function Workspace({ children }: { children?: ReactNode }) {
         <span className='brand'>figbird</span>
         <NavTab href='/' label='Issues' />
         <NavTab href='/teams' label='Teams' />
+        <NavTab href='/archive' label='Archive' />
         <button className='link new-issue-btn' onClick={() => setShowNewIssue(true)}>
           + New issue
         </button>
@@ -141,6 +143,7 @@ const routes = [
       // Eager route, on purpose — a small screen with no route-critical data doesn't
       // earn a chunk split. The demo shows both styles.
       { path: '/teams', component: TeamsPage },
+      { path: '/archive', component: ArchivePage },
     ],
   },
 ]

--- a/demo/src/figbird.ts
+++ b/demo/src/figbird.ts
@@ -43,6 +43,14 @@ export interface Issue {
    */
   commentIds: number[]
 }
+export interface ArchivedIssue {
+  id: number
+  title: string
+  assigneeId: number
+  teamId: number
+  deletedAt: string
+  deletionReason: string
+}
 export interface Comment {
   id: number
   issueId: number
@@ -83,6 +91,7 @@ export const schema = createSchema({
     users: service<{ item: User }>(),
     teams: service<{ item: Team }>(),
     issues: service<{ item: Issue }>(),
+    archivedIssues: service<{ item: ArchivedIssue }>(),
     comments: service<{ item: Comment }>(),
     labels: service<{ item: Label }>(),
     issueLabels: service<{ item: IssueLabel }>(),
@@ -102,6 +111,14 @@ export const schema = createSchema({
       // Label[] directly — figbird fetches the issueLabels junction, then the
       // labels, and hides the join. Realtime events on either service (e.g. a new
       // issueLabels row) flow into the assembled result.
+      labels: many(
+        { sourceField: 'id', destService: 'issueLabels', destField: 'issueId' },
+        { sourceField: 'labelId', destService: 'labels' },
+      ),
+    }),
+    archivedIssues: ({ one, many }) => ({
+      assignee: one({ sourceField: 'assigneeId', destService: 'users' }),
+      team: one({ sourceField: 'teamId', destService: 'teams' }),
       labels: many(
         { sourceField: 'id', destService: 'issueLabels', destField: 'issueId' },
         { sourceField: 'labelId', destService: 'labels' },

--- a/demo/src/figbird.ts
+++ b/demo/src/figbird.ts
@@ -180,6 +180,7 @@ export const figbird = new Figbird({ schema, adapter })
 // useMutations returns its typed write proxy inside components.
 export const {
   useQuery,
+  useWindowQuery,
   useQueries,
   q,
   useMutations,

--- a/demo/src/pages/Archive/components.tsx
+++ b/demo/src/pages/Archive/components.tsx
@@ -1,0 +1,153 @@
+import { Explain } from '../../components/Explain'
+import { StatusDot } from '../../components/ui'
+import type { ArchivedIssue, Label, Team, User } from '../../figbird'
+
+export type ArchiveSort = 'deleted-desc' | 'deleted-asc' | 'title-asc'
+
+type ArchiveRow = ArchivedIssue & {
+  assignee: User | null
+  team: Team | null
+  labels: Label[]
+}
+
+interface ArchiveToolbarProps {
+  searchInput: string
+  onSearchInputChange: (value: string) => void
+  sort: ArchiveSort
+  onSortChange: (value: ArchiveSort) => void
+  cachedRows: number
+  mountedRows: number
+  visibleStart: number
+  visibleEnd: number
+  total: number | undefined
+  isFetching: boolean
+  onJumpToTop: () => void
+}
+
+export function ArchiveToolbar({
+  searchInput,
+  onSearchInputChange,
+  sort,
+  onSortChange,
+  cachedRows,
+  mountedRows,
+  visibleStart,
+  visibleEnd,
+  total,
+  isFetching,
+  onJumpToTop,
+}: ArchiveToolbarProps) {
+  return (
+    <div className='archive-toolbar'>
+      <input
+        value={searchInput}
+        onChange={event => onSearchInputChange(event.target.value)}
+        className='search-input compact archive-search'
+        placeholder='Search archive…'
+        aria-label='Search archived issues'
+      />
+      <select
+        className='archive-sort'
+        value={sort}
+        onChange={event => onSortChange(event.target.value as ArchiveSort)}
+        aria-label='Sort archived issues'
+      >
+        <option value='deleted-desc'>Recently deleted</option>
+        <option value='deleted-asc'>Oldest deleted</option>
+        <option value='title-asc'>Title A–Z</option>
+      </select>
+      <div className='archive-stat'>
+        <span className='archive-stat-value'>{cachedRows.toLocaleString()}</span>
+        <span>cached</span>
+      </div>
+      <div className='archive-stat'>
+        <span className='archive-stat-value'>{mountedRows}</span>
+        <span>mounted</span>
+      </div>
+      <div className='archive-stat archive-stat-wide'>
+        <span className='archive-stat-value'>
+          {visibleStart + 1}–{Math.min(visibleEnd + 1, total ?? Infinity)}
+        </span>
+        <span>of {total?.toLocaleString() ?? 'unknown'}</span>
+      </div>
+      <StatusDot active={isFetching} />
+      <span className='archive-prefetch-state'>
+        {isFetching ? 'fetching window…' : 'adjacent pages ready'}
+      </span>
+      <button className='link archive-top-button' onClick={onJumpToTop}>
+        ↑ Top
+      </button>
+      <Explain
+        label='Windowed relational query'
+        query={`useWindowQuery(
+  q.archivedIssues
+    .where(search)
+    .orderBy(sortField, direction)
+    .related('assignee')
+    .related('team')
+    .related('labels'),
+  {
+    range: { start, end },
+    pageSize: 40,
+    preloadPages: 1,
+    maxPages: 5,
+  },
+)`}
+      >
+        TanStack Virtual reports the visible indexes. Figbird fetches those server blocks plus one
+        page on either side, assembles all three relations, and evicts distant blocks. Search and
+        sorting create a new server-authoritative list identity; a deep reload starts at the saved
+        window rather than rebuilding the prefix.
+      </Explain>
+    </div>
+  )
+}
+
+export function ArchiveWindowPlaceholder() {
+  return (
+    <div className='archive-loader' aria-label='Loading row'>
+      <span className='spinner archive-spinner' /> Fetching this window…
+    </div>
+  )
+}
+
+const DATE_FORMATTER = new Intl.DateTimeFormat('en', { dateStyle: 'medium' })
+
+export function ArchiveLedgerRow({ row, index }: { row: ArchiveRow; index: number }) {
+  return (
+    <article className='archive-row' role='listitem'>
+      <div className='archive-row-number'>{String(index + 1).padStart(4, '0')}</div>
+      <div className='archive-row-main'>
+        <div className='archive-row-title'>{row.title}</div>
+        <div className='archive-row-reason'>
+          {row.deletionReason} · {row.team?.name ?? 'No team'}
+        </div>
+      </div>
+      <div className='archive-assignee'>
+        <span className='archive-avatar'>{row.assignee?.avatar ?? '–'}</span>
+        <span>{row.assignee?.name ?? 'Unassigned'}</span>
+      </div>
+      <div className='archive-labels'>
+        {row.labels.map(label => (
+          <span key={label.id} className={`label mini ${label.tone}`}>
+            {label.name}
+          </span>
+        ))}
+      </div>
+      <time className='archive-date' dateTime={row.deletedAt}>
+        {DATE_FORMATTER.format(new Date(row.deletedAt))}
+      </time>
+    </article>
+  )
+}
+
+export function ArchiveSkeleton() {
+  return (
+    <section className='archive-ledger archive-skeleton' aria-label='Loading archive window'>
+      <div className='archive-toolbar'>Opening the requested archive window…</div>
+      {Array.from({ length: 9 }, (_, index) => (
+        <div key={index} className='archive-skeleton-row' />
+      ))}
+    </section>
+  )
+}

--- a/demo/src/pages/Archive/screen.tsx
+++ b/demo/src/pages/Archive/screen.tsx
@@ -1,0 +1,298 @@
+/**
+ * A deliberately deep archive combining Figbird's relational pagination with
+ * TanStack Virtual. The query owns server/cache concerns; the virtualizer owns
+ * which of the loaded rows are mounted in the DOM.
+ */
+
+import { Suspense, useEffect, useRef, useState } from 'react'
+import { useVirtualizer, type Virtualizer } from '@tanstack/react-virtual'
+import { Explain } from '../../components/Explain'
+import { StatusDot } from '../../components/ui'
+import { q, useQuery, type ArchivedIssue, type Label, type Team, type User } from '../../figbird'
+
+const PAGE_SIZE = 40
+const ROW_HEIGHT = 72
+const RESTORE_KEY = 'figbird-demo:archive-scroll'
+
+interface SavedPosition {
+  offset: number
+  index: number
+}
+
+type ArchiveRow = ArchivedIssue & {
+  assignee: User | null
+  team: Team | null
+  labels: Label[]
+}
+
+function readSavedPosition(): SavedPosition | null {
+  try {
+    const value: unknown = JSON.parse(sessionStorage.getItem(RESTORE_KEY) ?? 'null')
+    if (
+      value != null &&
+      typeof value === 'object' &&
+      'offset' in value &&
+      'index' in value &&
+      typeof value.offset === 'number' &&
+      typeof value.index === 'number'
+    ) {
+      return { offset: value.offset, index: value.index }
+    }
+  } catch {
+    // A malformed browser value should never keep the demo from rendering.
+  }
+  return null
+}
+
+export function ArchivePage() {
+  return (
+    <main className='detail archive-page'>
+      <header className='archive-head'>
+        <div>
+          <div className='archive-kicker'>Cold storage / 5,000 records</div>
+          <h1 className='archive-title'>The long tail</h1>
+          <p className='archive-deck'>
+            Relational pages arrive just ahead of the viewport. Only the visible ledger rows exist
+            in the DOM.
+          </p>
+        </div>
+        <div className='archive-head-note'>
+          Scroll deep, then reload. Your exact place is restored.
+        </div>
+      </header>
+      <Suspense fallback={<ArchiveSkeleton />}>
+        <VirtualArchive />
+      </Suspense>
+    </main>
+  )
+}
+
+function VirtualArchive() {
+  const {
+    data: rows,
+    total,
+    hasMore,
+    loadMore,
+    isLoadingMore,
+    isFetching,
+    loadMoreError,
+  } = useQuery(
+    q.archivedIssues
+      .orderBy('deletedAt', 'desc')
+      .paginate({ pageSize: PAGE_SIZE, includeTotal: true })
+      .related('assignee')
+      .related('team')
+      .related('labels'),
+  )
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const savedPosition = useRef(readSavedPosition())
+  const restored = useRef(savedPosition.current === null)
+  const [restoreComplete, setRestoreComplete] = useState(restored.current)
+
+  const virtualizer = useVirtualizer({
+    count: hasMore ? rows.length + 1 : rows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 5,
+    getItemKey: index => rows[index]?.id ?? 'archive-loader',
+    onChange: instance => persistPosition(instance, restored.current),
+  })
+  const virtualRows = virtualizer.getVirtualItems()
+  const lastVirtualIndex = virtualRows.at(-1)?.index
+
+  // There is no public "page 2 query" to prefetch: pagination cursors belong to
+  // the query ref. Calling loadMore one viewport early is the appropriate prefetch
+  // primitive, and the ref deduplicates overlapping calls.
+  useEffect(() => {
+    if (
+      restoreComplete &&
+      lastVirtualIndex != null &&
+      lastVirtualIndex >= rows.length - 12 &&
+      hasMore &&
+      !isLoadingMore
+    ) {
+      loadMore()
+    }
+  }, [hasMore, isLoadingMore, lastVirtualIndex, loadMore, restoreComplete, rows.length])
+
+  // Reload recovery first rebuilds the paginated prefix needed to reach the saved
+  // row, then asks the virtualizer to land on the exact pixel offset. This works
+  // without persisting Figbird's cache or teaching the server about UI state.
+  useEffect(() => {
+    if (restoreComplete) return
+    const target = savedPosition.current
+    if (target === null) {
+      restored.current = true
+      setRestoreComplete(true)
+      return
+    }
+    if (rows.length <= target.index && hasMore) {
+      if (!isLoadingMore) loadMore()
+      return
+    }
+
+    const frame = requestAnimationFrame(() => {
+      virtualizer.scrollToOffset(target.offset, { align: 'start' })
+      restored.current = true
+      setRestoreComplete(true)
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [hasMore, isLoadingMore, loadMore, restoreComplete, rows.length, virtualizer])
+
+  const mountedRows = virtualRows.filter(item => item.index < rows.length).length
+  const visibleStart = virtualRows.find(item => item.index < rows.length)?.index ?? 0
+  const visibleEnd =
+    virtualRows
+      .slice()
+      .reverse()
+      .find(item => item.index < rows.length)?.index ?? Math.max(0, rows.length - 1)
+
+  const jumpToTop = () => {
+    sessionStorage.removeItem(RESTORE_KEY)
+    virtualizer.scrollToOffset(0)
+  }
+
+  return (
+    <section className='archive-ledger'>
+      <div className='archive-toolbar'>
+        <div className='archive-stat'>
+          <span className='archive-stat-value'>{rows.length.toLocaleString()}</span>
+          <span>loaded</span>
+        </div>
+        <div className='archive-stat'>
+          <span className='archive-stat-value'>{mountedRows}</span>
+          <span>mounted</span>
+        </div>
+        <div className='archive-stat archive-stat-wide'>
+          <span className='archive-stat-value'>
+            {visibleStart + 1}–{visibleEnd + 1}
+          </span>
+          <span>render window</span>
+        </div>
+        <StatusDot active={isFetching || isLoadingMore} />
+        <span className='archive-prefetch-state'>
+          {isLoadingMore
+            ? 'preloading next page…'
+            : hasMore
+              ? 'next page armed'
+              : 'archive complete'}
+        </span>
+        <button className='link archive-top-button' onClick={jumpToTop}>
+          ↑ Top
+        </button>
+        <Explain
+          label='Virtualized relational pagination'
+          query={`q.archivedIssues
+  .orderBy('deletedAt', 'desc')
+  .paginate({ pageSize: 40, includeTotal: true })
+  .related('assignee')     // one
+  .related('team')         // one
+  .related('labels')       // many, two-hop junction
+
+// TanStack Virtual mounts visible rows only.
+// loadMore() runs one viewport before the edge.`}
+        >
+          Figbird fetches and assembles each page, including an assignee, team, and the two-hop
+          label list for every row. TanStack Virtual independently limits DOM work. Near the end of
+          the loaded window, <code>loadMore()</code> warms the next page before it is visible.
+          Scroll position is stored as a row plus pixel offset; reload reconstructs only the prefix
+          needed to reach it.
+        </Explain>
+      </div>
+
+      <div className='archive-columns' aria-hidden>
+        <span>No.</span>
+        <span>Archived issue</span>
+        <span>Assignee</span>
+        <span>Labels</span>
+        <span>Deleted</span>
+      </div>
+
+      <div ref={scrollRef} className='archive-scroll' role='list' aria-label='Archived issues'>
+        <div className='archive-virtual-space' style={{ height: virtualizer.getTotalSize() }}>
+          {virtualRows.map(virtualRow => {
+            const row = rows[virtualRow.index]
+            return (
+              <div
+                key={virtualRow.key}
+                className='archive-virtual-row'
+                style={{
+                  height: virtualRow.size,
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              >
+                {row ? (
+                  <ArchiveLedgerRow row={row} index={virtualRow.index} />
+                ) : (
+                  <div className='archive-loader'>
+                    <span className='spinner archive-spinner' /> Fetching the next {PAGE_SIZE}…
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      {!restoreComplete && savedPosition.current ? (
+        <div className='archive-restore'>
+          Restoring row{' '}
+          {Math.min(savedPosition.current.index + 1, total ?? Infinity).toLocaleString()}…{' '}
+          {rows.length.toLocaleString()} loaded
+        </div>
+      ) : null}
+      {loadMoreError ? (
+        <div className='archive-error'>Next page failed. Scroll again to retry.</div>
+      ) : null}
+    </section>
+  )
+}
+
+function persistPosition(virtualizer: Virtualizer<HTMLDivElement, Element>, canPersist: boolean) {
+  if (!canPersist) return
+  const offset = virtualizer.scrollOffset ?? 0
+  const value: SavedPosition = {
+    offset,
+    index: Math.max(0, Math.floor(offset / ROW_HEIGHT)),
+  }
+  sessionStorage.setItem(RESTORE_KEY, JSON.stringify(value))
+}
+
+function ArchiveLedgerRow({ row, index }: { row: ArchiveRow; index: number }) {
+  return (
+    <article className='archive-row' role='listitem'>
+      <div className='archive-row-number'>{String(index + 1).padStart(4, '0')}</div>
+      <div className='archive-row-main'>
+        <div className='archive-row-title'>{row.title}</div>
+        <div className='archive-row-reason'>
+          {row.deletionReason} · {row.team?.name ?? 'No team'}
+        </div>
+      </div>
+      <div className='archive-assignee'>
+        <span className='archive-avatar'>{row.assignee?.avatar ?? '–'}</span>
+        <span>{row.assignee?.name ?? 'Unassigned'}</span>
+      </div>
+      <div className='archive-labels'>
+        {row.labels.map(label => (
+          <span key={label.id} className={`label mini ${label.tone}`}>
+            {label.name}
+          </span>
+        ))}
+      </div>
+      <time className='archive-date' dateTime={row.deletedAt}>
+        {new Intl.DateTimeFormat('en', { dateStyle: 'medium' }).format(new Date(row.deletedAt))}
+      </time>
+    </article>
+  )
+}
+
+function ArchiveSkeleton() {
+  return (
+    <section className='archive-ledger archive-skeleton' aria-label='Loading archive'>
+      <div className='archive-toolbar'>Opening the archive…</div>
+      {Array.from({ length: 9 }, (_, index) => (
+        <div key={index} className='archive-skeleton-row' />
+      ))}
+    </section>
+  )
+}

--- a/demo/src/pages/Archive/screen.tsx
+++ b/demo/src/pages/Archive/screen.tsx
@@ -1,23 +1,33 @@
 /**
- * A deliberately deep archive combining Figbird's relational pagination with
- * TanStack Virtual. The query owns server/cache concerns; the virtualizer owns
- * which of the loaded rows are mounted in the DOM.
+ * A deep, relational archive driven by Figbird's viewport query and rendered with
+ * TanStack Virtual. Query windows and DOM windows stay independent and bounded.
  */
 
 import { Suspense, useEffect, useRef, useState } from 'react'
 import { useVirtualizer, type Virtualizer } from '@tanstack/react-virtual'
+import { useDebouncedTransition } from 'figbird'
 import { Explain } from '../../components/Explain'
 import { StatusDot } from '../../components/ui'
-import { q, useQuery, type ArchivedIssue, type Label, type Team, type User } from '../../figbird'
+import {
+  q,
+  useWindowQuery,
+  type ArchivedIssue,
+  type Label,
+  type Team,
+  type User,
+} from '../../figbird'
 
 const PAGE_SIZE = 40
 const ROW_HEIGHT = 72
 const RESTORE_KEY = 'figbird-demo:archive-scroll'
+const INITIAL_WINDOW_SIZE = 18
 
 interface SavedPosition {
   offset: number
   index: number
 }
+
+type ArchiveSort = 'deleted-desc' | 'deleted-asc' | 'title-asc'
 
 type ArchiveRow = ArchivedIssue & {
   assignee: User | null
@@ -52,12 +62,11 @@ export function ArchivePage() {
           <div className='archive-kicker'>Cold storage / 5,000 records</div>
           <h1 className='archive-title'>The long tail</h1>
           <p className='archive-deck'>
-            Relational pages arrive just ahead of the viewport. Only the visible ledger rows exist
-            in the DOM.
+            A bounded relational data window follows the virtualized viewport in either direction.
           </p>
         </div>
         <div className='archive-head-note'>
-          Scroll deep, then reload. Your exact place is restored.
+          Grab the scrollbar or reload deep in the list. Only that window is fetched.
         </div>
       </header>
       <Suspense fallback={<ArchiveSkeleton />}>
@@ -68,84 +77,76 @@ export function ArchivePage() {
 }
 
 function VirtualArchive() {
+  const savedPosition = useRef(readSavedPosition())
+  const initialIndex = savedPosition.current?.index ?? 0
+  const [range, setRange] = useState({
+    start: initialIndex,
+    end: initialIndex + INITIAL_WINDOW_SIZE,
+  })
+  const [searchInput, setSearchInput] = useState('')
+  const search = useDebouncedTransition(searchInput.trim(), 250)
+  const [sort, setSort] = useState<ArchiveSort>('deleted-desc')
+  const queryIdentity = `${search}\u0000${sort}`
+  const committedIdentity = useRef(queryIdentity)
+  const queryChanged = committedIdentity.current !== queryIdentity
+  const requestedRange = queryChanged ? { start: 0, end: INITIAL_WINDOW_SIZE } : range
+
+  let archiveQuery = q.archivedIssues.where(search === '' ? {} : { $search: search })
+  archiveQuery =
+    sort === 'title-asc'
+      ? archiveQuery.orderBy('title', 'asc').orderBy('id', 'asc')
+      : sort === 'deleted-asc'
+        ? archiveQuery.orderBy('deletedAt', 'asc').orderBy('id', 'asc')
+        : archiveQuery.orderBy('deletedAt', 'desc').orderBy('id', 'desc')
+
   const {
     data: rows,
     total,
-    hasMore,
-    loadMore,
-    isLoadingMore,
     isFetching,
-    loadMoreError,
-  } = useQuery(
-    q.archivedIssues
-      .orderBy('deletedAt', 'desc')
-      .paginate({ pageSize: PAGE_SIZE, includeTotal: true })
-      .related('assignee')
-      .related('team')
-      .related('labels'),
-  )
+    error,
+  } = useWindowQuery(archiveQuery.related('assignee').related('team').related('labels'), {
+    range: requestedRange,
+    pageSize: PAGE_SIZE,
+    preloadPages: 1,
+    maxPages: 5,
+  })
   const scrollRef = useRef<HTMLDivElement | null>(null)
-  const savedPosition = useRef(readSavedPosition())
-  const restored = useRef(savedPosition.current === null)
-  const [restoreComplete, setRestoreComplete] = useState(restored.current)
 
   const virtualizer = useVirtualizer({
-    count: hasMore ? rows.length + 1 : rows.length,
+    count: total ?? Math.max(1, requestedRange.end),
     getScrollElement: () => scrollRef.current,
     estimateSize: () => ROW_HEIGHT,
     overscan: 5,
-    getItemKey: index => rows[index]?.id ?? 'archive-loader',
-    onChange: instance => persistPosition(instance, restored.current),
+    initialOffset: savedPosition.current?.offset ?? 0,
+    getItemKey: index => index,
+    onChange: instance => {
+      if (committedIdentity.current !== queryIdentity) return
+      persistPosition(instance)
+      const items = instance.getVirtualItems()
+      const first = items[0]?.index
+      const last = items.at(-1)?.index
+      if (first === undefined || last === undefined) return
+      setRange(current =>
+        current.start === first && current.end === last + 1
+          ? current
+          : { start: first, end: last + 1 },
+      )
+    },
   })
+
+  useEffect(() => {
+    if (!queryChanged) return
+    committedIdentity.current = queryIdentity
+    savedPosition.current = null
+    sessionStorage.removeItem(RESTORE_KEY)
+    setRange({ start: 0, end: INITIAL_WINDOW_SIZE })
+    virtualizer.scrollToOffset(0)
+  }, [queryChanged, queryIdentity, virtualizer])
+
   const virtualRows = virtualizer.getVirtualItems()
-  const lastVirtualIndex = virtualRows.at(-1)?.index
-
-  // There is no public "page 2 query" to prefetch: pagination cursors belong to
-  // the query ref. Calling loadMore one viewport early is the appropriate prefetch
-  // primitive, and the ref deduplicates overlapping calls.
-  useEffect(() => {
-    if (
-      restoreComplete &&
-      lastVirtualIndex != null &&
-      lastVirtualIndex >= rows.length - 12 &&
-      hasMore &&
-      !isLoadingMore
-    ) {
-      loadMore()
-    }
-  }, [hasMore, isLoadingMore, lastVirtualIndex, loadMore, restoreComplete, rows.length])
-
-  // Reload recovery first rebuilds the paginated prefix needed to reach the saved
-  // row, then asks the virtualizer to land on the exact pixel offset. This works
-  // without persisting Figbird's cache or teaching the server about UI state.
-  useEffect(() => {
-    if (restoreComplete) return
-    const target = savedPosition.current
-    if (target === null) {
-      restored.current = true
-      setRestoreComplete(true)
-      return
-    }
-    if (rows.length <= target.index && hasMore) {
-      if (!isLoadingMore) loadMore()
-      return
-    }
-
-    const frame = requestAnimationFrame(() => {
-      virtualizer.scrollToOffset(target.offset, { align: 'start' })
-      restored.current = true
-      setRestoreComplete(true)
-    })
-    return () => cancelAnimationFrame(frame)
-  }, [hasMore, isLoadingMore, loadMore, restoreComplete, rows.length, virtualizer])
-
-  const mountedRows = virtualRows.filter(item => item.index < rows.length).length
-  const visibleStart = virtualRows.find(item => item.index < rows.length)?.index ?? 0
-  const visibleEnd =
-    virtualRows
-      .slice()
-      .reverse()
-      .find(item => item.index < rows.length)?.index ?? Math.max(0, rows.length - 1)
+  const mountedRows = virtualRows.filter(item => rows.has(item.index)).length
+  const visibleStart = virtualRows[0]?.index ?? requestedRange.start
+  const visibleEnd = virtualRows.at(-1)?.index ?? Math.max(0, requestedRange.end - 1)
 
   const jumpToTop = () => {
     sessionStorage.removeItem(RESTORE_KEY)
@@ -155,9 +156,26 @@ function VirtualArchive() {
   return (
     <section className='archive-ledger'>
       <div className='archive-toolbar'>
+        <input
+          value={searchInput}
+          onChange={event => setSearchInput(event.target.value)}
+          className='search-input compact archive-search'
+          placeholder='Search archive…'
+          aria-label='Search archived issues'
+        />
+        <select
+          className='archive-sort'
+          value={sort}
+          onChange={event => setSort(event.target.value as ArchiveSort)}
+          aria-label='Sort archived issues'
+        >
+          <option value='deleted-desc'>Recently deleted</option>
+          <option value='deleted-asc'>Oldest deleted</option>
+          <option value='title-asc'>Title A–Z</option>
+        </select>
         <div className='archive-stat'>
-          <span className='archive-stat-value'>{rows.length.toLocaleString()}</span>
-          <span>loaded</span>
+          <span className='archive-stat-value'>{rows.size.toLocaleString()}</span>
+          <span>cached</span>
         </div>
         <div className='archive-stat'>
           <span className='archive-stat-value'>{mountedRows}</span>
@@ -165,38 +183,38 @@ function VirtualArchive() {
         </div>
         <div className='archive-stat archive-stat-wide'>
           <span className='archive-stat-value'>
-            {visibleStart + 1}–{visibleEnd + 1}
+            {visibleStart + 1}–{Math.min(visibleEnd + 1, total ?? Infinity)}
           </span>
-          <span>render window</span>
+          <span>of {total?.toLocaleString() ?? 'unknown'}</span>
         </div>
-        <StatusDot active={isFetching || isLoadingMore} />
+        <StatusDot active={isFetching} />
         <span className='archive-prefetch-state'>
-          {isLoadingMore
-            ? 'preloading next page…'
-            : hasMore
-              ? 'next page armed'
-              : 'archive complete'}
+          {isFetching ? 'fetching window…' : 'adjacent pages ready'}
         </span>
         <button className='link archive-top-button' onClick={jumpToTop}>
           ↑ Top
         </button>
         <Explain
-          label='Virtualized relational pagination'
-          query={`q.archivedIssues
-  .orderBy('deletedAt', 'desc')
-  .paginate({ pageSize: 40, includeTotal: true })
-  .related('assignee')     // one
-  .related('team')         // one
-  .related('labels')       // many, two-hop junction
-
-// TanStack Virtual mounts visible rows only.
-// loadMore() runs one viewport before the edge.`}
+          label='Windowed relational query'
+          query={`useWindowQuery(
+  q.archivedIssues
+    .where(search)
+    .orderBy(sortField, direction)
+    .related('assignee')
+    .related('team')
+    .related('labels'),
+  {
+    range: { start, end },
+    pageSize: 40,
+    preloadPages: 1,
+    maxPages: 5,
+  },
+)`}
         >
-          Figbird fetches and assembles each page, including an assignee, team, and the two-hop
-          label list for every row. TanStack Virtual independently limits DOM work. Near the end of
-          the loaded window, <code>loadMore()</code> warms the next page before it is visible.
-          Scroll position is stored as a row plus pixel offset; reload reconstructs only the prefix
-          needed to reach it.
+          TanStack Virtual reports the visible indexes. Figbird fetches those server blocks plus one
+          page on either side, assembles all three relations, and evicts distant blocks. Search and
+          sorting create a new server-authoritative list identity; a deep reload starts at the saved
+          window rather than rebuilding the prefix.
         </Explain>
       </div>
 
@@ -211,7 +229,7 @@ function VirtualArchive() {
       <div ref={scrollRef} className='archive-scroll' role='list' aria-label='Archived issues'>
         <div className='archive-virtual-space' style={{ height: virtualizer.getTotalSize() }}>
           {virtualRows.map(virtualRow => {
-            const row = rows[virtualRow.index]
+            const row = rows.get(virtualRow.index) as ArchiveRow | undefined
             return (
               <div
                 key={virtualRow.key}
@@ -224,9 +242,7 @@ function VirtualArchive() {
                 {row ? (
                   <ArchiveLedgerRow row={row} index={virtualRow.index} />
                 ) : (
-                  <div className='archive-loader'>
-                    <span className='spinner archive-spinner' /> Fetching the next {PAGE_SIZE}…
-                  </div>
+                  <ArchiveWindowPlaceholder />
                 )}
               </div>
             )
@@ -234,28 +250,30 @@ function VirtualArchive() {
         </div>
       </div>
 
-      {!restoreComplete && savedPosition.current ? (
-        <div className='archive-restore'>
-          Restoring row{' '}
-          {Math.min(savedPosition.current.index + 1, total ?? Infinity).toLocaleString()}…{' '}
-          {rows.length.toLocaleString()} loaded
+      {error ? (
+        <div className='archive-error'>
+          This window failed to refresh. Scroll away and back to retry.
         </div>
-      ) : null}
-      {loadMoreError ? (
-        <div className='archive-error'>Next page failed. Scroll again to retry.</div>
       ) : null}
     </section>
   )
 }
 
-function persistPosition(virtualizer: Virtualizer<HTMLDivElement, Element>, canPersist: boolean) {
-  if (!canPersist) return
+function persistPosition(virtualizer: Virtualizer<HTMLDivElement, Element>) {
   const offset = virtualizer.scrollOffset ?? 0
   const value: SavedPosition = {
     offset,
     index: Math.max(0, Math.floor(offset / ROW_HEIGHT)),
   }
   sessionStorage.setItem(RESTORE_KEY, JSON.stringify(value))
+}
+
+function ArchiveWindowPlaceholder() {
+  return (
+    <div className='archive-loader' aria-label='Loading row'>
+      <span className='spinner archive-spinner' /> Fetching this window…
+    </div>
+  )
 }
 
 function ArchiveLedgerRow({ row, index }: { row: ArchiveRow; index: number }) {
@@ -288,8 +306,8 @@ function ArchiveLedgerRow({ row, index }: { row: ArchiveRow; index: number }) {
 
 function ArchiveSkeleton() {
   return (
-    <section className='archive-ledger archive-skeleton' aria-label='Loading archive'>
-      <div className='archive-toolbar'>Opening the archive…</div>
+    <section className='archive-ledger archive-skeleton' aria-label='Loading archive window'>
+      <div className='archive-toolbar'>Opening the requested archive window…</div>
       {Array.from({ length: 9 }, (_, index) => (
         <div key={index} className='archive-skeleton-row' />
       ))}

--- a/demo/src/pages/Archive/screen.tsx
+++ b/demo/src/pages/Archive/screen.tsx
@@ -3,36 +3,27 @@
  * TanStack Virtual. Query windows and DOM windows stay independent and bounded.
  */
 
-import { Suspense, useEffect, useRef, useState } from 'react'
+import { Suspense, startTransition, useRef, useState } from 'react'
 import { useVirtualizer, type Virtualizer } from '@tanstack/react-virtual'
 import { useDebouncedTransition } from 'figbird'
-import { Explain } from '../../components/Explain'
-import { StatusDot } from '../../components/ui'
+import { q, useWindowQuery } from '../../figbird'
 import {
-  q,
-  useWindowQuery,
-  type ArchivedIssue,
-  type Label,
-  type Team,
-  type User,
-} from '../../figbird'
+  ArchiveLedgerRow,
+  ArchiveSkeleton,
+  ArchiveToolbar,
+  ArchiveWindowPlaceholder,
+  type ArchiveSort,
+} from './components'
 
 const PAGE_SIZE = 40
 const ROW_HEIGHT = 72
 const RESTORE_KEY = 'figbird-demo:archive-scroll'
 const INITIAL_WINDOW_SIZE = 18
+const DEFAULT_SORT: ArchiveSort = 'deleted-desc'
 
 interface SavedPosition {
   offset: number
   index: number
-}
-
-type ArchiveSort = 'deleted-desc' | 'deleted-asc' | 'title-asc'
-
-type ArchiveRow = ArchivedIssue & {
-  assignee: User | null
-  team: Team | null
-  labels: Label[]
 }
 
 function readSavedPosition(): SavedPosition | null {
@@ -77,35 +68,61 @@ export function ArchivePage() {
 }
 
 function VirtualArchive() {
-  const savedPosition = useRef(readSavedPosition())
-  const initialIndex = savedPosition.current?.index ?? 0
-  const [range, setRange] = useState({
-    start: initialIndex,
-    end: initialIndex + INITIAL_WINDOW_SIZE,
-  })
   const [searchInput, setSearchInput] = useState('')
   const search = useDebouncedTransition(searchInput.trim(), 250)
-  const [sort, setSort] = useState<ArchiveSort>('deleted-desc')
-  const queryIdentity = `${search}\u0000${sort}`
-  const committedIdentity = useRef(queryIdentity)
-  const queryChanged = committedIdentity.current !== queryIdentity
-  const requestedRange = queryChanged ? { start: 0, end: INITIAL_WINDOW_SIZE } : range
+  const [sort, setSort] = useState<ArchiveSort>(DEFAULT_SORT)
 
-  let archiveQuery = q.archivedIssues.where(search === '' ? {} : { $search: search })
-  archiveQuery =
-    sort === 'title-asc'
-      ? archiveQuery.orderBy('title', 'asc').orderBy('id', 'asc')
-      : sort === 'deleted-asc'
-        ? archiveQuery.orderBy('deletedAt', 'asc').orderBy('id', 'asc')
-        : archiveQuery.orderBy('deletedAt', 'desc').orderBy('id', 'desc')
+  const changeSearch = (value: string) => {
+    clearSavedPosition()
+    setSearchInput(value)
+  }
+
+  const changeSort = (value: ArchiveSort) => {
+    clearSavedPosition()
+    startTransition(() => setSort(value))
+  }
+
+  return (
+    <ArchiveWindow
+      key={`${sort}:${search}`}
+      search={search}
+      searchInput={searchInput}
+      onSearchInputChange={changeSearch}
+      sort={sort}
+      onSortChange={changeSort}
+    />
+  )
+}
+
+interface ArchiveWindowProps {
+  search: string
+  searchInput: string
+  onSearchInputChange: (value: string) => void
+  sort: ArchiveSort
+  onSortChange: (value: ArchiveSort) => void
+}
+
+function ArchiveWindow({
+  search,
+  searchInput,
+  onSearchInputChange,
+  sort,
+  onSortChange,
+}: ArchiveWindowProps) {
+  const [initialPosition] = useState(readSavedPosition)
+  const [range, setRange] = useState(() => {
+    const start = initialPosition?.index ?? 0
+    return { start, end: start + INITIAL_WINDOW_SIZE }
+  })
+  const archiveQuery = buildArchiveQuery(search, sort)
 
   const {
     data: rows,
     total,
     isFetching,
     error,
-  } = useWindowQuery(archiveQuery.related('assignee').related('team').related('labels'), {
-    range: requestedRange,
+  } = useWindowQuery(archiveQuery, {
+    range,
     pageSize: PAGE_SIZE,
     preloadPages: 1,
     maxPages: 5,
@@ -113,14 +130,13 @@ function VirtualArchive() {
   const scrollRef = useRef<HTMLDivElement | null>(null)
 
   const virtualizer = useVirtualizer({
-    count: total ?? Math.max(1, requestedRange.end),
+    count: total ?? Math.max(1, range.end),
     getScrollElement: () => scrollRef.current,
     estimateSize: () => ROW_HEIGHT,
     overscan: 5,
-    initialOffset: savedPosition.current?.offset ?? 0,
+    initialOffset: initialPosition?.offset ?? 0,
     getItemKey: index => index,
     onChange: instance => {
-      if (committedIdentity.current !== queryIdentity) return
       persistPosition(instance)
       const items = instance.getVirtualItems()
       const first = items[0]?.index
@@ -134,89 +150,31 @@ function VirtualArchive() {
     },
   })
 
-  useEffect(() => {
-    if (!queryChanged) return
-    committedIdentity.current = queryIdentity
-    savedPosition.current = null
-    sessionStorage.removeItem(RESTORE_KEY)
-    setRange({ start: 0, end: INITIAL_WINDOW_SIZE })
-    virtualizer.scrollToOffset(0)
-  }, [queryChanged, queryIdentity, virtualizer])
-
   const virtualRows = virtualizer.getVirtualItems()
   const mountedRows = virtualRows.filter(item => rows.has(item.index)).length
-  const visibleStart = virtualRows[0]?.index ?? requestedRange.start
-  const visibleEnd = virtualRows.at(-1)?.index ?? Math.max(0, requestedRange.end - 1)
+  const visibleStart = virtualRows[0]?.index ?? range.start
+  const visibleEnd = virtualRows.at(-1)?.index ?? Math.max(0, range.end - 1)
 
   const jumpToTop = () => {
-    sessionStorage.removeItem(RESTORE_KEY)
+    clearSavedPosition()
     virtualizer.scrollToOffset(0)
   }
 
   return (
     <section className='archive-ledger'>
-      <div className='archive-toolbar'>
-        <input
-          value={searchInput}
-          onChange={event => setSearchInput(event.target.value)}
-          className='search-input compact archive-search'
-          placeholder='Search archive…'
-          aria-label='Search archived issues'
-        />
-        <select
-          className='archive-sort'
-          value={sort}
-          onChange={event => setSort(event.target.value as ArchiveSort)}
-          aria-label='Sort archived issues'
-        >
-          <option value='deleted-desc'>Recently deleted</option>
-          <option value='deleted-asc'>Oldest deleted</option>
-          <option value='title-asc'>Title A–Z</option>
-        </select>
-        <div className='archive-stat'>
-          <span className='archive-stat-value'>{rows.size.toLocaleString()}</span>
-          <span>cached</span>
-        </div>
-        <div className='archive-stat'>
-          <span className='archive-stat-value'>{mountedRows}</span>
-          <span>mounted</span>
-        </div>
-        <div className='archive-stat archive-stat-wide'>
-          <span className='archive-stat-value'>
-            {visibleStart + 1}–{Math.min(visibleEnd + 1, total ?? Infinity)}
-          </span>
-          <span>of {total?.toLocaleString() ?? 'unknown'}</span>
-        </div>
-        <StatusDot active={isFetching} />
-        <span className='archive-prefetch-state'>
-          {isFetching ? 'fetching window…' : 'adjacent pages ready'}
-        </span>
-        <button className='link archive-top-button' onClick={jumpToTop}>
-          ↑ Top
-        </button>
-        <Explain
-          label='Windowed relational query'
-          query={`useWindowQuery(
-  q.archivedIssues
-    .where(search)
-    .orderBy(sortField, direction)
-    .related('assignee')
-    .related('team')
-    .related('labels'),
-  {
-    range: { start, end },
-    pageSize: 40,
-    preloadPages: 1,
-    maxPages: 5,
-  },
-)`}
-        >
-          TanStack Virtual reports the visible indexes. Figbird fetches those server blocks plus one
-          page on either side, assembles all three relations, and evicts distant blocks. Search and
-          sorting create a new server-authoritative list identity; a deep reload starts at the saved
-          window rather than rebuilding the prefix.
-        </Explain>
-      </div>
+      <ArchiveToolbar
+        searchInput={searchInput}
+        onSearchInputChange={onSearchInputChange}
+        sort={sort}
+        onSortChange={onSortChange}
+        cachedRows={rows.size}
+        mountedRows={mountedRows}
+        visibleStart={visibleStart}
+        visibleEnd={visibleEnd}
+        total={total}
+        isFetching={isFetching}
+        onJumpToTop={jumpToTop}
+      />
 
       <div className='archive-columns' aria-hidden>
         <span>No.</span>
@@ -229,7 +187,7 @@ function VirtualArchive() {
       <div ref={scrollRef} className='archive-scroll' role='list' aria-label='Archived issues'>
         <div className='archive-virtual-space' style={{ height: virtualizer.getTotalSize() }}>
           {virtualRows.map(virtualRow => {
-            const row = rows.get(virtualRow.index) as ArchiveRow | undefined
+            const row = rows.get(virtualRow.index)
             return (
               <div
                 key={virtualRow.key}
@@ -259,6 +217,21 @@ function VirtualArchive() {
   )
 }
 
+function buildArchiveQuery(search: string, sort: ArchiveSort) {
+  let query = q.archivedIssues.where(search === '' ? {} : { $search: search })
+  query =
+    sort === 'title-asc'
+      ? query.orderBy('title', 'asc').orderBy('id', 'asc')
+      : sort === 'deleted-asc'
+        ? query.orderBy('deletedAt', 'asc').orderBy('id', 'asc')
+        : query.orderBy('deletedAt', 'desc').orderBy('id', 'desc')
+  return query.related('assignee').related('team').related('labels')
+}
+
+function clearSavedPosition() {
+  sessionStorage.removeItem(RESTORE_KEY)
+}
+
 function persistPosition(virtualizer: Virtualizer<HTMLDivElement, Element>) {
   const offset = virtualizer.scrollOffset ?? 0
   const value: SavedPosition = {
@@ -266,51 +239,4 @@ function persistPosition(virtualizer: Virtualizer<HTMLDivElement, Element>) {
     index: Math.max(0, Math.floor(offset / ROW_HEIGHT)),
   }
   sessionStorage.setItem(RESTORE_KEY, JSON.stringify(value))
-}
-
-function ArchiveWindowPlaceholder() {
-  return (
-    <div className='archive-loader' aria-label='Loading row'>
-      <span className='spinner archive-spinner' /> Fetching this window…
-    </div>
-  )
-}
-
-function ArchiveLedgerRow({ row, index }: { row: ArchiveRow; index: number }) {
-  return (
-    <article className='archive-row' role='listitem'>
-      <div className='archive-row-number'>{String(index + 1).padStart(4, '0')}</div>
-      <div className='archive-row-main'>
-        <div className='archive-row-title'>{row.title}</div>
-        <div className='archive-row-reason'>
-          {row.deletionReason} · {row.team?.name ?? 'No team'}
-        </div>
-      </div>
-      <div className='archive-assignee'>
-        <span className='archive-avatar'>{row.assignee?.avatar ?? '–'}</span>
-        <span>{row.assignee?.name ?? 'Unassigned'}</span>
-      </div>
-      <div className='archive-labels'>
-        {row.labels.map(label => (
-          <span key={label.id} className={`label mini ${label.tone}`}>
-            {label.name}
-          </span>
-        ))}
-      </div>
-      <time className='archive-date' dateTime={row.deletedAt}>
-        {new Intl.DateTimeFormat('en', { dateStyle: 'medium' }).format(new Date(row.deletedAt))}
-      </time>
-    </article>
-  )
-}
-
-function ArchiveSkeleton() {
-  return (
-    <section className='archive-ledger archive-skeleton' aria-label='Loading archive window'>
-      <div className='archive-toolbar'>Opening the requested archive window…</div>
-      {Array.from({ length: 9 }, (_, index) => (
-        <div key={index} className='archive-skeleton-row' />
-      ))}
-    </section>
-  )
 }

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -1769,6 +1769,326 @@ button.primary:hover:not(:disabled) {
   font-variant-numeric: tabular-nums;
 }
 
+/* ----- Archive: virtualized relational ledger ----- */
+
+.full .archive-page {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  background: var(--surface);
+}
+
+.archive-head {
+  flex: none;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 36px;
+  padding: 28px 40px 22px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.archive-kicker {
+  margin-bottom: 6px;
+  color: var(--text-dim);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.archive-title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: -0.02em;
+}
+
+.archive-deck {
+  margin: 7px 0 0;
+  color: var(--text-muted);
+  font-size: 12.5px;
+}
+
+.archive-head-note {
+  max-width: 245px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-dim);
+  font-size: 11.5px;
+  line-height: 1.4;
+  background: var(--hover);
+}
+
+.archive-ledger {
+  position: relative;
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.archive-toolbar {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 18px;
+  min-height: 42px;
+  padding: 7px 40px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 11px;
+  background: var(--surface);
+}
+
+.archive-stat {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  white-space: nowrap;
+}
+
+.archive-stat-value {
+  color: var(--text);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+}
+
+.archive-stat-wide {
+  padding-right: 18px;
+  border-right: 1px solid var(--border);
+}
+
+.archive-prefetch-state {
+  white-space: nowrap;
+}
+
+.archive-top-button {
+  margin-left: auto;
+}
+
+.archive-toolbar .explain {
+  margin-left: 0;
+}
+
+.archive-columns,
+.archive-row {
+  display: grid;
+  grid-template-columns: 60px minmax(320px, 1.7fr) minmax(120px, 0.6fr) minmax(190px, 1fr) 116px;
+  align-items: center;
+}
+
+.archive-columns {
+  flex: none;
+  height: 29px;
+  padding: 0 40px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--hover);
+}
+
+.archive-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  scrollbar-color: var(--border) transparent;
+}
+
+.archive-virtual-space {
+  position: relative;
+  width: 100%;
+}
+
+.archive-virtual-row {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+}
+
+.archive-row {
+  height: 100%;
+  padding: 0 40px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  transition: background 100ms ease;
+}
+
+.archive-row:hover {
+  background: var(--hover);
+}
+
+.archive-row-number,
+.archive-date {
+  color: var(--text-dim);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+}
+
+.archive-row-main {
+  min-width: 0;
+  padding-right: 24px;
+}
+
+.archive-row-title {
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.archive-row-reason {
+  overflow: hidden;
+  margin-top: 3px;
+  color: var(--text-dim);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.archive-assignee {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  white-space: nowrap;
+}
+
+.archive-avatar {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  flex: none;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--surface);
+  font-size: 12px;
+}
+
+.archive-labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  padding-right: 14px;
+}
+
+.archive-labels .label.mini {
+  margin-left: 0;
+}
+
+.archive-date {
+  text-align: right;
+}
+
+.archive-loader {
+  display: flex;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 11px;
+  background: var(--surface);
+}
+
+.archive-spinner {
+  width: 14px;
+  height: 14px;
+  border-color: var(--border);
+  border-top-color: var(--text);
+}
+
+.archive-restore {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  display: grid;
+  place-items: center;
+  color: var(--text-muted);
+  font-size: 11px;
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(2px);
+}
+
+.archive-error {
+  position: absolute;
+  right: 18px;
+  bottom: 18px;
+  padding: 8px 12px;
+  border: 1px solid #e2b7ae;
+  border-radius: 6px;
+  color: #8c2f22;
+  font-size: 11px;
+  background: #fff4f1;
+  box-shadow: 0 8px 24px rgba(80, 30, 20, 0.1);
+}
+
+.archive-skeleton {
+  padding-top: 0;
+}
+
+.archive-skeleton-row {
+  height: 72px;
+  margin: 0 40px;
+  border-bottom: 1px solid var(--border);
+  background: linear-gradient(90deg, var(--hover) 25%, var(--surface) 45%, var(--hover) 65%);
+  background-size: 300% 100%;
+  animation: archive-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes archive-shimmer {
+  from {
+    background-position: 100% 0;
+  }
+  to {
+    background-position: 0 0;
+  }
+}
+
+@media (max-width: 900px) {
+  .archive-head,
+  .archive-toolbar,
+  .archive-columns,
+  .archive-row {
+    padding-right: 20px;
+    padding-left: 32px;
+  }
+
+  .archive-columns,
+  .archive-row {
+    grid-template-columns: 48px minmax(240px, 1fr) 120px 160px;
+  }
+
+  .archive-columns > :last-child,
+  .archive-date {
+    display: none;
+  }
+
+  .archive-stat-wide,
+  .archive-prefetch-state {
+    display: none;
+  }
+}
+
 /* ----- Explain code snippets + chaos button ----- */
 
 .explain-code {

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -1856,6 +1856,27 @@ button.primary:hover:not(:disabled) {
   white-space: nowrap;
 }
 
+.archive-search {
+  width: 190px;
+  flex: none;
+}
+
+.archive-sort {
+  height: 28px;
+  flex: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0 26px 0 9px;
+  color: var(--text-muted);
+  background: var(--surface);
+  font: inherit;
+}
+
+.archive-sort:focus {
+  outline: none;
+  border-color: var(--text-dim);
+}
+
 .archive-stat-value {
   color: var(--text);
   font-size: 12px;
@@ -1904,7 +1925,19 @@ button.primary:hover:not(:disabled) {
   flex: 1;
   min-height: 0;
   overflow: auto;
+  scrollbar-gutter: stable;
+  scrollbar-width: auto;
   scrollbar-color: var(--border) transparent;
+}
+
+.archive-scroll::-webkit-scrollbar {
+  width: 12px;
+}
+
+.archive-scroll::-webkit-scrollbar-thumb {
+  border: 3px solid var(--surface);
+  border-radius: 999px;
+  background: var(--border);
 }
 
 .archive-virtual-space {
@@ -2084,7 +2117,8 @@ button.primary:hover:not(:disabled) {
   }
 
   .archive-stat-wide,
-  .archive-prefetch-state {
+  .archive-prefetch-state,
+  .archive-search {
     display: none;
   }
 }

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -376,6 +376,55 @@ const { data, loadMore, hasMore, isLoadingMore, loadMoreError, total } = useQuer
 The server owns page boundaries. Figbird merges a realtime event locally only when it
 can prove that the event leaves the current window unchanged; otherwise it refetches.
 
+### Virtualized windows
+
+`useWindowQuery` is the indexed, bounded counterpart to `.paginate()`. Give it the
+row range reported by React Window, TanStack Virtual, or another virtualizer; it
+returns a sparse `ReadonlyMap` keyed by absolute row index:
+
+```tsx
+const { data: rows, total, isFetching, error } = useWindowQuery(
+  q.archivedIssues
+    .where(search ? { $search: search } : {})
+    .orderBy(sortField, sortDirection)
+    .related('assignee')
+    .related('labels'),
+  {
+    range: { start: firstVisible, end: lastVisible + 1 },
+    pageSize: 40,
+    preloadPages: 1,
+    maxPages: 5,
+  },
+)
+
+const row = rows.get(absoluteIndex) // undefined while that block is arriving
+```
+
+The range is end-exclusive. Figbird fetches every block intersecting it, preloads
+the configured number of adjacent blocks, assembles relations per block, and evicts
+the least-recently-used distant blocks. `maxPages` is a retention target; active
+readers can temporarily require more blocks. Evicted root query indexes are removed
+from the query store, while normalized entities remain available to ordinary Figbird
+queries and relation fan-ins.
+
+The hook detects the adapter's pagination capability:
+
+- Offset services jump straight to any requested index with `$skip` and `$limit`.
+- Cursor services walk forward from their nearest known cursor checkpoint. They do
+  not pretend a cursor is a random-access offset; a future seek-capable adapter can
+  optimize that walk without changing the hook API.
+
+When the server reports `total`, give it to the virtualizer as its item count to get
+a full-size scrollbar and direct scrollbar jumps. Restoring a saved scroll offset is
+then an application concern: initialize the virtualizer and `range` from that offset.
+On offset services only the restored block and its neighbors load—not the whole
+prefix. Cursor services necessarily advance through the cursor chain to reach it.
+
+Filtering and ordering belong on the builder, so server-side search and sort create
+a new query identity automatically. Builders passed to `useWindowQuery` must produce
+a list and must not use `.limit()`, `.skip()`, `.paginate()`, or `.all()`; the window
+controller owns those boundaries.
+
 ### Cursor pagination
 
 Pagination uses `$limit` and `$skip` by default. Configure cursor-backed Feathers
@@ -1413,6 +1462,31 @@ suspension for the set (see [Several queries at once](#several-queries-at-once))
 Each element has the `useQuery` suspense result shape for its builder (`data`,
 `error`, `isFetching`, `refetch`, plus the `loadMore`/`hasMore`/… family on a
 `.paginate()` element). Suspense-only. Options: `staleTime?: number`.
+
+## useWindowQuery
+
+```ts
+const { data, total, error, isFetching, refetch } = useWindowQuery(
+  q.issues.orderBy('updatedAt', 'desc').related('assignee'),
+  {
+    range: { start, end }, // end-exclusive visible indexes
+    pageSize: 40,
+    preloadPages: 1,      // default: 1
+    maxPages: 5,          // default: 5
+  },
+)
+```
+
+`data` is a sparse `ReadonlyMap<number, Item>` indexed into the complete server
+result, while `total` is the server-reported count when available. Missing entries
+are blocks currently loading. The hook is Suspense-native for its first window and
+keeps the previous window mounted during later movement; pass `{ suspense: false }`
+for the tagged-union form. It accepts the same `skip` and `staleTime` options and the
+same builder, bound-request, and argumentless-definition inputs as `useQuery`.
+
+Offset adapters jump directly; cursor adapters advance sequentially and reuse cursor
+checkpoints. Relations, filtering, and sorting are part of each fetched block. See
+[Virtualized windows](#virtualized-windows) for lifecycle and restoration semantics.
 
 ## m and useMutations
 

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -64,6 +64,8 @@ import type {
 } from './schema.js'
 import { resolveServicePath } from './schema.js'
 
+const MAX_WINDOW_QUERY_CACHE_SIZE = 20
+
 type DescriptorWriteProjection<TItem> =
   | {
       optimistic?: true
@@ -199,7 +201,9 @@ export class Figbird<
 
   // Window refs are interned independently from ordinary relational refs because their
   // range is subscriber state rather than query identity. Multiple readers of the same
-  // list share retained blocks while contributing their own visible ranges.
+  // list share retained blocks while contributing their own visible ranges. Recently
+  // settled render-phase reads stay warm for React's retry; an LRU bound prevents
+  // abandoned reads for old query shapes from accumulating indefinitely.
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   #windowQueryCache: Map<string, WindowQueryRef<any, S, any, any, any>> = new Map()
 
@@ -432,21 +436,44 @@ export class Figbird<
     const cached = this.#windowQueryCache.get(hash)
     let ref = cached as
       WindowQueryRef<T, S, AdapterParams<A>, AdapterFindMeta<A>, AdapterQuery<A>> | undefined
-    if (!ref) {
+    if (ref) {
+      // Map insertion order is the LRU order. A Suspense retry therefore protects
+      // the ref it is actively trying to commit.
+      this.#windowQueryCache.delete(hash)
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      this.#windowQueryCache.set(hash, ref as WindowQueryRef<any, S, any, any, any>)
+      this.#trimWindowQueryCache(ref)
+    } else {
       ref = new WindowQueryRef<T, S, AdapterParams<A>, AdapterFindMeta<A>, AdapterQuery<A>>(
         this,
         ast,
         this.schema,
         config,
-        () => {
-          if (this.#windowQueryCache.get(hash) === ref) this.#windowQueryCache.delete(hash)
+        {
+          onEvict: () => {
+            if (this.#windowQueryCache.get(hash) === ref) this.#windowQueryCache.delete(hash)
+          },
+          onIdle: () => this.#trimWindowQueryCache(ref),
         },
       )
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any
       this.#windowQueryCache.set(hash, ref as WindowQueryRef<any, S, any, any, any>)
+      this.#trimWindowQueryCache(ref)
     }
     ref.setDisplayName(name)
     return ref
+  }
+
+  #trimWindowQueryCache(
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    protectedRef: WindowQueryRef<any, S, any, any, any> | undefined,
+  ): void {
+    if (this.#windowQueryCache.size <= MAX_WINDOW_QUERY_CACHE_SIZE) return
+    for (const candidate of this.#windowQueryCache.values()) {
+      if (this.#windowQueryCache.size <= MAX_WINDOW_QUERY_CACHE_SIZE) return
+      if (candidate === protectedRef) continue
+      candidate.evictAbandonedRead()
+    }
   }
 
   /**

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -8,6 +8,7 @@ import {
   type PageRequest,
 } from '../adapters/adapter.js'
 import { registerDevtoolsInstance } from './devtoolsBridge.js'
+import { hashObject } from './hash.js'
 import type { FigbirdEvents } from './events.js'
 import { createMutationsProxy, type MutationsHost, type MutationsProxy } from './mutations.js'
 import {
@@ -22,7 +23,9 @@ import {
   createQueryBuilderProxy,
   queryBuilderUsesSchema,
   type AnyQueryBuilder,
+  type AnyWindowQueryBuilder,
   type QueryBuilderProxy,
+  type QueryBuilderItem,
   type QueryBuilderResult,
 } from './queryBuilder.js'
 import { resolveQueryInput, type PreparedQuery, type QueryInput } from './queryDefinition.js'
@@ -47,6 +50,7 @@ import {
   type ServiceState,
 } from './queryTypes.js'
 import { RelationalQueryRef, type InspectedRelationalQuery } from './relationalQuery.js'
+import { WindowQueryRef, type WindowQueryConfig } from './windowQuery.js'
 export type { InspectedRelationalQuery } from './relationalQuery.js'
 import type {
   AnySchema,
@@ -192,6 +196,12 @@ export class Figbird<
   // (see RelationalQueryRef#cleanup).
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   #relationalQueryCache: Map<string, RelationalQueryRef<any, S, any, any, any>> = new Map()
+
+  // Window refs are interned independently from ordinary relational refs because their
+  // range is subscriber state rather than query identity. Multiple readers of the same
+  // list share retained blocks while contributing their own visible ranges.
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  #windowQueryCache: Map<string, WindowQueryRef<any, S, any, any, any>> = new Map()
 
   // Keyed mutation queues outlive individual React owners while work remains,
   // allowing a remounted feature to reconnect to its pending/error state.
@@ -384,6 +394,56 @@ export class Figbird<
       )
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any
       this.#relationalQueryCache.set(hash, ref as RelationalQueryRef<any, S, any, any, any>)
+    }
+    ref.setDisplayName(name)
+    return ref
+  }
+
+  /**
+   * Materialize a viewport-indexed relational query. The builder describes list
+   * identity (filters, ordering, relations); the hook supplies each reader's range.
+   * Offset services address blocks directly, while native cursor services retain
+   * index checkpoints and advance only as far as required.
+   */
+  window<Args, B extends AnyWindowQueryBuilder<S>>(
+    queryOrBuilder: QueryInput<B, Args>,
+    config: WindowQueryConfig,
+  ): WindowQueryRef<QueryBuilderItem<B>, S, AdapterParams<A>, AdapterFindMeta<A>, AdapterQuery<A>> {
+    type T = QueryBuilderItem<B>
+    if (!this.schema) {
+      throw new Error(
+        'Cannot use window queries without a schema. ' +
+          'Pass schema to Figbird constructor: new Figbird({ schema, adapter })',
+      )
+    }
+    const { builder, name } = resolveQueryInput(queryOrBuilder)
+    if (!queryBuilderUsesSchema(builder, this.schema)) {
+      throw new Error('The query builder uses a different schema from this Figbird instance')
+    }
+    const ast = builder.toAST()
+    if (ast.kind !== 'find' || ast.cardinality !== 'many') {
+      throw new Error('useWindowQuery() requires a list-producing find builder')
+    }
+    if (ast.query.$limit !== undefined || ast.query.$skip !== undefined) {
+      throw new Error('useWindowQuery() owns $limit/$skip; remove .limit() and .skip()')
+    }
+
+    const hash = hashObject({ ast, window: config })
+    const cached = this.#windowQueryCache.get(hash)
+    let ref = cached as
+      WindowQueryRef<T, S, AdapterParams<A>, AdapterFindMeta<A>, AdapterQuery<A>> | undefined
+    if (!ref) {
+      ref = new WindowQueryRef<T, S, AdapterParams<A>, AdapterFindMeta<A>, AdapterQuery<A>>(
+        this,
+        ast,
+        this.schema,
+        config,
+        () => {
+          if (this.#windowQueryCache.get(hash) === ref) this.#windowQueryCache.delete(hash)
+        },
+      )
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      this.#windowQueryCache.set(hash, ref as WindowQueryRef<any, S, any, any, any>)
     }
     ref.setDisplayName(name)
     return ref

--- a/lib/core/queryBuilder.ts
+++ b/lib/core/queryBuilder.ts
@@ -595,3 +595,18 @@ export type QueryBuilderKind<B> =
  */
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyQueryBuilder<S extends Schema = any> = QueryBuilder<S, any, any, any, any, any>
+
+/** A list-producing find builder accepted by viewport/window query consumers. */
+/* oxlint-disable @typescript-eslint/no-explicit-any -- public overload seam preserves concrete builder types */
+export type AnyWindowQueryBuilder<S extends Schema = any> = QueryBuilder<
+  S,
+  any,
+  any,
+  any,
+  'many',
+  'find'
+>
+/* oxlint-enable @typescript-eslint/no-explicit-any */
+
+/** Extract one assembled row from a list-producing query builder. */
+export type QueryBuilderItem<B> = QueryBuilderResult<B> extends Array<infer T> ? T : never

--- a/lib/core/queryIdentity.ts
+++ b/lib/core/queryIdentity.ts
@@ -7,11 +7,19 @@ export type QueryIdentityConfig = {
   [queryIdentityKey]?: string
 }
 
+/** Internal cache-lifecycle controls that remain part of query identity. */
+export interface QueryLifecycleConfig {
+  gcOnUnsubscribe?: boolean
+}
+
 let nextIsolatedQueryIdentity = 0
 
 /** Results that belong to one consumer and are removed with its last subscription. */
-export function isEphemeralQuery<TItem, TQuery>(config: QueryConfig<TItem, TQuery>): boolean {
+export function isEphemeralQuery<TItem, TQuery>(
+  config: QueryConfig<TItem, TQuery> & QueryLifecycleConfig,
+): boolean {
   return (
+    config.gcOnUnsubscribe === true ||
     config.fetchPolicy === 'network-only' ||
     (config.matcher !== undefined && config.matcherKey === undefined)
   )

--- a/lib/core/queryRoots.ts
+++ b/lib/core/queryRoots.ts
@@ -15,6 +15,12 @@ export interface RootSnapshot {
 /** Common lifecycle for a single-query root and an accumulating page root. */
 export interface RootSource {
   snapshot(): RootSnapshot
+  /** Normalized native continuation metadata for a page-backed root, when present. */
+  pageInfo(): PageInfo | undefined
+  /** Server-reported result-set size, when the adapter supplied one. */
+  total(): number | undefined
+  /** Root row identity, excluding relation-only changes. */
+  revision(): unknown
   setStaleTime(staleTime: number): void
   ensureFresh(staleTime?: number): void
   refetch(): void
@@ -142,6 +148,23 @@ export class SingleQueryRoot<
       isFetching: state.isFetching,
       error: null,
     }
+  }
+
+  pageInfo(): PageInfo | undefined {
+    return this.#queryRef.getSnapshot()?.pageInfo
+  }
+
+  total(): number | undefined {
+    const state = this.#queryRef.getSnapshot()
+    const pageTotal = state?.pageInfo?.total
+    if (typeof pageTotal === 'number' && pageTotal >= 0) return pageTotal
+    const meta = state?.meta as { total?: unknown } | undefined
+    return typeof meta?.total === 'number' && meta.total >= 0 ? meta.total : undefined
+  }
+
+  revision(): unknown {
+    const state = this.#queryRef.getSnapshot()
+    return state?.status === 'success' ? state.data : undefined
   }
 
   ensureFresh(staleTime?: number): void {
@@ -388,6 +411,19 @@ export class PagedQueryRoot<
       isFetching: pageStates.some(state => state.isFetching),
       error: null,
     }
+  }
+
+  pageInfo(): PageInfo | undefined {
+    const state = this.#pageRefs.at(-1)?.getSnapshot()
+    return state?.pageInfo
+  }
+
+  total(): number | undefined {
+    return this.#computeTotal()
+  }
+
+  revision(): unknown {
+    return this.#lastAllPagesData
   }
 
   ensureFresh(staleTime?: number): void {

--- a/lib/core/queryRoots.ts
+++ b/lib/core/queryRoots.ts
@@ -12,15 +12,20 @@ export interface RootSnapshot {
   error: Error | null
 }
 
+/** Adapter-neutral metadata attached to the relational root query. */
+export interface RootMetadata {
+  /** Normalized native continuation metadata, when the root is page-backed. */
+  pageInfo: PageInfo | undefined
+  /** Server-reported result-set size, when the adapter supplied one. */
+  total: number | undefined
+  /** Root row identity, excluding relation-only changes. */
+  revision: unknown
+}
+
 /** Common lifecycle for a single-query root and an accumulating page root. */
 export interface RootSource {
   snapshot(): RootSnapshot
-  /** Normalized native continuation metadata for a page-backed root, when present. */
-  pageInfo(): PageInfo | undefined
-  /** Server-reported result-set size, when the adapter supplied one. */
-  total(): number | undefined
-  /** Root row identity, excluding relation-only changes. */
-  revision(): unknown
+  metadata(): RootMetadata
   setStaleTime(staleTime: number): void
   ensureFresh(staleTime?: number): void
   refetch(): void
@@ -150,21 +155,21 @@ export class SingleQueryRoot<
     }
   }
 
-  pageInfo(): PageInfo | undefined {
-    return this.#queryRef.getSnapshot()?.pageInfo
-  }
-
-  total(): number | undefined {
+  metadata(): RootMetadata {
     const state = this.#queryRef.getSnapshot()
     const pageTotal = state?.pageInfo?.total
-    if (typeof pageTotal === 'number' && pageTotal >= 0) return pageTotal
     const meta = state?.meta as { total?: unknown } | undefined
-    return typeof meta?.total === 'number' && meta.total >= 0 ? meta.total : undefined
-  }
-
-  revision(): unknown {
-    const state = this.#queryRef.getSnapshot()
-    return state?.status === 'success' ? state.data : undefined
+    const total =
+      typeof pageTotal === 'number' && pageTotal >= 0
+        ? pageTotal
+        : typeof meta?.total === 'number' && meta.total >= 0
+          ? meta.total
+          : undefined
+    return {
+      pageInfo: state?.pageInfo,
+      total,
+      revision: state?.status === 'success' ? state.data : undefined,
+    }
   }
 
   ensureFresh(staleTime?: number): void {
@@ -413,17 +418,13 @@ export class PagedQueryRoot<
     }
   }
 
-  pageInfo(): PageInfo | undefined {
+  metadata(): RootMetadata {
     const state = this.#pageRefs.at(-1)?.getSnapshot()
-    return state?.pageInfo
-  }
-
-  total(): number | undefined {
-    return this.#computeTotal()
-  }
-
-  revision(): unknown {
-    return this.#lastAllPagesData
+    return {
+      pageInfo: state?.pageInfo,
+      total: this.#computeTotal(),
+      revision: this.#lastAllPagesData,
+    }
   }
 
   ensureFresh(staleTime?: number): void {

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -4,6 +4,7 @@ import { cursorQueryCanKeepPrefix, cursorQueryInputsUnchanged } from './cursorMa
 import type { QueryAST } from './queryBuilder.js'
 import { planRelation, planRootPagination, rootAllPages } from './queryClassification.js'
 import type { QueryRef } from './queryRef.js'
+import type { QueryLifecycleConfig } from './queryIdentity.js'
 import type {
   ProcessedProjectionEvent,
   ProcessedRealtimeEvent,
@@ -72,7 +73,10 @@ export interface RelationalQueryHost<TParams, TMeta extends Record<string, unkno
   }
   getState(): Map<string, ServiceState<TMeta>>
   /** Returns a QueryRef; typed loosely here and re-typed once at the engine's seam. */
-  queryDesc(desc: QueryDescriptor, config?: QueryConfig<unknown, unknown>): unknown
+  queryDesc(
+    desc: QueryDescriptor,
+    config?: QueryConfig<unknown, unknown> & QueryLifecycleConfig,
+  ): unknown
 }
 
 /**
@@ -173,7 +177,7 @@ export interface InspectedRelationalQuery {
 /** Internal escape hatch for consumers that need a custom root query boundary. */
 export interface RelationalRootOverride {
   descriptor: QueryDescriptor
-  config?: QueryConfig<unknown, unknown>
+  config?: QueryConfig<unknown, unknown> & QueryLifecycleConfig
 }
 
 interface RelationalQueryOptions {
@@ -347,7 +351,7 @@ export class RelationalQueryRef<
    */
   #query(
     desc: QueryDescriptor,
-    config: QueryConfig<unknown, unknown>,
+    config: QueryConfig<unknown, unknown> & QueryLifecycleConfig,
   ): QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery> {
     return this.#host.queryDesc(desc, config) as QueryRef<
       unknown[],
@@ -401,11 +405,12 @@ export class RelationalQueryRef<
   }
 
   #currentStaleTime(): number {
+    if (this.#listenerStaleTimes.size === 0) return 0
     let staleTime = Infinity
     for (const value of this.#listenerStaleTimes.values()) {
       staleTime = Math.min(staleTime, value)
     }
-    return staleTime === Infinity ? 0 : staleTime
+    return staleTime
   }
 
   #ensureFresh(staleTime: number): void {

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -1,5 +1,5 @@
 import { hashObject } from './hash.js'
-import type { MatcherContext, PageInfo, PageRequest, PageSource } from '../adapters/adapter.js'
+import type { MatcherContext, PageSource } from '../adapters/adapter.js'
 import { cursorQueryCanKeepPrefix, cursorQueryInputsUnchanged } from './cursorMaintenance.js'
 import type { QueryAST } from './queryBuilder.js'
 import { planRelation, planRootPagination, rootAllPages } from './queryClassification.js'
@@ -18,6 +18,7 @@ import {
   type PaginatedRootSource,
   type InspectedPagination,
   type RelationalPaginationState,
+  type RootMetadata,
   type RootSource,
 } from './queryRoots.js'
 import {
@@ -169,15 +170,14 @@ export interface InspectedRelationalQuery {
   }>
 }
 
-/** Internal root override used by window queries to materialize one native page. */
-export interface RelationalPageRoot {
-  page: PageRequest
-  realtime: 'disabled' | 'refetch'
+/** Internal escape hatch for consumers that need a custom root query boundary. */
+export interface RelationalRootOverride {
+  descriptor: QueryDescriptor
+  config?: QueryConfig<unknown, unknown>
 }
 
 interface RelationalQueryOptions {
-  pageRoot?: RelationalPageRoot
-  ephemeralRoot?: boolean
+  root?: RelationalRootOverride
 }
 
 /**
@@ -254,8 +254,7 @@ export class RelationalQueryRef<
 
   #onEvict: (() => void) | null = null
   #name: string | undefined
-  #pageRoot: RelationalPageRoot | null
-  #ephemeralRoot: boolean
+  #rootOverride: RelationalRootOverride | null
 
   constructor(
     host: RelationalQueryHost<TParams, TMeta, TQuery>,
@@ -267,10 +266,9 @@ export class RelationalQueryRef<
     this.#host = host
     this.#ast = ast
     this.#schema = schema
-    this.#queryId = `rq/${hashObject(options?.pageRoot ? { ast, page: options.pageRoot.page } : ast)}`
+    this.#queryId = `rq/${hashObject(options?.root ? { ast, root: options.root } : ast)}`
     this.#onEvict = onEvict ?? null
-    this.#pageRoot = options?.pageRoot ?? null
-    this.#ephemeralRoot = options?.ephemeralRoot ?? false
+    this.#rootOverride = options?.root ?? null
   }
 
   /** Returns internal details of this query reference (for debugging/testing). */
@@ -338,19 +336,9 @@ export class RelationalQueryRef<
     return this.#ast.kind
   }
 
-  /** Native continuation metadata for an internally page-backed relational query. */
-  pageInfo(): PageInfo | undefined {
-    return this.#root?.pageInfo()
-  }
-
-  /** Server-reported result-set size for this root window, when available. */
-  total(): number | undefined {
-    return this.#root?.total()
-  }
-
-  /** Root row identity, excluding relation-only updates. */
-  rootRevision(): unknown {
-    return this.#root?.revision()
+  /** Adapter-neutral metadata for the root query, excluding relation-only updates. */
+  rootMetadata(): RootMetadata {
+    return this.#root?.metadata() ?? { pageInfo: undefined, total: undefined, revision: undefined }
   }
 
   /**
@@ -927,13 +915,8 @@ export class RelationalQueryRef<
       return
     }
 
-    const rootDesc: QueryDescriptor = this.#pageRoot
-      ? {
-          serviceName,
-          method: 'find',
-          params: { query: this.#ast.query },
-          page: this.#pageRoot.page,
-        }
+    const rootDesc: QueryDescriptor = this.#rootOverride
+      ? this.#rootOverride.descriptor
       : this.#ast.kind === 'get'
         ? {
             serviceName,
@@ -949,16 +932,14 @@ export class RelationalQueryRef<
 
     this.#root = new SingleQueryRoot({
       queryRef: this.#query(rootDesc, {
-        realtime: this.#pageRoot?.realtime ?? this.#realtimeMode,
-        // Window blocks are deliberately ephemeral: once a block leaves the retained
-        // viewport set, its QueryStore index is vacuumed with the last subscription.
-        // Normal relational queries keep their usual SWR cache lifetime.
-        fetchPolicy: this.#ephemeralRoot ? 'network-only' : 'swr',
+        realtime: this.#realtimeMode,
+        fetchPolicy: 'swr',
         // .all() fetches every page (rootAllPages — shared with explain()); when
         // unfiltered, success marks the service fully materialized.
         ...(rootAllPages(this.#ast.kind) ? { allPages: true } : {}),
         ...(this.#ast.kind !== 'get' ? matcherConfig : {}),
-        ...(this.#ast.server || this.#pageRoot ? { server: true } : {}),
+        ...(this.#ast.server ? { server: true } : {}),
+        ...this.#rootOverride?.config,
       }),
       isGet: this.#ast.kind === 'get',
       onRows,

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -1,5 +1,5 @@
 import { hashObject } from './hash.js'
-import type { MatcherContext, PageSource } from '../adapters/adapter.js'
+import type { MatcherContext, PageInfo, PageRequest, PageSource } from '../adapters/adapter.js'
 import { cursorQueryCanKeepPrefix, cursorQueryInputsUnchanged } from './cursorMaintenance.js'
 import type { QueryAST } from './queryBuilder.js'
 import { planRelation, planRootPagination, rootAllPages } from './queryClassification.js'
@@ -169,6 +169,17 @@ export interface InspectedRelationalQuery {
   }>
 }
 
+/** Internal root override used by window queries to materialize one native page. */
+export interface RelationalPageRoot {
+  page: PageRequest
+  realtime: 'disabled' | 'refetch'
+}
+
+interface RelationalQueryOptions {
+  pageRoot?: RelationalPageRoot
+  ephemeralRoot?: boolean
+}
+
 /**
  * Reference to a relational query with nested relations.
  * Manages multiple sub-queries and assembles data on-the-fly from entity caches.
@@ -243,18 +254,23 @@ export class RelationalQueryRef<
 
   #onEvict: (() => void) | null = null
   #name: string | undefined
+  #pageRoot: RelationalPageRoot | null
+  #ephemeralRoot: boolean
 
   constructor(
     host: RelationalQueryHost<TParams, TMeta, TQuery>,
     ast: QueryAST,
     schema: S,
     onEvict?: () => void,
+    options?: RelationalQueryOptions,
   ) {
     this.#host = host
     this.#ast = ast
     this.#schema = schema
-    this.#queryId = `rq/${hashObject(ast)}`
+    this.#queryId = `rq/${hashObject(options?.pageRoot ? { ast, page: options.pageRoot.page } : ast)}`
     this.#onEvict = onEvict ?? null
+    this.#pageRoot = options?.pageRoot ?? null
+    this.#ephemeralRoot = options?.ephemeralRoot ?? false
   }
 
   /** Returns internal details of this query reference (for debugging/testing). */
@@ -320,6 +336,21 @@ export class RelationalQueryRef<
    */
   kind(): QueryAST['kind'] {
     return this.#ast.kind
+  }
+
+  /** Native continuation metadata for an internally page-backed relational query. */
+  pageInfo(): PageInfo | undefined {
+    return this.#root?.pageInfo()
+  }
+
+  /** Server-reported result-set size for this root window, when available. */
+  total(): number | undefined {
+    return this.#root?.total()
+  }
+
+  /** Root row identity, excluding relation-only updates. */
+  rootRevision(): unknown {
+    return this.#root?.revision()
   }
 
   /**
@@ -896,8 +927,14 @@ export class RelationalQueryRef<
       return
     }
 
-    const rootDesc: QueryDescriptor =
-      this.#ast.kind === 'get'
+    const rootDesc: QueryDescriptor = this.#pageRoot
+      ? {
+          serviceName,
+          method: 'find',
+          params: { query: this.#ast.query },
+          page: this.#pageRoot.page,
+        }
+      : this.#ast.kind === 'get'
         ? {
             serviceName,
             method: 'get',
@@ -912,13 +949,16 @@ export class RelationalQueryRef<
 
     this.#root = new SingleQueryRoot({
       queryRef: this.#query(rootDesc, {
-        realtime: this.#realtimeMode,
-        fetchPolicy: 'swr',
+        realtime: this.#pageRoot?.realtime ?? this.#realtimeMode,
+        // Window blocks are deliberately ephemeral: once a block leaves the retained
+        // viewport set, its QueryStore index is vacuumed with the last subscription.
+        // Normal relational queries keep their usual SWR cache lifetime.
+        fetchPolicy: this.#ephemeralRoot ? 'network-only' : 'swr',
         // .all() fetches every page (rootAllPages — shared with explain()); when
         // unfiltered, success marks the service fully materialized.
         ...(rootAllPages(this.#ast.kind) ? { allPages: true } : {}),
         ...(this.#ast.kind !== 'get' ? matcherConfig : {}),
-        ...(this.#ast.server ? { server: true } : {}),
+        ...(this.#ast.server || this.#pageRoot ? { server: true } : {}),
       }),
       isGet: this.#ast.kind === 'get',
       onRows,

--- a/lib/core/windowQuery.ts
+++ b/lib/core/windowQuery.ts
@@ -72,6 +72,7 @@ interface SettledColdRead {
   status: 'settled'
   range: WindowRange
   promise: Promise<void>
+  lastUsed: number
 }
 
 type ColdRead = PendingColdRead | SettledColdRead
@@ -284,7 +285,10 @@ export class WindowQueryRef<
 
     const key = rangeKey(range)
     const existing = this.#coldReads.get(key)
-    if (existing) return existing.promise
+    if (existing) {
+      if (existing.status === 'settled') existing.lastUsed = ++this.#clock
+      return existing.promise
+    }
 
     let resolve = () => {}
     let reject = (_error: Error) => {}
@@ -411,6 +415,7 @@ export class WindowQueryRef<
   }
 
   #settleColdReads(): void {
+    let settled = false
     for (const [key, read] of this.#coldReads) {
       if (read.status === 'settled') continue
       const required = this.#pager.requiredStarts(read.range).flatMap(start => {
@@ -427,6 +432,7 @@ export class WindowQueryRef<
           status: 'settled',
           range: read.range,
           promise: read.promise,
+          lastUsed: ++this.#clock,
         })
         read.reject(error)
       } else if (this.#pager.rangeReady(read.range)) {
@@ -434,14 +440,39 @@ export class WindowQueryRef<
           status: 'settled',
           range: read.range,
           promise: read.promise,
+          lastUsed: ++this.#clock,
         })
         read.resolve()
       } else {
         continue
       }
-      // A settled render-phase read stays warm until React commits its subscriber.
-      // Genuinely abandoned reads are bounded by Figbird's idle window-ref LRU.
+      settled = true
+    }
+    if (settled) {
+      // The newest settled read stays warm for React's retry. Older abandoned
+      // ranges share the ordinary retained-page budget instead of pinning pages
+      // forever while another range has a committed subscriber.
+      this.#pruneSettledColdReads()
       this.#onIdle?.()
+    }
+  }
+
+  #pruneSettledColdReads(): void {
+    const reads = Array.from(this.#coldReads.entries())
+      .filter((entry): entry is [string, SettledColdRead] => entry[1].status === 'settled')
+      .sort((a, b) => b[1].lastUsed - a[1].lastUsed)
+    const retainedStarts = new Set<number>()
+
+    for (const [index, [key, read]] of reads.entries()) {
+      const targets = new Set(this.#pager.targetStarts(read.range, this.#config.preloadPages))
+      const starts = this.#pager.protectedStarts(targets)
+      const nextSize = new Set([...retainedStarts, ...starts]).size
+      const budget = Math.max(this.#config.maxPages, retainedStarts.size)
+      if (index > 0 && nextSize > budget) {
+        this.#coldReads.delete(key)
+        continue
+      }
+      for (const start of starts) retainedStarts.add(start)
     }
   }
 

--- a/lib/core/windowQuery.ts
+++ b/lib/core/windowQuery.ts
@@ -83,6 +83,7 @@ interface WindowQueryLifecycle {
 }
 
 const EMPTY_DATA: ReadonlyMap<number, never> = new Map<number, never>()
+const MAX_SETTLED_COLD_READS = 20
 
 function normalizeRange(range: WindowRange): WindowRange {
   if (!Number.isInteger(range.start) || range.start < 0) {
@@ -449,9 +450,9 @@ export class WindowQueryRef<
       settled = true
     }
     if (settled) {
-      // The newest settled read stays warm for React's retry. Older abandoned
-      // ranges share the ordinary retained-page budget instead of pinning pages
-      // forever while another range has a committed subscriber.
+      // Settled render-phase reads stay warm independently of maxPages so
+      // concurrent Suspense retries cannot evict one another. The separate cap
+      // bounds abandoned renders until React commits and subscribes a reader.
       this.#pruneSettledColdReads()
       this.#onIdle?.()
     }
@@ -461,19 +462,8 @@ export class WindowQueryRef<
     const reads = Array.from(this.#coldReads.entries())
       .filter((entry): entry is [string, SettledColdRead] => entry[1].status === 'settled')
       .sort((a, b) => b[1].lastUsed - a[1].lastUsed)
-    const retainedStarts = new Set<number>()
 
-    for (const [index, [key, read]] of reads.entries()) {
-      const targets = new Set(this.#pager.targetStarts(read.range, this.#config.preloadPages))
-      const starts = this.#pager.protectedStarts(targets)
-      const nextSize = new Set([...retainedStarts, ...starts]).size
-      const budget = Math.max(this.#config.maxPages, retainedStarts.size)
-      if (index > 0 && nextSize > budget) {
-        this.#coldReads.delete(key)
-        continue
-      }
-      for (const start of starts) retainedStarts.add(start)
-    }
+    for (const [key] of reads.slice(MAX_SETTLED_COLD_READS)) this.#coldReads.delete(key)
   }
 
   #syncPageFreshness(): void {

--- a/lib/core/windowQuery.ts
+++ b/lib/core/windowQuery.ts
@@ -60,12 +60,25 @@ interface WindowPage<T, S extends Schema, TParams, TMeta extends Record<string, 
   lastUsed: number
 }
 
-interface ColdRead {
+interface PendingColdRead {
+  status: 'pending'
   range: WindowRange
   promise: Promise<void>
   resolve: () => void
   reject: (error: Error) => void
-  releaseTimer: ReturnType<typeof setTimeout> | null
+}
+
+interface SettledColdRead {
+  status: 'settled'
+  range: WindowRange
+  promise: Promise<void>
+}
+
+type ColdRead = PendingColdRead | SettledColdRead
+
+interface WindowQueryLifecycle {
+  onEvict?: () => void
+  onIdle?: () => void
 }
 
 const EMPTY_DATA: ReadonlyMap<number, never> = new Map<number, never>()
@@ -109,6 +122,7 @@ export class WindowQueryRef<
   #key: string
   #name: string | undefined
   #onEvict: (() => void) | null
+  #onIdle: (() => void) | null
 
   #pages = new Map<number, WindowPage<T, S, TParams, TMeta, TQuery>>()
   #subscribers = new Map<(state: WindowQueryState<T>) => void, WindowSubscriber<T>>()
@@ -127,7 +141,7 @@ export class WindowQueryRef<
     ast: QueryAST,
     schema: S,
     config: WindowQueryConfig,
-    onEvict?: () => void,
+    lifecycle?: WindowQueryLifecycle,
   ) {
     if (!Number.isInteger(config.pageSize) || config.pageSize <= 0) {
       throw new Error(
@@ -149,7 +163,8 @@ export class WindowQueryRef<
     this.#schema = schema
     this.#config = config
     this.#key = `wq/${hashObject({ ast, config })}`
-    this.#onEvict = onEvict ?? null
+    this.#onEvict = lifecycle?.onEvict ?? null
+    this.#onIdle = lifecycle?.onIdle ?? null
 
     const serviceName = resolveServicePath(schema, ast.service)
     const context = {
@@ -192,7 +207,7 @@ export class WindowQueryRef<
       staleTime: options.staleTime ?? 0,
     })
     const coldRead = this.#coldReads.get(rangeKey(range))
-    if (coldRead && coldRead.releaseTimer !== null) {
+    if (coldRead?.status === 'settled') {
       this.#releaseColdRead(rangeKey(range), coldRead)
     }
     this.#syncPages()
@@ -278,11 +293,11 @@ export class WindowQueryRef<
       reject = rejectPromise
     })
     this.#coldReads.set(key, {
+      status: 'pending',
       range,
       promise,
       resolve,
       reject,
-      releaseTimer: null,
     })
     this.#syncPages()
     this.#settleColdReads()
@@ -293,6 +308,16 @@ export class WindowQueryRef<
     const range = normalizeRange(rangeInput)
     const key = rangeKey(range)
     this.#releaseColdRead(key)
+  }
+
+  /** @internal Evicts an abandoned render-phase read under Figbird cache pressure. */
+  evictAbandonedRead(): boolean {
+    if (this.#subscribers.size > 0 || this.#coldReads.size === 0) return false
+    for (const read of this.#coldReads.values()) {
+      if (read.status === 'pending') return false
+    }
+    this.#cleanup()
+    return true
   }
 
   #desiredStarts(): Set<number> {
@@ -387,7 +412,7 @@ export class WindowQueryRef<
 
   #settleColdReads(): void {
     for (const [key, read] of this.#coldReads) {
-      if (read.releaseTimer !== null) continue
+      if (read.status === 'settled') continue
       const required = this.#pager.requiredStarts(read.range).flatMap(start => {
         const page = this.#pages.get(start)
         return page ? [page] : []
@@ -398,15 +423,25 @@ export class WindowQueryRef<
         if (state.status === 'error') error ??= state.error
       }
       if (error) {
+        this.#coldReads.set(key, {
+          status: 'settled',
+          range: read.range,
+          promise: read.promise,
+        })
         read.reject(error)
       } else if (this.#pager.rangeReady(read.range)) {
+        this.#coldReads.set(key, {
+          status: 'settled',
+          range: read.range,
+          promise: read.promise,
+        })
         read.resolve()
       } else {
         continue
       }
-      // React retries a suspended render asynchronously. Keep this range pinned
-      // through that retry, but expire it on the next task if no subscription commits.
-      read.releaseTimer = setTimeout(() => this.#releaseColdRead(key, read), 0)
+      // A settled render-phase read stays warm until React commits its subscriber.
+      // Genuinely abandoned reads are bounded by Figbird's idle window-ref LRU.
+      this.#onIdle?.()
     }
   }
 
@@ -499,7 +534,6 @@ export class WindowQueryRef<
   #releaseColdRead(key: string, expected?: ColdRead): void {
     const read = this.#coldReads.get(key)
     if (!read || (expected && read !== expected)) return
-    if (read.releaseTimer !== null) clearTimeout(read.releaseTimer)
     this.#coldReads.delete(key)
     if (this.#subscribers.size === 0 && this.#coldReads.size === 0) this.#scheduleCleanup()
   }
@@ -511,9 +545,6 @@ export class WindowQueryRef<
     this.#data = EMPTY_DATA
     this.#total = undefined
     this.#snapshotCache.clear()
-    for (const read of this.#coldReads.values()) {
-      if (read.releaseTimer !== null) clearTimeout(read.releaseTimer)
-    }
     this.#coldReads.clear()
     this.#onEvict?.()
   }

--- a/lib/core/windowQuery.ts
+++ b/lib/core/windowQuery.ts
@@ -1,13 +1,14 @@
-import type { PageCursor, PageInfo } from '../adapters/adapter.js'
 import { hashObject } from './hash.js'
 import type { QueryAST } from './queryBuilder.js'
-import {
-  RelationalQueryRef,
-  type RelationalPageRoot,
-  type RelationalQueryHost,
-} from './relationalQuery.js'
+import { RelationalQueryRef, type RelationalQueryHost } from './relationalQuery.js'
 import type { AnySchema, Schema } from './schema.js'
 import { resolveServicePath } from './schema.js'
+import {
+  CursorWindowPager,
+  OffsetWindowPager,
+  type PagerPage,
+  type WindowPager,
+} from './windowQueryPager.js'
 
 export interface WindowRange {
   /** First requested row index. */
@@ -56,7 +57,6 @@ interface WindowPage<T, S extends Schema, TParams, TMeta extends Record<string, 
   ref: RelationalQueryRef<T[], S, TParams, TMeta, TQuery>
   unsubscribe: () => void
   lastUsed: number
-  rootRevision: unknown
 }
 
 interface SuspenseWaiter {
@@ -88,9 +88,9 @@ function rangeKey(range: WindowRange): string {
 }
 
 /**
- * A viewport-indexed relational query. Offset services address blocks directly;
- * native cursor services walk forward once and retain index -> cursor checkpoints.
- * The public hook supplies ranges, while this reference owns page lifetimes.
+ * Shared lifecycle for a viewport-indexed relational query. Pagination-specific
+ * addressing and readiness live behind WindowPager; this class owns readers,
+ * relational page refs, Suspense waiters, and bounded retention.
  */
 export class WindowQueryRef<
   T,
@@ -103,25 +103,22 @@ export class WindowQueryRef<
   #ast: QueryAST
   #schema: S
   #config: WindowQueryConfig
-  #strategy: 'offset' | 'cursor'
-  #serviceName: string
+  #pager: WindowPager
   #key: string
   #name: string | undefined
   #onEvict: (() => void) | null
 
   #pages = new Map<number, WindowPage<T, S, TParams, TMeta, TQuery>>()
-  #cursorAt = new Map<number, PageCursor | undefined>([[0, undefined]])
-  #terminalIndex: number | undefined
   #subscribers = new Map<(state: WindowQueryState<T>) => void, WindowSubscriber<T>>()
   #coldRanges = new Map<string, WindowRange>()
   #waiters = new Map<string, SuspenseWaiter>()
   #cleanupScheduled = false
   #syncScheduled = false
+  #notifyScheduled = false
   #clock = 0
   #version = 0
   #data: ReadonlyMap<number, T> = EMPTY_DATA
   #total: number | undefined
-  #hasSuccessfulWindow = false
   #snapshotCache = new Map<string, { version: number; state: WindowQueryState<T> }>()
 
   constructor(
@@ -150,10 +147,29 @@ export class WindowQueryRef<
     this.#ast = ast
     this.#schema = schema
     this.#config = config
-    this.#serviceName = resolveServicePath(schema, ast.service)
-    this.#strategy = host.adapter.pageSource?.(this.#serviceName) ? 'cursor' : 'offset'
     this.#key = `wq/${hashObject({ ast, config })}`
     this.#onEvict = onEvict ?? null
+
+    const serviceName = resolveServicePath(schema, ast.service)
+    const context = {
+      pageSize: config.pageSize,
+      serviceName,
+      ast,
+      access: {
+        page: (start: number) => this.#pagerPage(start),
+        pages: () => Array.from(this.#pages.keys(), start => this.#pagerPage(start)!),
+        ensure: (start: number) => this.#ensurePage(start),
+        drop: (start: number) => this.#dropPage(start),
+        touch: (start: number) => this.#touchPage(start),
+        total: () => this.#total,
+        setTotal: (total: number) => {
+          this.#total = total
+        },
+      },
+    }
+    this.#pager = host.adapter.pageSource?.(serviceName)
+      ? new CursorWindowPager(context)
+      : new OffsetWindowPager(context)
   }
 
   hash(): string {
@@ -190,38 +206,25 @@ export class WindowQueryRef<
     const cached = this.#snapshotCache.get(key)
     if (cached?.version === this.#version) return cached.state
 
-    const required =
-      this.#strategy === 'cursor'
-        ? this.#cursorPagesForRange(range)
-        : this.#pageStarts(range, 0).flatMap(start => {
-            const page = this.#pages.get(start)
-            return page ? [page] : []
-          })
-    let missing =
-      this.#strategy === 'cursor'
-        ? !this.#cursorRangeReady(range)
-        : required.length !== this.#pageStarts(range, 0).length
+    const required = this.#pager.requiredStarts(range).flatMap(start => {
+      const page = this.#pages.get(start)
+      return page ? [page] : []
+    })
+    const missing = !this.#pager.rangeReady(range)
     let isFetching = false
     let error: Error | null = null
     for (const page of required) {
       const state = page.ref.getSnapshot()
-      if (!state || state.status === 'loading') missing = true
-      if (state?.isFetching) isFetching = true
-      if (state?.status === 'error') error ??= state.error
-      if (state?.status === 'success' && state.error) error ??= state.error
+      if (state.isFetching) isFetching = true
+      if (state.status === 'error') error ??= state.error
+      if (state.status === 'success' && state.error) error ??= state.error
     }
-    if (this.#strategy === 'cursor') {
-      for (const page of this.#pages.values()) {
-        if (page.ref.getSnapshot().isFetching) isFetching = true
-      }
-    } else {
-      for (const start of this.#pageStarts(range, this.#config.preloadPages)) {
-        if (this.#pages.get(start)?.ref.getSnapshot().isFetching) isFetching = true
-      }
+    for (const start of this.#pager.fetchingStarts(range, this.#config.preloadPages)) {
+      if (this.#pages.get(start)?.ref.getSnapshot().isFetching) isFetching = true
     }
 
     let state: WindowQueryState<T>
-    if (error && !this.#hasSuccessfulWindow) {
+    if (error) {
       state = {
         status: 'error',
         data: this.#data,
@@ -229,7 +232,7 @@ export class WindowQueryRef<
         error,
         isFetching: false,
       }
-    } else if (missing && !this.#hasSuccessfulWindow) {
+    } else if (missing) {
       state = {
         status: 'loading',
         data: this.#data,
@@ -242,8 +245,8 @@ export class WindowQueryRef<
         status: 'success',
         data: this.#data,
         total: this.#total,
-        error,
-        isFetching: isFetching || missing,
+        error: null,
+        isFetching,
       }
     }
     this.#snapshotCache.set(key, { version: this.#version, state })
@@ -256,7 +259,6 @@ export class WindowQueryRef<
 
   suspensePromise(rangeInput: WindowRange): Promise<void> {
     const range = normalizeRange(rangeInput)
-    if (this.#hasSuccessfulWindow) return Promise.resolve()
     const state = this.getSnapshot(range)
     if (state.status === 'success') return Promise.resolve()
     if (state.status === 'error') return Promise.reject(state.error)
@@ -286,68 +288,30 @@ export class WindowQueryRef<
     if (this.#subscribers.size === 0 && this.#coldRanges.size === 0) this.#scheduleCleanup()
   }
 
-  #pageStarts(range: WindowRange, preloadPages: number): number[] {
-    const { pageSize } = this.#config
-    const firstVisible = Math.floor(range.start / pageSize) * pageSize
-    const lastVisible = Math.floor((Math.max(range.start + 1, range.end) - 1) / pageSize) * pageSize
-    const first = Math.max(0, firstVisible - preloadPages * pageSize)
-    const last = lastVisible + preloadPages * pageSize
-    const starts: number[] = []
-    for (let start = first; start <= last; start += pageSize) {
-      if (this.#total !== undefined && start >= this.#total) continue
-      starts.push(start)
-    }
-    return starts
-  }
-
   #desiredStarts(): Set<number> {
     const starts = new Set<number>()
     for (const subscriber of this.#subscribers.values()) {
-      for (const start of this.#pageStarts(subscriber.range, this.#config.preloadPages)) {
+      for (const start of this.#pager.targetStarts(subscriber.range, this.#config.preloadPages)) {
         starts.add(start)
       }
     }
     for (const range of this.#coldRanges.values()) {
-      for (const start of this.#pageStarts(range, this.#config.preloadPages)) starts.add(start)
+      for (const start of this.#pager.targetStarts(range, this.#config.preloadPages)) {
+        starts.add(start)
+      }
     }
     return starts
   }
 
   #syncPages(): void {
     const desired = this.#desiredStarts()
-    if (this.#strategy === 'offset') {
-      for (const start of desired) this.#ensurePage(start)
-    } else {
-      // Page zero is the cursor chain's total/reconnect sentinel. Other desired
-      // blocks start directly once their index checkpoint has been discovered.
-      this.#ensurePage(0)
-      for (const target of desired) {
-        const lastIndex = Math.min(
-          target + this.#config.pageSize - 1,
-          (this.#total ?? Infinity) - 1,
-        )
-        if (lastIndex >= target) this.#ensureCursorPath(lastIndex)
-      }
+    this.#pager.sync(desired)
+    if (this.#evictPages(this.#pager.protectedStarts(desired))) {
+      this.#rebuildData()
+      this.#version += 1
+      this.#snapshotCache.clear()
+      this.#scheduleNotify()
     }
-    this.#evictPages(this.#strategy === 'cursor' ? this.#cursorProtectedStarts(desired) : desired)
-  }
-
-  #ensureCursorPath(target: number): void {
-    if (this.#terminalIndex !== undefined && target >= this.#terminalIndex) return
-    const covering = this.#cursorPageCovering(target)
-    if (covering) {
-      covering.lastUsed = ++this.#clock
-      return
-    }
-    if (this.#cursorAt.has(target)) {
-      this.#ensurePage(target)
-      return
-    }
-    let nearest = 0
-    for (const index of this.#cursorAt.keys()) {
-      if (index <= target && index > nearest) nearest = index
-    }
-    this.#ensurePage(nearest)
   }
 
   #ensurePage(start: number): void {
@@ -356,38 +320,13 @@ export class WindowQueryRef<
       existing.lastUsed = ++this.#clock
       return
     }
-    if (this.#strategy === 'cursor' && !this.#cursorAt.has(start)) return
 
-    const pageRoot: RelationalPageRoot | undefined =
-      this.#strategy === 'cursor'
-        ? {
-            page: {
-              limit: this.#config.pageSize,
-              ...(this.#cursorAt.get(start) !== undefined
-                ? { after: this.#cursorAt.get(start)! }
-                : {}),
-              includeTotal: start === 0,
-            },
-            realtime: start === 0 && !this.#ast.snapshot ? 'refetch' : 'disabled',
-          }
-        : undefined
-    const pageAst: QueryAST =
-      this.#strategy === 'offset'
-        ? {
-            ...this.#ast,
-            query: {
-              ...this.#ast.query,
-              $limit: this.#config.pageSize,
-              $skip: start,
-            },
-          }
-        : this.#ast
     const ref = new RelationalQueryRef<T[], S, TParams, TMeta, TQuery>(
       this.#host,
-      pageAst,
+      this.#ast,
       this.#schema,
       undefined,
-      { ...(pageRoot ? { pageRoot } : {}), ephemeralRoot: true },
+      { root: this.#pager.rootOverride(start) },
     )
     ref.setDisplayName(this.#name ? `${this.#name} [${start}]` : undefined)
     const page: WindowPage<T, S, TParams, TMeta, TQuery> = {
@@ -395,7 +334,6 @@ export class WindowQueryRef<
       ref,
       unsubscribe: () => {},
       lastUsed: ++this.#clock,
-      rootRevision: undefined,
     }
     this.#pages.set(start, page)
     page.unsubscribe = ref.subscribe(() => this.#pageChanged(start), {
@@ -409,66 +347,21 @@ export class WindowQueryRef<
     if (!page) return
     const state = page.ref.getSnapshot()
     if (state.status === 'success') {
-      const total = page.ref.total()
-      if (total !== undefined) {
-        this.#total = total
-        if (this.#strategy === 'cursor') this.#terminalIndex = total
-      }
-
-      if (this.#strategy === 'cursor') {
-        const revision = page.ref.rootRevision()
-        if (start === 0 && page.rootRevision !== undefined && page.rootRevision !== revision) {
-          this.#resetCursorDescendants()
-        }
-        page.rootRevision = revision
-        this.#recordCursorContinuation(start, state.data.length, page.ref.pageInfo())
-      }
+      const metadata = page.ref.rootMetadata()
+      this.#pager.pageSucceeded({
+        start,
+        rowCount: state.data.length,
+        pageInfo: metadata.pageInfo,
+        total: metadata.total,
+        revision: metadata.revision,
+      })
     }
     this.#rebuildData()
-    this.#refreshSuccessfulWindow()
     this.#version += 1
     this.#snapshotCache.clear()
     this.#settleWaiters()
     this.#scheduleSync()
-    for (const subscriber of this.#subscribers.values()) {
-      subscriber.listener(this.getSnapshot(subscriber.range))
-    }
-  }
-
-  #recordCursorContinuation(start: number, rowCount: number, pageInfo: PageInfo | undefined): void {
-    if (!pageInfo) return
-    if (!pageInfo.hasMore) {
-      this.#terminalIndex = start + rowCount
-      this.#total ??= this.#terminalIndex
-      return
-    }
-    const next = start + rowCount
-    if (rowCount === 0) return
-    this.#cursorAt.set(next, pageInfo.endCursor)
-  }
-
-  #resetCursorDescendants(): void {
-    for (const start of Array.from(this.#pages.keys())) {
-      if (start > 0) this.#dropPage(start)
-    }
-    this.#cursorAt = new Map([[0, undefined]])
-    this.#terminalIndex = undefined
-  }
-
-  #refreshSuccessfulWindow(): void {
-    if (this.#hasSuccessfulWindow) return
-    const ranges = [
-      ...Array.from(this.#subscribers.values(), subscriber => subscriber.range),
-      ...this.#coldRanges.values(),
-    ]
-    this.#hasSuccessfulWindow = ranges.some(range =>
-      this.#strategy === 'cursor'
-        ? this.#cursorRangeReady(range)
-        : this.#pageStarts(range, 0).every(start => {
-            const state = this.#pages.get(start)?.ref.getSnapshot()
-            return state?.status === 'success'
-          }),
-    )
+    this.#scheduleNotify()
   }
 
   #rebuildData(): void {
@@ -484,28 +377,20 @@ export class WindowQueryRef<
 
   #settleWaiters(): void {
     for (const [key, waiter] of this.#waiters) {
-      const required =
-        this.#strategy === 'cursor'
-          ? this.#cursorPagesForRange(waiter.range)
-          : this.#pageStarts(waiter.range, 0).flatMap(start => {
-              const page = this.#pages.get(start)
-              return page ? [page] : []
-            })
+      const required = this.#pager.requiredStarts(waiter.range).flatMap(start => {
+        const page = this.#pages.get(start)
+        return page ? [page] : []
+      })
       let error: Error | null = null
-      let ready =
-        this.#strategy === 'cursor'
-          ? this.#cursorRangeReady(waiter.range)
-          : required.length === this.#pageStarts(waiter.range, 0).length
       for (const page of required) {
         const state = page.ref.getSnapshot()
-        if (state.status === 'loading') ready = false
-        if (state?.status === 'error') error ??= state.error
+        if (state.status === 'error') error ??= state.error
       }
       if (error) {
         this.#waiters.delete(key)
         this.#coldRanges.delete(key)
         waiter.reject(error)
-      } else if (ready) {
+      } else if (this.#pager.rangeReady(waiter.range)) {
         this.#waiters.delete(key)
         waiter.resolve()
       }
@@ -520,88 +405,24 @@ export class WindowQueryRef<
     return staleTime === Infinity ? 0 : staleTime
   }
 
-  /** A successful cursor page whose absolute interval contains this row. */
-  #cursorPageCovering(index: number): WindowPage<T, S, TParams, TMeta, TQuery> | undefined {
-    for (const page of this.#pages.values()) {
-      const state = page.ref.getSnapshot()
-      if (
-        state.status === 'success' &&
-        page.start <= index &&
-        index < page.start + state.data.length
-      ) {
-        return page
-      }
+  #pagerPage(start: number): PagerPage | undefined {
+    const page = this.#pages.get(start)
+    if (!page) return undefined
+    const state = page.ref.getSnapshot()
+    return {
+      start,
+      status: state.status,
+      rowCount: state.status === 'success' ? state.data.length : 0,
     }
-    return undefined
   }
 
-  /** Cursor pages currently responsible for making a visible range ready. */
-  #cursorPagesForRange(range: WindowRange): WindowPage<T, S, TParams, TMeta, TQuery>[] {
-    const pages = new Set<WindowPage<T, S, TParams, TMeta, TQuery>>()
-    const knownEnd = Math.min(range.end, this.#terminalIndex ?? this.#total ?? range.end)
-    let index = range.start
-    while (index < knownEnd) {
-      const covering = this.#cursorPageCovering(index)
-      if (covering) {
-        pages.add(covering)
-        const state = covering.ref.getSnapshot()
-        if (state.status !== 'success') break
-        index = covering.start + state.data.length
-        continue
-      }
-      let nearest = 0
-      for (const checkpoint of this.#cursorAt.keys()) {
-        if (checkpoint <= index && checkpoint > nearest) nearest = checkpoint
-      }
-      const page = this.#pages.get(nearest)
-      if (page) pages.add(page)
-      break
-    }
-    return Array.from(pages)
+  #touchPage(start: number): void {
+    const page = this.#pages.get(start)
+    if (page) page.lastUsed = ++this.#clock
   }
 
-  #cursorRangeReady(range: WindowRange): boolean {
-    const knownEnd = Math.min(range.end, this.#terminalIndex ?? this.#total ?? range.end)
-    let index = range.start
-    while (index < knownEnd) {
-      const page = this.#cursorPageCovering(index)
-      if (!page) return false
-      const state = page.ref.getSnapshot()
-      if (state.status !== 'success') return false
-      index = page.start + state.data.length
-    }
-    return true
-  }
-
-  #cursorProtectedStarts(targets: ReadonlySet<number>): Set<number> {
-    const starts = new Set<number>([0])
-    for (const target of targets) {
-      const targetEnd = target + this.#config.pageSize
-      for (const page of this.#pages.values()) {
-        const state = page.ref.getSnapshot()
-        if (
-          state.status === 'success' &&
-          page.start < targetEnd &&
-          page.start + state.data.length > target
-        ) {
-          starts.add(page.start)
-        }
-      }
-      const covering = this.#cursorPageCovering(target)
-      if (covering) {
-        starts.add(covering.start)
-      }
-      const lastIndex = Math.min(target + this.#config.pageSize - 1, (this.#total ?? Infinity) - 1)
-      let nearest = 0
-      for (const checkpoint of this.#cursorAt.keys()) {
-        if (checkpoint <= lastIndex && checkpoint > nearest) nearest = checkpoint
-      }
-      if (this.#pages.has(nearest)) starts.add(nearest)
-    }
-    return starts
-  }
-
-  #evictPages(protectedStarts: ReadonlySet<number>): void {
+  #evictPages(protectedStarts: ReadonlySet<number>): boolean {
+    let evicted = false
     while (this.#pages.size > this.#config.maxPages) {
       const candidates = Array.from(this.#pages.values())
         .filter(page => !protectedStarts.has(page.start))
@@ -609,7 +430,9 @@ export class WindowQueryRef<
       const oldest = candidates[0]
       if (!oldest) break
       this.#dropPage(oldest.start)
+      evicted = true
     }
+    return evicted
   }
 
   #dropPage(start: number): void {
@@ -628,6 +451,17 @@ export class WindowQueryRef<
     })
   }
 
+  #scheduleNotify(): void {
+    if (this.#notifyScheduled) return
+    this.#notifyScheduled = true
+    queueMicrotask(() => {
+      this.#notifyScheduled = false
+      for (const subscriber of this.#subscribers.values()) {
+        subscriber.listener(this.getSnapshot(subscriber.range))
+      }
+    })
+  }
+
   #scheduleCleanup(): void {
     if (this.#cleanupScheduled) return
     this.#cleanupScheduled = true
@@ -640,11 +474,9 @@ export class WindowQueryRef<
   #cleanup(): void {
     for (const page of this.#pages.values()) page.unsubscribe()
     this.#pages.clear()
-    this.#cursorAt = new Map([[0, undefined]])
-    this.#terminalIndex = undefined
+    this.#pager.reset()
     this.#data = EMPTY_DATA
     this.#total = undefined
-    this.#hasSuccessfulWindow = false
     this.#snapshotCache.clear()
     this.#waiters.clear()
     this.#onEvict?.()

--- a/lib/core/windowQuery.ts
+++ b/lib/core/windowQuery.ts
@@ -1,0 +1,652 @@
+import type { PageCursor, PageInfo } from '../adapters/adapter.js'
+import { hashObject } from './hash.js'
+import type { QueryAST } from './queryBuilder.js'
+import {
+  RelationalQueryRef,
+  type RelationalPageRoot,
+  type RelationalQueryHost,
+} from './relationalQuery.js'
+import type { AnySchema, Schema } from './schema.js'
+import { resolveServicePath } from './schema.js'
+
+export interface WindowRange {
+  /** First requested row index. */
+  start: number
+  /** First row index after the requested range. */
+  end: number
+}
+
+export interface WindowQueryConfig {
+  pageSize: number
+  preloadPages: number
+  maxPages: number
+}
+
+export type WindowQueryState<T> =
+  | {
+      status: 'loading'
+      data: ReadonlyMap<number, T>
+      total: number | undefined
+      error: null
+      isFetching: true
+    }
+  | {
+      status: 'success'
+      data: ReadonlyMap<number, T>
+      total: number | undefined
+      error: Error | null
+      isFetching: boolean
+    }
+  | {
+      status: 'error'
+      data: ReadonlyMap<number, T>
+      total: number | undefined
+      error: Error
+      isFetching: false
+    }
+
+interface WindowSubscriber<T> {
+  range: WindowRange
+  staleTime: number
+  listener: (state: WindowQueryState<T>) => void
+}
+
+interface WindowPage<T, S extends Schema, TParams, TMeta extends Record<string, unknown>, TQuery> {
+  start: number
+  ref: RelationalQueryRef<T[], S, TParams, TMeta, TQuery>
+  unsubscribe: () => void
+  lastUsed: number
+  rootRevision: unknown
+}
+
+interface SuspenseWaiter {
+  range: WindowRange
+  promise: Promise<void>
+  resolve: () => void
+  reject: (error: Error) => void
+}
+
+const EMPTY_DATA: ReadonlyMap<number, never> = new Map<number, never>()
+
+function normalizeRange(range: WindowRange): WindowRange {
+  if (!Number.isInteger(range.start) || range.start < 0) {
+    throw new Error(
+      `useWindowQuery(): range.start must be a non-negative integer, got ${range.start}`,
+    )
+  }
+  if (!Number.isInteger(range.end) || range.end < range.start) {
+    throw new Error(
+      `useWindowQuery(): range.end must be an integer greater than or equal to range.start, got ${range.end}`,
+    )
+  }
+  // An empty viewport still needs one row request to discover the server total.
+  return range.end === range.start ? { start: range.start, end: range.start + 1 } : range
+}
+
+function rangeKey(range: WindowRange): string {
+  return `${range.start}:${range.end}`
+}
+
+/**
+ * A viewport-indexed relational query. Offset services address blocks directly;
+ * native cursor services walk forward once and retain index -> cursor checkpoints.
+ * The public hook supplies ranges, while this reference owns page lifetimes.
+ */
+export class WindowQueryRef<
+  T,
+  S extends Schema = AnySchema,
+  TParams = unknown,
+  TMeta extends Record<string, unknown> = Record<string, unknown>,
+  TQuery = Record<string, unknown>,
+> {
+  #host: RelationalQueryHost<TParams, TMeta, TQuery>
+  #ast: QueryAST
+  #schema: S
+  #config: WindowQueryConfig
+  #strategy: 'offset' | 'cursor'
+  #serviceName: string
+  #key: string
+  #name: string | undefined
+  #onEvict: (() => void) | null
+
+  #pages = new Map<number, WindowPage<T, S, TParams, TMeta, TQuery>>()
+  #cursorAt = new Map<number, PageCursor | undefined>([[0, undefined]])
+  #terminalIndex: number | undefined
+  #subscribers = new Map<(state: WindowQueryState<T>) => void, WindowSubscriber<T>>()
+  #coldRanges = new Map<string, WindowRange>()
+  #waiters = new Map<string, SuspenseWaiter>()
+  #cleanupScheduled = false
+  #syncScheduled = false
+  #clock = 0
+  #version = 0
+  #data: ReadonlyMap<number, T> = EMPTY_DATA
+  #total: number | undefined
+  #hasSuccessfulWindow = false
+  #snapshotCache = new Map<string, { version: number; state: WindowQueryState<T> }>()
+
+  constructor(
+    host: RelationalQueryHost<TParams, TMeta, TQuery>,
+    ast: QueryAST,
+    schema: S,
+    config: WindowQueryConfig,
+    onEvict?: () => void,
+  ) {
+    if (!Number.isInteger(config.pageSize) || config.pageSize <= 0) {
+      throw new Error(
+        `useWindowQuery(): pageSize must be a positive integer, got ${config.pageSize}`,
+      )
+    }
+    if (!Number.isInteger(config.preloadPages) || config.preloadPages < 0) {
+      throw new Error(
+        `useWindowQuery(): preloadPages must be a non-negative integer, got ${config.preloadPages}`,
+      )
+    }
+    if (!Number.isInteger(config.maxPages) || config.maxPages <= 0) {
+      throw new Error(
+        `useWindowQuery(): maxPages must be a positive integer, got ${config.maxPages}`,
+      )
+    }
+    this.#host = host
+    this.#ast = ast
+    this.#schema = schema
+    this.#config = config
+    this.#serviceName = resolveServicePath(schema, ast.service)
+    this.#strategy = host.adapter.pageSource?.(this.#serviceName) ? 'cursor' : 'offset'
+    this.#key = `wq/${hashObject({ ast, config })}`
+    this.#onEvict = onEvict ?? null
+  }
+
+  hash(): string {
+    return this.#key
+  }
+
+  setDisplayName(name: string | undefined): void {
+    if (name && !this.#name) this.#name = name
+  }
+
+  subscribe(
+    listener: (state: WindowQueryState<T>) => void,
+    options: { range: WindowRange; staleTime?: number },
+  ): () => void {
+    const range = normalizeRange(options.range)
+    this.#subscribers.set(listener, {
+      listener,
+      range,
+      staleTime: options.staleTime ?? 0,
+    })
+    this.#coldRanges.delete(rangeKey(range))
+    this.#syncPages()
+
+    return () => {
+      this.#subscribers.delete(listener)
+      this.#scheduleSync()
+      if (this.#subscribers.size === 0 && this.#coldRanges.size === 0) this.#scheduleCleanup()
+    }
+  }
+
+  getSnapshot(rangeInput: WindowRange): WindowQueryState<T> {
+    const range = normalizeRange(rangeInput)
+    const key = rangeKey(range)
+    const cached = this.#snapshotCache.get(key)
+    if (cached?.version === this.#version) return cached.state
+
+    const required =
+      this.#strategy === 'cursor'
+        ? this.#cursorPagesForRange(range)
+        : this.#pageStarts(range, 0).flatMap(start => {
+            const page = this.#pages.get(start)
+            return page ? [page] : []
+          })
+    let missing =
+      this.#strategy === 'cursor'
+        ? !this.#cursorRangeReady(range)
+        : required.length !== this.#pageStarts(range, 0).length
+    let isFetching = false
+    let error: Error | null = null
+    for (const page of required) {
+      const state = page.ref.getSnapshot()
+      if (!state || state.status === 'loading') missing = true
+      if (state?.isFetching) isFetching = true
+      if (state?.status === 'error') error ??= state.error
+      if (state?.status === 'success' && state.error) error ??= state.error
+    }
+    if (this.#strategy === 'cursor') {
+      for (const page of this.#pages.values()) {
+        if (page.ref.getSnapshot().isFetching) isFetching = true
+      }
+    } else {
+      for (const start of this.#pageStarts(range, this.#config.preloadPages)) {
+        if (this.#pages.get(start)?.ref.getSnapshot().isFetching) isFetching = true
+      }
+    }
+
+    let state: WindowQueryState<T>
+    if (error && !this.#hasSuccessfulWindow) {
+      state = {
+        status: 'error',
+        data: this.#data,
+        total: this.#total,
+        error,
+        isFetching: false,
+      }
+    } else if (missing && !this.#hasSuccessfulWindow) {
+      state = {
+        status: 'loading',
+        data: this.#data,
+        total: this.#total,
+        error: null,
+        isFetching: true,
+      }
+    } else {
+      state = {
+        status: 'success',
+        data: this.#data,
+        total: this.#total,
+        error,
+        isFetching: isFetching || missing,
+      }
+    }
+    this.#snapshotCache.set(key, { version: this.#version, state })
+    return state
+  }
+
+  refetch(): void {
+    for (const page of this.#pages.values()) page.ref.refetch()
+  }
+
+  suspensePromise(rangeInput: WindowRange): Promise<void> {
+    const range = normalizeRange(rangeInput)
+    if (this.#hasSuccessfulWindow) return Promise.resolve()
+    const state = this.getSnapshot(range)
+    if (state.status === 'success') return Promise.resolve()
+    if (state.status === 'error') return Promise.reject(state.error)
+
+    const key = rangeKey(range)
+    const existing = this.#waiters.get(key)
+    if (existing) return existing.promise
+
+    let resolve = () => {}
+    let reject = (_error: Error) => {}
+    const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise
+      reject = rejectPromise
+    })
+    this.#waiters.set(key, { range, promise, resolve, reject })
+    this.#coldRanges.set(key, range)
+    this.#syncPages()
+    this.#settleWaiters()
+    return promise
+  }
+
+  releaseColdStart(rangeInput: WindowRange): void {
+    const range = normalizeRange(rangeInput)
+    const key = rangeKey(range)
+    this.#coldRanges.delete(key)
+    this.#waiters.delete(key)
+    if (this.#subscribers.size === 0 && this.#coldRanges.size === 0) this.#scheduleCleanup()
+  }
+
+  #pageStarts(range: WindowRange, preloadPages: number): number[] {
+    const { pageSize } = this.#config
+    const firstVisible = Math.floor(range.start / pageSize) * pageSize
+    const lastVisible = Math.floor((Math.max(range.start + 1, range.end) - 1) / pageSize) * pageSize
+    const first = Math.max(0, firstVisible - preloadPages * pageSize)
+    const last = lastVisible + preloadPages * pageSize
+    const starts: number[] = []
+    for (let start = first; start <= last; start += pageSize) {
+      if (this.#total !== undefined && start >= this.#total) continue
+      starts.push(start)
+    }
+    return starts
+  }
+
+  #desiredStarts(): Set<number> {
+    const starts = new Set<number>()
+    for (const subscriber of this.#subscribers.values()) {
+      for (const start of this.#pageStarts(subscriber.range, this.#config.preloadPages)) {
+        starts.add(start)
+      }
+    }
+    for (const range of this.#coldRanges.values()) {
+      for (const start of this.#pageStarts(range, this.#config.preloadPages)) starts.add(start)
+    }
+    return starts
+  }
+
+  #syncPages(): void {
+    const desired = this.#desiredStarts()
+    if (this.#strategy === 'offset') {
+      for (const start of desired) this.#ensurePage(start)
+    } else {
+      // Page zero is the cursor chain's total/reconnect sentinel. Other desired
+      // blocks start directly once their index checkpoint has been discovered.
+      this.#ensurePage(0)
+      for (const target of desired) {
+        const lastIndex = Math.min(
+          target + this.#config.pageSize - 1,
+          (this.#total ?? Infinity) - 1,
+        )
+        if (lastIndex >= target) this.#ensureCursorPath(lastIndex)
+      }
+    }
+    this.#evictPages(this.#strategy === 'cursor' ? this.#cursorProtectedStarts(desired) : desired)
+  }
+
+  #ensureCursorPath(target: number): void {
+    if (this.#terminalIndex !== undefined && target >= this.#terminalIndex) return
+    const covering = this.#cursorPageCovering(target)
+    if (covering) {
+      covering.lastUsed = ++this.#clock
+      return
+    }
+    if (this.#cursorAt.has(target)) {
+      this.#ensurePage(target)
+      return
+    }
+    let nearest = 0
+    for (const index of this.#cursorAt.keys()) {
+      if (index <= target && index > nearest) nearest = index
+    }
+    this.#ensurePage(nearest)
+  }
+
+  #ensurePage(start: number): void {
+    const existing = this.#pages.get(start)
+    if (existing) {
+      existing.lastUsed = ++this.#clock
+      return
+    }
+    if (this.#strategy === 'cursor' && !this.#cursorAt.has(start)) return
+
+    const pageRoot: RelationalPageRoot | undefined =
+      this.#strategy === 'cursor'
+        ? {
+            page: {
+              limit: this.#config.pageSize,
+              ...(this.#cursorAt.get(start) !== undefined
+                ? { after: this.#cursorAt.get(start)! }
+                : {}),
+              includeTotal: start === 0,
+            },
+            realtime: start === 0 && !this.#ast.snapshot ? 'refetch' : 'disabled',
+          }
+        : undefined
+    const pageAst: QueryAST =
+      this.#strategy === 'offset'
+        ? {
+            ...this.#ast,
+            query: {
+              ...this.#ast.query,
+              $limit: this.#config.pageSize,
+              $skip: start,
+            },
+          }
+        : this.#ast
+    const ref = new RelationalQueryRef<T[], S, TParams, TMeta, TQuery>(
+      this.#host,
+      pageAst,
+      this.#schema,
+      undefined,
+      { ...(pageRoot ? { pageRoot } : {}), ephemeralRoot: true },
+    )
+    ref.setDisplayName(this.#name ? `${this.#name} [${start}]` : undefined)
+    const page: WindowPage<T, S, TParams, TMeta, TQuery> = {
+      start,
+      ref,
+      unsubscribe: () => {},
+      lastUsed: ++this.#clock,
+      rootRevision: undefined,
+    }
+    this.#pages.set(start, page)
+    page.unsubscribe = ref.subscribe(() => this.#pageChanged(start), {
+      staleTime: this.#currentStaleTime(),
+    })
+    this.#pageChanged(start)
+  }
+
+  #pageChanged(start: number): void {
+    const page = this.#pages.get(start)
+    if (!page) return
+    const state = page.ref.getSnapshot()
+    if (state.status === 'success') {
+      const total = page.ref.total()
+      if (total !== undefined) {
+        this.#total = total
+        if (this.#strategy === 'cursor') this.#terminalIndex = total
+      }
+
+      if (this.#strategy === 'cursor') {
+        const revision = page.ref.rootRevision()
+        if (start === 0 && page.rootRevision !== undefined && page.rootRevision !== revision) {
+          this.#resetCursorDescendants()
+        }
+        page.rootRevision = revision
+        this.#recordCursorContinuation(start, state.data.length, page.ref.pageInfo())
+      }
+    }
+    this.#rebuildData()
+    this.#refreshSuccessfulWindow()
+    this.#version += 1
+    this.#snapshotCache.clear()
+    this.#settleWaiters()
+    this.#scheduleSync()
+    for (const subscriber of this.#subscribers.values()) {
+      subscriber.listener(this.getSnapshot(subscriber.range))
+    }
+  }
+
+  #recordCursorContinuation(start: number, rowCount: number, pageInfo: PageInfo | undefined): void {
+    if (!pageInfo) return
+    if (!pageInfo.hasMore) {
+      this.#terminalIndex = start + rowCount
+      this.#total ??= this.#terminalIndex
+      return
+    }
+    const next = start + rowCount
+    if (rowCount === 0) return
+    this.#cursorAt.set(next, pageInfo.endCursor)
+  }
+
+  #resetCursorDescendants(): void {
+    for (const start of Array.from(this.#pages.keys())) {
+      if (start > 0) this.#dropPage(start)
+    }
+    this.#cursorAt = new Map([[0, undefined]])
+    this.#terminalIndex = undefined
+  }
+
+  #refreshSuccessfulWindow(): void {
+    if (this.#hasSuccessfulWindow) return
+    const ranges = [
+      ...Array.from(this.#subscribers.values(), subscriber => subscriber.range),
+      ...this.#coldRanges.values(),
+    ]
+    this.#hasSuccessfulWindow = ranges.some(range =>
+      this.#strategy === 'cursor'
+        ? this.#cursorRangeReady(range)
+        : this.#pageStarts(range, 0).every(start => {
+            const state = this.#pages.get(start)?.ref.getSnapshot()
+            return state?.status === 'success'
+          }),
+    )
+  }
+
+  #rebuildData(): void {
+    const data = new Map<number, T>()
+    const pages = Array.from(this.#pages.values()).sort((a, b) => a.start - b.start)
+    for (const page of pages) {
+      const state = page.ref.getSnapshot()
+      if (state.status !== 'success') continue
+      state.data.forEach((item, index) => data.set(page.start + index, item))
+    }
+    this.#data = data
+  }
+
+  #settleWaiters(): void {
+    for (const [key, waiter] of this.#waiters) {
+      const required =
+        this.#strategy === 'cursor'
+          ? this.#cursorPagesForRange(waiter.range)
+          : this.#pageStarts(waiter.range, 0).flatMap(start => {
+              const page = this.#pages.get(start)
+              return page ? [page] : []
+            })
+      let error: Error | null = null
+      let ready =
+        this.#strategy === 'cursor'
+          ? this.#cursorRangeReady(waiter.range)
+          : required.length === this.#pageStarts(waiter.range, 0).length
+      for (const page of required) {
+        const state = page.ref.getSnapshot()
+        if (state.status === 'loading') ready = false
+        if (state?.status === 'error') error ??= state.error
+      }
+      if (error) {
+        this.#waiters.delete(key)
+        this.#coldRanges.delete(key)
+        waiter.reject(error)
+      } else if (ready) {
+        this.#waiters.delete(key)
+        waiter.resolve()
+      }
+    }
+  }
+
+  #currentStaleTime(): number {
+    let staleTime = Infinity
+    for (const subscriber of this.#subscribers.values()) {
+      staleTime = Math.min(staleTime, subscriber.staleTime)
+    }
+    return staleTime === Infinity ? 0 : staleTime
+  }
+
+  /** A successful cursor page whose absolute interval contains this row. */
+  #cursorPageCovering(index: number): WindowPage<T, S, TParams, TMeta, TQuery> | undefined {
+    for (const page of this.#pages.values()) {
+      const state = page.ref.getSnapshot()
+      if (
+        state.status === 'success' &&
+        page.start <= index &&
+        index < page.start + state.data.length
+      ) {
+        return page
+      }
+    }
+    return undefined
+  }
+
+  /** Cursor pages currently responsible for making a visible range ready. */
+  #cursorPagesForRange(range: WindowRange): WindowPage<T, S, TParams, TMeta, TQuery>[] {
+    const pages = new Set<WindowPage<T, S, TParams, TMeta, TQuery>>()
+    const knownEnd = Math.min(range.end, this.#terminalIndex ?? this.#total ?? range.end)
+    let index = range.start
+    while (index < knownEnd) {
+      const covering = this.#cursorPageCovering(index)
+      if (covering) {
+        pages.add(covering)
+        const state = covering.ref.getSnapshot()
+        if (state.status !== 'success') break
+        index = covering.start + state.data.length
+        continue
+      }
+      let nearest = 0
+      for (const checkpoint of this.#cursorAt.keys()) {
+        if (checkpoint <= index && checkpoint > nearest) nearest = checkpoint
+      }
+      const page = this.#pages.get(nearest)
+      if (page) pages.add(page)
+      break
+    }
+    return Array.from(pages)
+  }
+
+  #cursorRangeReady(range: WindowRange): boolean {
+    const knownEnd = Math.min(range.end, this.#terminalIndex ?? this.#total ?? range.end)
+    let index = range.start
+    while (index < knownEnd) {
+      const page = this.#cursorPageCovering(index)
+      if (!page) return false
+      const state = page.ref.getSnapshot()
+      if (state.status !== 'success') return false
+      index = page.start + state.data.length
+    }
+    return true
+  }
+
+  #cursorProtectedStarts(targets: ReadonlySet<number>): Set<number> {
+    const starts = new Set<number>([0])
+    for (const target of targets) {
+      const targetEnd = target + this.#config.pageSize
+      for (const page of this.#pages.values()) {
+        const state = page.ref.getSnapshot()
+        if (
+          state.status === 'success' &&
+          page.start < targetEnd &&
+          page.start + state.data.length > target
+        ) {
+          starts.add(page.start)
+        }
+      }
+      const covering = this.#cursorPageCovering(target)
+      if (covering) {
+        starts.add(covering.start)
+      }
+      const lastIndex = Math.min(target + this.#config.pageSize - 1, (this.#total ?? Infinity) - 1)
+      let nearest = 0
+      for (const checkpoint of this.#cursorAt.keys()) {
+        if (checkpoint <= lastIndex && checkpoint > nearest) nearest = checkpoint
+      }
+      if (this.#pages.has(nearest)) starts.add(nearest)
+    }
+    return starts
+  }
+
+  #evictPages(protectedStarts: ReadonlySet<number>): void {
+    while (this.#pages.size > this.#config.maxPages) {
+      const candidates = Array.from(this.#pages.values())
+        .filter(page => !protectedStarts.has(page.start))
+        .sort((a, b) => a.lastUsed - b.lastUsed)
+      const oldest = candidates[0]
+      if (!oldest) break
+      this.#dropPage(oldest.start)
+    }
+  }
+
+  #dropPage(start: number): void {
+    const page = this.#pages.get(start)
+    if (!page) return
+    this.#pages.delete(start)
+    page.unsubscribe()
+  }
+
+  #scheduleSync(): void {
+    if (this.#syncScheduled) return
+    this.#syncScheduled = true
+    queueMicrotask(() => {
+      this.#syncScheduled = false
+      this.#syncPages()
+    })
+  }
+
+  #scheduleCleanup(): void {
+    if (this.#cleanupScheduled) return
+    this.#cleanupScheduled = true
+    queueMicrotask(() => {
+      this.#cleanupScheduled = false
+      if (this.#subscribers.size === 0 && this.#coldRanges.size === 0) this.#cleanup()
+    })
+  }
+
+  #cleanup(): void {
+    for (const page of this.#pages.values()) page.unsubscribe()
+    this.#pages.clear()
+    this.#cursorAt = new Map([[0, undefined]])
+    this.#terminalIndex = undefined
+    this.#data = EMPTY_DATA
+    this.#total = undefined
+    this.#hasSuccessfulWindow = false
+    this.#snapshotCache.clear()
+    this.#waiters.clear()
+    this.#onEvict?.()
+  }
+}

--- a/lib/core/windowQuery.ts
+++ b/lib/core/windowQuery.ts
@@ -56,14 +56,16 @@ interface WindowPage<T, S extends Schema, TParams, TMeta extends Record<string, 
   start: number
   ref: RelationalQueryRef<T[], S, TParams, TMeta, TQuery>
   unsubscribe: () => void
+  staleTime: number
   lastUsed: number
 }
 
-interface SuspenseWaiter {
+interface ColdRead {
   range: WindowRange
   promise: Promise<void>
   resolve: () => void
   reject: (error: Error) => void
+  releaseTimer: ReturnType<typeof setTimeout> | null
 }
 
 const EMPTY_DATA: ReadonlyMap<number, never> = new Map<number, never>()
@@ -90,7 +92,7 @@ function rangeKey(range: WindowRange): string {
 /**
  * Shared lifecycle for a viewport-indexed relational query. Pagination-specific
  * addressing and readiness live behind WindowPager; this class owns readers,
- * relational page refs, Suspense waiters, and bounded retention.
+ * relational page refs, render-phase cold reads, and bounded retention.
  */
 export class WindowQueryRef<
   T,
@@ -110,8 +112,7 @@ export class WindowQueryRef<
 
   #pages = new Map<number, WindowPage<T, S, TParams, TMeta, TQuery>>()
   #subscribers = new Map<(state: WindowQueryState<T>) => void, WindowSubscriber<T>>()
-  #coldRanges = new Map<string, WindowRange>()
-  #waiters = new Map<string, SuspenseWaiter>()
+  #coldReads = new Map<string, ColdRead>()
   #cleanupScheduled = false
   #syncScheduled = false
   #notifyScheduled = false
@@ -190,13 +191,16 @@ export class WindowQueryRef<
       range,
       staleTime: options.staleTime ?? 0,
     })
-    this.#coldRanges.delete(rangeKey(range))
+    const coldRead = this.#coldReads.get(rangeKey(range))
+    if (coldRead && coldRead.releaseTimer !== null) {
+      this.#releaseColdRead(rangeKey(range), coldRead)
+    }
     this.#syncPages()
 
     return () => {
       this.#subscribers.delete(listener)
       this.#scheduleSync()
-      if (this.#subscribers.size === 0 && this.#coldRanges.size === 0) this.#scheduleCleanup()
+      if (this.#subscribers.size === 0 && this.#coldReads.size === 0) this.#scheduleCleanup()
     }
   }
 
@@ -264,7 +268,7 @@ export class WindowQueryRef<
     if (state.status === 'error') return Promise.reject(state.error)
 
     const key = rangeKey(range)
-    const existing = this.#waiters.get(key)
+    const existing = this.#coldReads.get(key)
     if (existing) return existing.promise
 
     let resolve = () => {}
@@ -273,19 +277,22 @@ export class WindowQueryRef<
       resolve = resolvePromise
       reject = rejectPromise
     })
-    this.#waiters.set(key, { range, promise, resolve, reject })
-    this.#coldRanges.set(key, range)
+    this.#coldReads.set(key, {
+      range,
+      promise,
+      resolve,
+      reject,
+      releaseTimer: null,
+    })
     this.#syncPages()
-    this.#settleWaiters()
+    this.#settleColdReads()
     return promise
   }
 
   releaseColdStart(rangeInput: WindowRange): void {
     const range = normalizeRange(rangeInput)
     const key = rangeKey(range)
-    this.#coldRanges.delete(key)
-    this.#waiters.delete(key)
-    if (this.#subscribers.size === 0 && this.#coldRanges.size === 0) this.#scheduleCleanup()
+    this.#releaseColdRead(key)
   }
 
   #desiredStarts(): Set<number> {
@@ -295,8 +302,8 @@ export class WindowQueryRef<
         starts.add(start)
       }
     }
-    for (const range of this.#coldRanges.values()) {
-      for (const start of this.#pager.targetStarts(range, this.#config.preloadPages)) {
+    for (const read of this.#coldReads.values()) {
+      for (const start of this.#pager.targetStarts(read.range, this.#config.preloadPages)) {
         starts.add(start)
       }
     }
@@ -306,6 +313,7 @@ export class WindowQueryRef<
   #syncPages(): void {
     const desired = this.#desiredStarts()
     this.#pager.sync(desired)
+    this.#syncPageFreshness()
     if (this.#evictPages(this.#pager.protectedStarts(desired))) {
       this.#rebuildData()
       this.#version += 1
@@ -329,15 +337,17 @@ export class WindowQueryRef<
       { root: this.#pager.rootOverride(start) },
     )
     ref.setDisplayName(this.#name ? `${this.#name} [${start}]` : undefined)
+    const staleTime = this.#currentStaleTime()
     const page: WindowPage<T, S, TParams, TMeta, TQuery> = {
       start,
       ref,
       unsubscribe: () => {},
+      staleTime,
       lastUsed: ++this.#clock,
     }
     this.#pages.set(start, page)
     page.unsubscribe = ref.subscribe(() => this.#pageChanged(start), {
-      staleTime: this.#currentStaleTime(),
+      staleTime,
     })
     this.#pageChanged(start)
   }
@@ -359,7 +369,7 @@ export class WindowQueryRef<
     this.#rebuildData()
     this.#version += 1
     this.#snapshotCache.clear()
-    this.#settleWaiters()
+    this.#settleColdReads()
     this.#scheduleSync()
     this.#scheduleNotify()
   }
@@ -375,9 +385,10 @@ export class WindowQueryRef<
     this.#data = data
   }
 
-  #settleWaiters(): void {
-    for (const [key, waiter] of this.#waiters) {
-      const required = this.#pager.requiredStarts(waiter.range).flatMap(start => {
+  #settleColdReads(): void {
+    for (const [key, read] of this.#coldReads) {
+      if (read.releaseTimer !== null) continue
+      const required = this.#pager.requiredStarts(read.range).flatMap(start => {
         const page = this.#pages.get(start)
         return page ? [page] : []
       })
@@ -387,22 +398,36 @@ export class WindowQueryRef<
         if (state.status === 'error') error ??= state.error
       }
       if (error) {
-        this.#waiters.delete(key)
-        this.#coldRanges.delete(key)
-        waiter.reject(error)
-      } else if (this.#pager.rangeReady(waiter.range)) {
-        this.#waiters.delete(key)
-        waiter.resolve()
+        read.reject(error)
+      } else if (this.#pager.rangeReady(read.range)) {
+        read.resolve()
+      } else {
+        continue
       }
+      // React retries a suspended render asynchronously. Keep this range pinned
+      // through that retry, but expire it on the next task if no subscription commits.
+      read.releaseTimer = setTimeout(() => this.#releaseColdRead(key, read), 0)
+    }
+  }
+
+  #syncPageFreshness(): void {
+    const staleTime = this.#currentStaleTime()
+    for (const page of this.#pages.values()) {
+      if (page.staleTime === staleTime) continue
+      const unsubscribe = page.ref.subscribe(() => this.#pageChanged(page.start), { staleTime })
+      page.unsubscribe()
+      page.unsubscribe = unsubscribe
+      page.staleTime = staleTime
     }
   }
 
   #currentStaleTime(): number {
+    if (this.#subscribers.size === 0) return 0
     let staleTime = Infinity
     for (const subscriber of this.#subscribers.values()) {
       staleTime = Math.min(staleTime, subscriber.staleTime)
     }
-    return staleTime === Infinity ? 0 : staleTime
+    return staleTime
   }
 
   #pagerPage(start: number): PagerPage | undefined {
@@ -467,8 +492,16 @@ export class WindowQueryRef<
     this.#cleanupScheduled = true
     queueMicrotask(() => {
       this.#cleanupScheduled = false
-      if (this.#subscribers.size === 0 && this.#coldRanges.size === 0) this.#cleanup()
+      if (this.#subscribers.size === 0 && this.#coldReads.size === 0) this.#cleanup()
     })
+  }
+
+  #releaseColdRead(key: string, expected?: ColdRead): void {
+    const read = this.#coldReads.get(key)
+    if (!read || (expected && read !== expected)) return
+    if (read.releaseTimer !== null) clearTimeout(read.releaseTimer)
+    this.#coldReads.delete(key)
+    if (this.#subscribers.size === 0 && this.#coldReads.size === 0) this.#scheduleCleanup()
   }
 
   #cleanup(): void {
@@ -478,7 +511,10 @@ export class WindowQueryRef<
     this.#data = EMPTY_DATA
     this.#total = undefined
     this.#snapshotCache.clear()
-    this.#waiters.clear()
+    for (const read of this.#coldReads.values()) {
+      if (read.releaseTimer !== null) clearTimeout(read.releaseTimer)
+    }
+    this.#coldReads.clear()
     this.#onEvict?.()
   }
 }

--- a/lib/core/windowQueryPager.ts
+++ b/lib/core/windowQueryPager.ts
@@ -117,7 +117,8 @@ export class OffsetWindowPager implements WindowPager {
       },
       config: {
         realtime: ast.snapshot ? 'disabled' : 'merge',
-        fetchPolicy: 'network-only',
+        fetchPolicy: 'swr',
+        gcOnUnsubscribe: true,
         ...(ast.server ? { server: true } : {}),
       },
     }
@@ -220,7 +221,8 @@ export class CursorWindowPager implements WindowPager {
       },
       config: {
         realtime: start === 0 && !ast.snapshot ? 'refetch' : 'disabled',
-        fetchPolicy: 'network-only',
+        fetchPolicy: 'swr',
+        gcOnUnsubscribe: true,
         server: true,
       },
     }

--- a/lib/core/windowQueryPager.ts
+++ b/lib/core/windowQueryPager.ts
@@ -1,0 +1,320 @@
+import type { PageCursor, PageInfo } from '../adapters/adapter.js'
+import type { QueryAST } from './queryBuilder.js'
+import type { RelationalRootOverride } from './relationalQuery.js'
+
+export interface PagerRange {
+  start: number
+  end: number
+}
+
+export interface PagerPage {
+  start: number
+  status: 'idle' | 'loading' | 'success' | 'error'
+  rowCount: number
+}
+
+export interface PagerPageSuccess {
+  start: number
+  rowCount: number
+  pageInfo: PageInfo | undefined
+  total: number | undefined
+  revision: unknown
+}
+
+export interface WindowPagerAccess {
+  page(start: number): PagerPage | undefined
+  pages(): Iterable<PagerPage>
+  ensure(start: number): void
+  drop(start: number): void
+  touch(start: number): void
+  total(): number | undefined
+  setTotal(total: number): void
+}
+
+export interface WindowPager {
+  targetStarts(range: PagerRange, preloadPages: number): number[]
+  requiredStarts(range: PagerRange): number[]
+  fetchingStarts(range: PagerRange, preloadPages: number): number[]
+  rangeReady(range: PagerRange): boolean
+  sync(targets: ReadonlySet<number>): void
+  protectedStarts(targets: ReadonlySet<number>): ReadonlySet<number>
+  rootOverride(start: number): RelationalRootOverride
+  pageSucceeded(page: PagerPageSuccess): void
+  reset(): void
+}
+
+interface WindowPagerContext {
+  pageSize: number
+  serviceName: string
+  ast: QueryAST
+  access: WindowPagerAccess
+}
+
+function targetStarts(
+  range: PagerRange,
+  preloadPages: number,
+  pageSize: number,
+  total: number | undefined,
+): number[] {
+  const firstVisible = Math.floor(range.start / pageSize) * pageSize
+  const lastVisible = Math.floor((Math.max(range.start + 1, range.end) - 1) / pageSize) * pageSize
+  const first = Math.max(0, firstVisible - preloadPages * pageSize)
+  const last = lastVisible + preloadPages * pageSize
+  const starts: number[] = []
+  for (let start = first; start <= last; start += pageSize) {
+    if (total !== undefined && start >= total) continue
+    starts.push(start)
+  }
+  return starts
+}
+
+export class OffsetWindowPager implements WindowPager {
+  #context: WindowPagerContext
+
+  constructor(context: WindowPagerContext) {
+    this.#context = context
+  }
+
+  targetStarts(range: PagerRange, preloadPages: number): number[] {
+    return targetStarts(range, preloadPages, this.#context.pageSize, this.#context.access.total())
+  }
+
+  requiredStarts(range: PagerRange): number[] {
+    return this.targetStarts(range, 0)
+  }
+
+  fetchingStarts(range: PagerRange, preloadPages: number): number[] {
+    return this.targetStarts(range, preloadPages)
+  }
+
+  rangeReady(range: PagerRange): boolean {
+    return this.requiredStarts(range).every(
+      start => this.#context.access.page(start)?.status === 'success',
+    )
+  }
+
+  sync(targets: ReadonlySet<number>): void {
+    for (const start of targets) this.#context.access.ensure(start)
+  }
+
+  protectedStarts(targets: ReadonlySet<number>): ReadonlySet<number> {
+    return targets
+  }
+
+  rootOverride(start: number): RelationalRootOverride {
+    const { ast, pageSize, serviceName } = this.#context
+    return {
+      descriptor: {
+        serviceName,
+        method: 'find',
+        params: {
+          query: {
+            ...ast.query,
+            $limit: pageSize,
+            $skip: start,
+          },
+        },
+      },
+      config: {
+        realtime: ast.snapshot ? 'disabled' : 'merge',
+        fetchPolicy: 'network-only',
+        ...(ast.server ? { server: true } : {}),
+      },
+    }
+  }
+
+  pageSucceeded(page: PagerPageSuccess): void {
+    if (page.total !== undefined) this.#context.access.setTotal(page.total)
+  }
+
+  reset(): void {}
+}
+
+export class CursorWindowPager implements WindowPager {
+  #context: WindowPagerContext
+  #cursorAt = new Map<number, PageCursor | undefined>([[0, undefined]])
+  #terminalIndex: number | undefined
+  #rootRevision: unknown
+
+  constructor(context: WindowPagerContext) {
+    this.#context = context
+  }
+
+  targetStarts(range: PagerRange, preloadPages: number): number[] {
+    return targetStarts(range, preloadPages, this.#context.pageSize, this.#context.access.total())
+  }
+
+  requiredStarts(range: PagerRange): number[] {
+    return this.#pagesForRange(range).map(page => page.start)
+  }
+
+  fetchingStarts(_range: PagerRange, _preloadPages: number): number[] {
+    return Array.from(this.#context.access.pages(), page => page.start)
+  }
+
+  rangeReady(range: PagerRange): boolean {
+    const knownEnd = Math.min(
+      range.end,
+      this.#terminalIndex ?? this.#context.access.total() ?? range.end,
+    )
+    let index = range.start
+    while (index < knownEnd) {
+      const page = this.#pageCovering(index)
+      if (!page || page.status !== 'success') return false
+      index = page.start + page.rowCount
+    }
+    return true
+  }
+
+  sync(targets: ReadonlySet<number>): void {
+    // Page zero is the cursor chain's total/reconnect sentinel. Other target blocks
+    // start directly once their absolute-index checkpoint has been discovered.
+    this.#context.access.ensure(0)
+    for (const target of targets) {
+      const lastIndex = Math.min(
+        target + this.#context.pageSize - 1,
+        (this.#context.access.total() ?? Infinity) - 1,
+      )
+      if (lastIndex >= target) this.#ensurePath(lastIndex)
+    }
+  }
+
+  protectedStarts(targets: ReadonlySet<number>): ReadonlySet<number> {
+    const starts = new Set<number>([0])
+    for (const target of targets) {
+      const targetEnd = target + this.#context.pageSize
+      for (const page of this.#context.access.pages()) {
+        if (
+          page.status === 'success' &&
+          page.start < targetEnd &&
+          page.start + page.rowCount > target
+        ) {
+          starts.add(page.start)
+        }
+      }
+      const covering = this.#pageCovering(target)
+      if (covering) starts.add(covering.start)
+      const lastIndex = Math.min(
+        target + this.#context.pageSize - 1,
+        (this.#context.access.total() ?? Infinity) - 1,
+      )
+      const nearest = this.#nearestCheckpoint(lastIndex)
+      if (this.#context.access.page(nearest)) starts.add(nearest)
+    }
+    return starts
+  }
+
+  rootOverride(start: number): RelationalRootOverride {
+    const cursor = this.#cursorAt.get(start)
+    const { ast, pageSize, serviceName } = this.#context
+    return {
+      descriptor: {
+        serviceName,
+        method: 'find',
+        params: { query: ast.query },
+        page: {
+          limit: pageSize,
+          ...(cursor !== undefined ? { after: cursor } : {}),
+          includeTotal: start === 0,
+        },
+      },
+      config: {
+        realtime: start === 0 && !ast.snapshot ? 'refetch' : 'disabled',
+        fetchPolicy: 'network-only',
+        server: true,
+      },
+    }
+  }
+
+  pageSucceeded(page: PagerPageSuccess): void {
+    if (!page.pageInfo) throw new Error('Native window page settled without pageInfo')
+    if (page.start === 0) {
+      if (this.#rootRevision !== undefined && this.#rootRevision !== page.revision) {
+        this.#resetDescendants()
+      }
+      this.#rootRevision = page.revision
+    }
+    if (page.total !== undefined) {
+      this.#context.access.setTotal(page.total)
+      this.#terminalIndex = page.total
+    }
+    if (!page.pageInfo.hasMore) {
+      this.#terminalIndex = page.start + page.rowCount
+      if (this.#context.access.total() === undefined) {
+        this.#context.access.setTotal(this.#terminalIndex)
+      }
+      return
+    }
+    if (page.rowCount === 0) {
+      throw new Error('Native window page reported hasMore without returning rows')
+    }
+    this.#cursorAt.set(page.start + page.rowCount, page.pageInfo.endCursor)
+  }
+
+  reset(): void {
+    this.#cursorAt = new Map([[0, undefined]])
+    this.#terminalIndex = undefined
+    this.#rootRevision = undefined
+  }
+
+  #ensurePath(target: number): void {
+    if (this.#terminalIndex !== undefined && target >= this.#terminalIndex) return
+    const covering = this.#pageCovering(target)
+    if (covering) {
+      this.#context.access.touch(covering.start)
+      return
+    }
+    if (this.#cursorAt.has(target)) {
+      this.#context.access.ensure(target)
+      return
+    }
+    this.#context.access.ensure(this.#nearestCheckpoint(target))
+  }
+
+  #nearestCheckpoint(index: number): number {
+    let nearest = 0
+    for (const checkpoint of this.#cursorAt.keys()) {
+      if (checkpoint <= index && checkpoint > nearest) nearest = checkpoint
+    }
+    return nearest
+  }
+
+  #pageCovering(index: number): PagerPage | undefined {
+    for (const page of this.#context.access.pages()) {
+      if (page.status === 'success' && page.start <= index && index < page.start + page.rowCount) {
+        return page
+      }
+    }
+    return undefined
+  }
+
+  #pagesForRange(range: PagerRange): PagerPage[] {
+    const pages = new Set<PagerPage>()
+    const knownEnd = Math.min(
+      range.end,
+      this.#terminalIndex ?? this.#context.access.total() ?? range.end,
+    )
+    let index = range.start
+    while (index < knownEnd) {
+      const covering = this.#pageCovering(index)
+      if (covering) {
+        pages.add(covering)
+        if (covering.status !== 'success') break
+        index = covering.start + covering.rowCount
+        continue
+      }
+      const page = this.#context.access.page(this.#nearestCheckpoint(index))
+      if (page) pages.add(page)
+      break
+    }
+    return Array.from(pages)
+  }
+
+  #resetDescendants(): void {
+    for (const page of Array.from(this.#context.access.pages())) {
+      if (page.start > 0) this.#context.access.drop(page.start)
+    }
+    this.#cursorAt = new Map([[0, undefined]])
+    this.#terminalIndex = undefined
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -138,6 +138,8 @@ export { useFind, useGet } from './react/useQueryByDesc.js'
 // useQuery is the unified, Suspense-by-default builder hook; pass { suspense: false }
 // for the explicit tagged-union variant.
 export { useQuery } from './react/useQuery.js'
+// useWindowQuery keeps a bounded set of relational pages around a visible index range.
+export { useWindowQuery } from './react/useWindowQuery.js'
 // useQueries suspends on several independent queries at once — one boundary, all
 // fetches in parallel, no sequential waterfall.
 export { useQueries } from './react/useQueries.js'
@@ -151,6 +153,14 @@ export type {
   UseQueryHook,
   UseQueryOptions,
 } from './react/useQuery.js'
+export type {
+  SuspenseWindowQueryResult,
+  UseWindowQueryHook,
+  UseWindowQueryOptions,
+  WindowQueryResult,
+  WindowRange,
+} from './react/useWindowQuery.js'
+export type { WindowQueryConfig, WindowQueryState } from './core/windowQuery.js'
 export type { UseQueriesHook, UseQueriesOptions } from './react/useQueries.js'
 
 // Query-related types for advanced usage

--- a/lib/react/createHooks.ts
+++ b/lib/react/createHooks.ts
@@ -37,6 +37,7 @@ import type { MutationQueueDefinition } from '../core/mutationQueue.js'
 import { useFind, useGet, type QueryResult } from './useQueryByDesc.js'
 import { useQueries, type UseQueriesHook } from './useQueries.js'
 import { useQuery, type UseQueryHook } from './useQuery.js'
+import { useWindowQuery, type UseWindowQueryHook } from './useWindowQuery.js'
 
 /**
  * Strongly-typed call signatures per service name.
@@ -105,6 +106,8 @@ export interface FigbirdHooks<S extends Schema, A extends Adapter = Adapter> {
   /** Return the Figbird instance supplied by the nearest provider. */
   useFigbird: () => Figbird<S, A>
   useQuery: UseQueryHook<S>
+  /** Query a bounded, viewport-indexed relational list. */
+  useWindowQuery: UseWindowQueryHook<S>
   useQueries: UseQueriesHook<S>
   q: QueryBuilderProxy<S>
   defineQuery: DefineQueryForSchema<S>
@@ -202,6 +205,7 @@ export function createHooks<S extends Schema, A extends Adapter = Adapter>(
     useFeathers: useTypedFeathers as UseFeathersForSchema<S>,
     useFigbird: useBoundFigbird,
     useQuery: useQuery as UseQueryHook<S>,
+    useWindowQuery: useWindowQuery as UseWindowQueryHook<S>,
     useQueries: useQueries as UseQueriesHook<S>,
     q,
     defineQuery: baseDefineQuery as DefineQueryForSchema<S>,

--- a/lib/react/useWindowQuery.ts
+++ b/lib/react/useWindowQuery.ts
@@ -72,6 +72,51 @@ interface WindowQueryRefLike<T> {
   releaseColdStart(range: WindowRange): void
 }
 
+/**
+ * Reader-local projection of a shared window ref. A later viewport keeps the
+ * reader's committed sparse map mounted, but a second hook using the same ref
+ * still gets its own cold-start Suspense and error lifecycle.
+ */
+class WindowQueryReader<T> {
+  #ref: WindowQueryRefLike<T>
+  #settled = false
+  #lastSource: WindowQueryState<T> | null = null
+  #lastProjection: WindowQueryState<T> | null = null
+
+  constructor(ref: WindowQueryRefLike<T>) {
+    this.#ref = ref
+  }
+
+  getSnapshot(range: WindowRange): WindowQueryState<T> {
+    const source = this.#ref.getSnapshot(range)
+    if (source === this.#lastSource) return this.#lastProjection!
+
+    let projection = source
+    if (source.status === 'success') {
+      this.#settled = true
+    } else if (this.#settled) {
+      projection = {
+        status: 'success',
+        data: source.data,
+        total: source.total,
+        error: source.status === 'error' ? source.error : null,
+        isFetching: source.status === 'loading',
+      }
+    }
+    this.#lastSource = source
+    this.#lastProjection = projection
+    return projection
+  }
+
+  suspensePromise(range: WindowRange): Promise<void> {
+    return this.#ref.suspensePromise(range)
+  }
+
+  releaseColdStart(range: WindowRange): void {
+    this.#ref.releaseColdStart(range)
+  }
+}
+
 interface FigbirdWindowLike {
   window<Args, B extends AnyWindowQueryBuilder>(
     query: QueryInput<B, Args>,
@@ -138,6 +183,7 @@ export function useWindowQueryImpl(
   const { range, suspense = true, staleTime, skip = false } = options
   const config = normalizeConfig(options)
   const qRef = skip || query === null ? null : figbird.window(query, config)
+  const reader = useMemo(() => (qRef ? new WindowQueryReader(qRef) : null), [qRef])
   const stableRange = useMemo(
     () => ({ start: range.start, end: range.end }),
     [range.start, range.end],
@@ -154,8 +200,8 @@ export function useWindowQueryImpl(
     [qRef, stableRange, staleTime],
   )
   const getSnapshot = useCallback(
-    () => (qRef ? qRef.getSnapshot(stableRange) : idleState),
-    [qRef, stableRange],
+    () => (reader ? reader.getSnapshot(stableRange) : idleState),
+    [reader, stableRange],
   )
   const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
   const refetch = useCallback(() => qRef?.refetch(), [qRef])
@@ -176,10 +222,10 @@ export function useWindowQueryImpl(
     }
   }
   if (state.status === 'error') {
-    qRef.releaseColdStart(stableRange)
+    reader!.releaseColdStart(stableRange)
     throw state.error
   }
-  if (state.status !== 'success') throw qRef.suspensePromise(stableRange)
+  if (state.status !== 'success') throw reader!.suspensePromise(stableRange)
 
   return {
     data: state.data,

--- a/lib/react/useWindowQuery.ts
+++ b/lib/react/useWindowQuery.ts
@@ -1,0 +1,191 @@
+import { useCallback, useMemo, useSyncExternalStore } from 'react'
+import type { AnyWindowQueryBuilder, QueryBuilderItem } from '../core/queryBuilder.js'
+import type { QueryInput, QueryRequest } from '../core/queryDefinition.js'
+import type { Schema } from '../core/schema.js'
+import type { WindowQueryConfig, WindowQueryState, WindowRange } from '../core/windowQuery.js'
+import { useFigbird } from './context.js'
+import type { UseQueryOptions } from './useQuery.js'
+
+export type { WindowRange }
+
+export interface UseWindowQueryOptions extends UseQueryOptions {
+  /** Visible row indexes; `start` is inclusive and `end` is exclusive. */
+  range: WindowRange
+  /** Number of server rows in one retained block. */
+  pageSize: number
+  /** Adjacent blocks fetched ahead of the visible range. Defaults to 1. */
+  preloadPages?: number
+  /** Maximum retained blocks, excluding blocks required by active readers. Defaults to 5. */
+  maxPages?: number
+}
+
+export type WindowQueryResult<T> =
+  | {
+      status: 'idle' | 'loading'
+      data: ReadonlyMap<number, T>
+      total: number | undefined
+      error: null
+      isFetching: boolean
+      refetch: () => void
+    }
+  | {
+      status: 'success'
+      data: ReadonlyMap<number, T>
+      total: number | undefined
+      error: Error | null
+      isFetching: boolean
+      refetch: () => void
+    }
+  | {
+      status: 'error'
+      data: ReadonlyMap<number, T>
+      total: number | undefined
+      error: Error
+      isFetching: false
+      refetch: () => void
+    }
+
+type WindowData<T> = ReadonlyMap<number, T>
+
+type SkipAwareWindowData<T, O extends UseWindowQueryOptions> = [O] extends [{ skip: false }]
+  ? WindowData<T>
+  : O extends { skip: boolean }
+    ? WindowData<T> | undefined
+    : WindowData<T>
+
+export interface SuspenseWindowQueryResult<T, TData = WindowData<T>> {
+  data: TData
+  total: number | undefined
+  error: Error | null
+  isFetching: boolean
+  refetch: () => void
+}
+
+interface WindowQueryRefLike<T> {
+  subscribe(
+    listener: (state: WindowQueryState<T>) => void,
+    options: { range: WindowRange; staleTime?: number },
+  ): () => void
+  getSnapshot(range: WindowRange): WindowQueryState<T>
+  refetch(): void
+  suspensePromise(range: WindowRange): Promise<void>
+  releaseColdStart(range: WindowRange): void
+}
+
+interface FigbirdWindowLike {
+  window<Args, B extends AnyWindowQueryBuilder>(
+    query: QueryInput<B, Args>,
+    config: WindowQueryConfig,
+  ): WindowQueryRefLike<QueryBuilderItem<B>>
+}
+
+// oxlint-disable-next-line @typescript-eslint/no-explicit-any
+export interface UseWindowQueryHook<S extends Schema = any> {
+  <Args, B extends AnyWindowQueryBuilder<S>>(
+    query: QueryInput<B, Args>,
+    options: UseWindowQueryOptions & { suspense: false },
+  ): WindowQueryResult<QueryBuilderItem<B>>
+  <Args, B extends AnyWindowQueryBuilder<S>, O extends UseWindowQueryOptions>(
+    query: QueryInput<B, Args>,
+    options: O,
+  ): SuspenseWindowQueryResult<QueryBuilderItem<B>, SkipAwareWindowData<QueryBuilderItem<B>, O>>
+  <Args, B extends AnyWindowQueryBuilder<S>>(
+    request: QueryRequest<Args, B> | null,
+    options: UseWindowQueryOptions & { suspense: false },
+  ): WindowQueryResult<QueryBuilderItem<B>>
+  <Args, B extends AnyWindowQueryBuilder<S>>(
+    request: QueryRequest<Args, B> | null,
+    options: UseWindowQueryOptions,
+  ): SuspenseWindowQueryResult<QueryBuilderItem<B>, WindowData<QueryBuilderItem<B>> | undefined>
+}
+
+const EMPTY_DATA: ReadonlyMap<number, never> = new Map<number, never>()
+const idleState = {
+  status: 'idle' as const,
+  data: EMPTY_DATA,
+  total: undefined,
+  error: null,
+  isFetching: false,
+}
+
+function normalizeConfig(options: UseWindowQueryOptions): WindowQueryConfig {
+  const { pageSize, preloadPages = 1, maxPages = 5 } = options
+  if (!Number.isInteger(pageSize) || pageSize <= 0) {
+    throw new Error(`useWindowQuery(): pageSize must be a positive integer, got ${pageSize}`)
+  }
+  if (!Number.isInteger(preloadPages) || preloadPages < 0) {
+    throw new Error(
+      `useWindowQuery(): preloadPages must be a non-negative integer, got ${preloadPages}`,
+    )
+  }
+  if (!Number.isInteger(maxPages) || maxPages <= 0) {
+    throw new Error(`useWindowQuery(): maxPages must be a positive integer, got ${maxPages}`)
+  }
+  return { pageSize, preloadPages, maxPages }
+}
+
+export const useWindowQuery: UseWindowQueryHook = ((
+  query: QueryInput<AnyWindowQueryBuilder> | null,
+  options: UseWindowQueryOptions,
+): unknown =>
+  useWindowQueryImpl(useFigbird() as FigbirdWindowLike, query, options)) as UseWindowQueryHook
+
+export function useWindowQueryImpl(
+  figbird: FigbirdWindowLike,
+  query: QueryInput<AnyWindowQueryBuilder> | null,
+  options: UseWindowQueryOptions,
+): unknown {
+  const { range, suspense = true, staleTime, skip = false } = options
+  const config = normalizeConfig(options)
+  const qRef = skip || query === null ? null : figbird.window(query, config)
+  const stableRange = useMemo(
+    () => ({ start: range.start, end: range.end }),
+    [range.start, range.end],
+  )
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!qRef) return () => {}
+      return qRef.subscribe(onStoreChange, {
+        range: stableRange,
+        ...(staleTime !== undefined ? { staleTime } : {}),
+      })
+    },
+    [qRef, stableRange, staleTime],
+  )
+  const getSnapshot = useCallback(
+    () => (qRef ? qRef.getSnapshot(stableRange) : idleState),
+    [qRef, stableRange],
+  )
+  const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  const refetch = useCallback(() => qRef?.refetch(), [qRef])
+
+  const taggedResult = useMemo(
+    () => ({ ...state, refetch }) as WindowQueryResult<unknown>,
+    [state, refetch],
+  )
+  if (!suspense) return taggedResult
+
+  if (!qRef) {
+    return {
+      data: undefined,
+      total: undefined,
+      error: null,
+      isFetching: false,
+      refetch,
+    }
+  }
+  if (state.status === 'error') {
+    qRef.releaseColdStart(stableRange)
+    throw state.error
+  }
+  if (state.status !== 'success') throw qRef.suspensePromise(stableRange)
+
+  return {
+    data: state.data,
+    total: state.total,
+    error: state.error,
+    isFetching: state.isFetching,
+    refetch,
+  }
+}

--- a/test/window-query.test.tsx
+++ b/test/window-query.test.tsx
@@ -152,8 +152,8 @@ test('window query: retention never evicts pages required by active readers', as
   deep.unsubscribe()
 })
 
-test('window query: a settled cold read expires when no React reader commits', async t => {
-  const { figbird } = createTestApp(schema, {
+test('window query: settled cold reads survive delayed retries and remain bounded', async t => {
+  const { figbird, feathers } = createTestApp(schema, {
     items: { data: keyed(makeRows(20)) },
     owners: { data: {} },
   })
@@ -163,6 +163,21 @@ test('window query: a settled cold read expires when no React reader commits', a
 
   await abandoned.suspensePromise({ start: 0, end: 5 })
   await new Promise(resolve => setTimeout(resolve, 10))
+  const retry = figbird.window(query, config)
+
+  t.is(retry, abandoned)
+  t.is(retry.getSnapshot({ start: 0, end: 5 }).status, 'success')
+  t.is(feathers.service('items').counts.find, 1)
+
+  const pressure = Array.from({ length: 20 }, (_, index) => {
+    const ref = figbird.window(query, {
+      pageSize: 100 + index,
+      preloadPages: 0,
+      maxPages: 2,
+    })
+    return ref.suspensePromise({ start: 0, end: 1 })
+  })
+  await Promise.all(pressure)
 
   t.not(figbird.window(query, config), abandoned)
 })

--- a/test/window-query.test.tsx
+++ b/test/window-query.test.tsx
@@ -152,6 +152,32 @@ test('window query: retention never evicts pages required by active readers', as
   deep.unsubscribe()
 })
 
+test('window query: concurrent cold reads stay warm beyond the page retention budget', async t => {
+  const { figbird, feathers } = createTestApp(schema, {
+    items: { data: keyed(makeRows(80)) },
+    owners: { data: {} },
+  })
+  const ref = figbird.window(figbird.q.items.orderBy('rank', 'asc'), {
+    pageSize: 10,
+    preloadPages: 0,
+    maxPages: 1,
+  })
+  const top = { start: 0, end: 5 }
+  const deep = { start: 50, end: 55 }
+
+  await Promise.all([ref.suspensePromise(top), ref.suspensePromise(deep)])
+  await new Promise<void>(resolve => queueMicrotask(resolve))
+
+  t.is(ref.getSnapshot(top).status, 'success')
+  t.is(ref.getSnapshot(deep).status, 'success')
+  t.is(feathers.service('items').counts.find, 2)
+
+  await ref.suspensePromise(top)
+  t.is(feathers.service('items').counts.find, 2)
+  ref.releaseColdStart(top)
+  ref.releaseColdStart(deep)
+})
+
 test('window query: settled cold reads survive delayed retries and remain bounded', async t => {
   const { figbird, feathers } = createTestApp(schema, {
     items: { data: keyed(makeRows(20)) },
@@ -182,9 +208,9 @@ test('window query: settled cold reads survive delayed retries and remain bounde
   t.not(figbird.window(query, config), abandoned)
 })
 
-test('window query: abandoned ranges cannot bypass page retention on an active ref', async t => {
+test('window query: abandoned ranges have a separate bounded retry cache', async t => {
   const { figbird } = createTestApp(schema, {
-    items: { data: keyed(makeRows(100)) },
+    items: { data: keyed(makeRows(240)) },
     owners: { data: {} },
   })
   const ref = figbird.window(figbird.q.items.orderBy('rank', 'asc'), {
@@ -195,19 +221,20 @@ test('window query: abandoned ranges cannot bypass page retention on an active r
   const visible = readSettledWindow(ref, { start: 0, end: 5 })
   await visible.promise
 
-  await ref.suspensePromise({ start: 20, end: 25 })
-  await ref.suspensePromise({ start: 40, end: 45 })
-  await ref.suspensePromise({ start: 60, end: 65 })
+  const abandonedRanges = Array.from({ length: 21 }, (_, index) => ({
+    start: (index + 1) * 10,
+    end: (index + 1) * 10 + 5,
+  }))
+  for (const range of abandonedRanges) await ref.suspensePromise(range)
   await new Promise<void>(resolve => queueMicrotask(resolve))
 
   const data = ref.getSnapshot({ start: 0, end: 5 }).data
-  t.is(data.size, 20)
+  t.is(data.size, 210)
   t.is(data.get(0)?.id, 1)
-  t.is(data.get(60)?.id, 61)
-  t.false(data.has(20))
-  t.false(data.has(40))
+  t.false(data.has(10))
+  t.is(data.get(210)?.id, 211)
 
-  ref.releaseColdStart({ start: 60, end: 65 })
+  for (const range of abandonedRanges) ref.releaseColdStart(range)
   visible.unsubscribe()
 })
 

--- a/test/window-query.test.tsx
+++ b/test/window-query.test.tsx
@@ -64,13 +64,13 @@ function keyed<T extends { id: number }>(rows: T[]): Record<string, T> {
 interface TestWindowRef<T> {
   subscribe(
     listener: (state: WindowQueryState<T>) => void,
-    options: { range: WindowRange },
+    options: { range: WindowRange; staleTime?: number },
   ): () => void
   getSnapshot(range: WindowRange): WindowQueryState<T>
   refetch(): void
 }
 
-function readSettledWindow<T>(ref: TestWindowRef<T>, range: WindowRange) {
+function readSettledWindow<T>(ref: TestWindowRef<T>, range: WindowRange, staleTime?: number) {
   let unsubscribe = () => {}
   const promise = new Promise<WindowQueryState<T>>(resolve => {
     const check = () => {
@@ -79,7 +79,7 @@ function readSettledWindow<T>(ref: TestWindowRef<T>, range: WindowRange) {
         resolve(state)
       }
     }
-    unsubscribe = ref.subscribe(check, { range })
+    unsubscribe = ref.subscribe(check, { range, ...(staleTime !== undefined ? { staleTime } : {}) })
     check()
   })
   return { promise, unsubscribe: () => unsubscribe() }
@@ -150,6 +150,70 @@ test('window query: retention never evicts pages required by active readers', as
   t.is(data.size, 20)
   top.unsubscribe()
   deep.unsubscribe()
+})
+
+test('window query: a settled cold read expires when no React reader commits', async t => {
+  const { figbird } = createTestApp(schema, {
+    items: { data: keyed(makeRows(20)) },
+    owners: { data: {} },
+  })
+  const query = figbird.q.items.orderBy('rank', 'asc')
+  const config = { pageSize: 10, preloadPages: 0, maxPages: 2 }
+  const abandoned = figbird.window(query, config)
+
+  await abandoned.suspensePromise({ start: 0, end: 5 })
+  await new Promise(resolve => setTimeout(resolve, 10))
+
+  t.not(figbird.window(query, config), abandoned)
+})
+
+test('window query: retained pages follow the strictest active reader', async t => {
+  const { figbird, feathers } = createTestApp(schema, {
+    items: { data: keyed(makeRows(20)) },
+    owners: { data: {} },
+  })
+  const range = { start: 0, end: 5 }
+  const ref = figbird.window(figbird.q.items.orderBy('rank', 'asc'), {
+    pageSize: 10,
+    preloadPages: 0,
+    maxPages: 2,
+  })
+  const lenient = readSettledWindow(ref, range, Infinity)
+  await lenient.promise
+  const service = feathers.service('items')
+  const initialFetches = service.counts.find
+
+  const addStrictReader = (expectedFetches: number) => {
+    let unsubscribe = () => {}
+    const settled = new Promise<void>(resolve => {
+      const check = () => {
+        const state = ref.getSnapshot(range)
+        if (
+          service.counts.find >= expectedFetches &&
+          state.status === 'success' &&
+          !state.isFetching
+        ) {
+          resolve()
+        }
+      }
+      unsubscribe = ref.subscribe(check, { range, staleTime: 0 })
+      check()
+    })
+    return { settled, unsubscribe: () => unsubscribe() }
+  }
+
+  const firstStrict = addStrictReader(initialFetches + 1)
+  await firstStrict.settled
+  t.is(service.counts.find, initialFetches + 1)
+  firstStrict.unsubscribe()
+  await new Promise<void>(resolve => queueMicrotask(resolve))
+
+  const secondStrict = addStrictReader(initialFetches + 2)
+  await secondStrict.settled
+  t.is(service.counts.find, initialFetches + 2)
+
+  secondStrict.unsubscribe()
+  lenient.unsubscribe()
 })
 
 test('useWindowQuery: each hook gets an independent first-window Suspense lifecycle', async t => {

--- a/test/window-query.test.tsx
+++ b/test/window-query.test.tsx
@@ -182,6 +182,35 @@ test('window query: settled cold reads survive delayed retries and remain bounde
   t.not(figbird.window(query, config), abandoned)
 })
 
+test('window query: abandoned ranges cannot bypass page retention on an active ref', async t => {
+  const { figbird } = createTestApp(schema, {
+    items: { data: keyed(makeRows(100)) },
+    owners: { data: {} },
+  })
+  const ref = figbird.window(figbird.q.items.orderBy('rank', 'asc'), {
+    pageSize: 10,
+    preloadPages: 0,
+    maxPages: 1,
+  })
+  const visible = readSettledWindow(ref, { start: 0, end: 5 })
+  await visible.promise
+
+  await ref.suspensePromise({ start: 20, end: 25 })
+  await ref.suspensePromise({ start: 40, end: 45 })
+  await ref.suspensePromise({ start: 60, end: 65 })
+  await new Promise<void>(resolve => queueMicrotask(resolve))
+
+  const data = ref.getSnapshot({ start: 0, end: 5 }).data
+  t.is(data.size, 20)
+  t.is(data.get(0)?.id, 1)
+  t.is(data.get(60)?.id, 61)
+  t.false(data.has(20))
+  t.false(data.has(40))
+
+  ref.releaseColdStart({ start: 60, end: 65 })
+  visible.unsubscribe()
+})
+
 test('window query: retained pages follow the strictest active reader', async t => {
   const { figbird, feathers } = createTestApp(schema, {
     items: { data: keyed(makeRows(20)) },

--- a/test/window-query.test.tsx
+++ b/test/window-query.test.tsx
@@ -1,0 +1,308 @@
+import test from 'ava'
+import { Suspense, useState } from 'react'
+import {
+  createSchema,
+  cursorPagination,
+  FeathersAdapter,
+  Figbird,
+  service,
+  useWindowQuery,
+  type FeathersClient,
+  type FeathersParams,
+  type FeathersService,
+  type WindowQueryState,
+  type WindowRange,
+} from '../lib/index.js'
+import { createTestApp, dom } from './helpers.js'
+
+interface Item {
+  [key: string]: unknown
+  id: number
+  ownerId: number
+  rank: number
+  title: string
+}
+
+interface ItemService {
+  item: Item
+}
+
+interface Owner {
+  id: number
+  name: string
+}
+
+interface OwnerService {
+  item: Owner
+}
+
+const schema = createSchema({
+  services: {
+    items: service<ItemService>(),
+    owners: service<OwnerService>(),
+  },
+  relationships: {
+    items: ({ one }) => ({
+      owner: one({ sourceField: 'ownerId', destService: 'owners', destField: 'id' }),
+    }),
+  },
+})
+
+function makeRows(count: number): Item[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: index + 1,
+    ownerId: (index % 2) + 1,
+    rank: index + 1,
+    title: `Item ${index + 1}`,
+  }))
+}
+
+function keyed<T extends { id: number }>(rows: T[]): Record<string, T> {
+  return Object.fromEntries(rows.map(row => [row.id, row]))
+}
+
+interface TestWindowRef<T> {
+  subscribe(
+    listener: (state: WindowQueryState<T>) => void,
+    options: { range: WindowRange },
+  ): () => void
+  getSnapshot(range: WindowRange): WindowQueryState<T>
+  refetch(): void
+}
+
+function readSettledWindow<T>(ref: TestWindowRef<T>, range: WindowRange) {
+  let unsubscribe = () => {}
+  const promise = new Promise<WindowQueryState<T>>(resolve => {
+    const check = () => {
+      const state = ref.getSnapshot(range)
+      if (state.status === 'error' || (state.status === 'success' && !state.isFetching)) {
+        resolve(state)
+      }
+    }
+    unsubscribe = ref.subscribe(check, { range })
+    check()
+  })
+  return { promise, unsubscribe: () => unsubscribe() }
+}
+
+test('window query: offset jumps directly, assembles relations, and evicts distant pages', async t => {
+  const rows = makeRows(120)
+  const { figbird } = createTestApp(schema, {
+    items: { data: keyed(rows) },
+    owners: {
+      data: {
+        1: { id: 1, name: 'Ada' },
+        2: { id: 2, name: 'Grace' },
+      },
+    },
+  })
+  const ref = figbird.window(figbird.q.items.orderBy('rank', 'asc').related('owner'), {
+    pageSize: 10,
+    preloadPages: 1,
+    maxPages: 3,
+  })
+
+  const first = readSettledWindow(ref, { start: 50, end: 55 })
+  const firstState = await first.promise
+  t.is(firstState.status, 'success')
+  if (firstState.status !== 'success') return
+  t.is(firstState.total, 120)
+  t.is(firstState.data.get(50)?.id, 51)
+  t.is(firstState.data.get(50)?.owner?.name, 'Ada')
+  t.deepEqual(
+    figbird
+      .inspect()
+      .filter(query => query.serviceName === 'items')
+      .map(query => query.query?.$skip)
+      .sort((a, b) => Number(a) - Number(b)),
+    [40, 50, 60],
+  )
+
+  first.unsubscribe()
+  const second = readSettledWindow(ref, { start: 90, end: 95 })
+  const secondState = await second.promise
+  await new Promise<void>(resolve => queueMicrotask(() => resolve()))
+  t.is(secondState.status, 'success')
+  t.true(ref.getSnapshot({ start: 90, end: 95 }).data.size <= 30)
+  t.is(ref.getSnapshot({ start: 90, end: 95 }).data.get(90)?.id, 91)
+  t.is(ref.getSnapshot({ start: 90, end: 95 }).data.get(90)?.owner?.name, 'Ada')
+  second.unsubscribe()
+})
+
+test('window query: retention never evicts pages required by active readers', async t => {
+  const { figbird } = createTestApp(schema, {
+    items: { data: keyed(makeRows(80)) },
+    owners: { data: {} },
+  })
+  const ref = figbird.window(figbird.q.items.orderBy('rank', 'asc'), {
+    pageSize: 10,
+    preloadPages: 0,
+    maxPages: 1,
+  })
+
+  const top = readSettledWindow(ref, { start: 0, end: 5 })
+  const deep = readSettledWindow(ref, { start: 50, end: 55 })
+  await Promise.all([top.promise, deep.promise])
+
+  const data = ref.getSnapshot({ start: 0, end: 5 }).data
+  t.is(data.get(0)?.id, 1)
+  t.is(data.get(50)?.id, 51)
+  t.is(data.size, 20)
+  top.unsubscribe()
+  deep.unsubscribe()
+})
+
+test('useWindowQuery: each hook gets an independent first-window Suspense lifecycle', async t => {
+  const rows = makeRows(80)
+  const { App, feathers, figbird } = createTestApp(schema, {
+    items: { data: keyed(rows) },
+    owners: { data: {} },
+  })
+  const { render, flush, act, $, unmount } = dom()
+  let showSecond = () => {}
+
+  function Reader({ className, range }: { className: string; range: WindowRange }) {
+    const { data } = useWindowQuery(figbird.q.items.orderBy('rank', 'asc'), {
+      range,
+      pageSize: 10,
+      preloadPages: 0,
+      maxPages: 3,
+    })
+    return <div className={className}>{Array.from(data.values(), row => row.id).join(',')}</div>
+  }
+
+  function Harness() {
+    const [second, setSecond] = useState(false)
+    showSecond = () => setSecond(true)
+    return (
+      <>
+        <Suspense fallback={<div className='first-loading' />}>
+          <Reader className='first' range={{ start: 0, end: 5 }} />
+        </Suspense>
+        {second ? (
+          <Suspense fallback={<div className='second-loading' />}>
+            <Reader className='second' range={{ start: 50, end: 55 }} />
+          </Suspense>
+        ) : null}
+      </>
+    )
+  }
+
+  render(
+    <App>
+      <Harness />
+    </App>,
+  )
+  await flush()
+  t.truthy($('.first'))
+
+  feathers.service('items').setDelay(40)
+  act(showSecond)
+  t.truthy($('.second-loading'))
+  t.falsy($('.second'))
+
+  await flush(() => new Promise(resolve => setTimeout(resolve, 60)))
+  t.truthy($('.second'))
+  t.falsy($('.second-loading'))
+  unmount()
+})
+
+interface CursorCall {
+  after: string | null
+  limit: number
+}
+
+function createCursorWindowApp(initialRows: Item[]) {
+  let rows = initialRows
+  const calls: CursorCall[] = []
+  const listeners = new Map<string, Set<(item: unknown) => void>>()
+  const cursorService = {
+    async find(params: FeathersParams = {}) {
+      const query = (params.query ?? {}) as Record<string, unknown>
+      const after = (query.$after as string | null) ?? null
+      const requestedLimit = query.$limit as number
+      calls.push({ after, limit: requestedLimit })
+      const start = after ? Number(after.slice('cursor:'.length)) : 0
+      // Deliberately return short, non-terminal pages to prove that absolute
+      // checkpoints follow actual row counts rather than requested page size.
+      const data = rows.slice(start, start + Math.min(2, requestedLimit))
+      const end = start + data.length
+      return {
+        data,
+        limit: requestedLimit,
+        hasPreviousPage: start > 0,
+        hasNextPage: end < rows.length,
+        startCursor: data.length > 0 ? `cursor:${start}` : null,
+        endCursor: data.length > 0 ? `cursor:${end}` : null,
+        ...(query.$total ? { total: rows.length } : {}),
+      }
+    },
+    on(event: string, listener: (item: unknown) => void) {
+      const eventListeners = listeners.get(event) ?? new Set()
+      eventListeners.add(listener)
+      listeners.set(event, eventListeners)
+    },
+    off(event: string, listener: (item: unknown) => void) {
+      listeners.get(event)?.delete(listener)
+    },
+  }
+  const feathers: FeathersClient = {
+    service: () => cursorService as unknown as FeathersService,
+  }
+  const adapter = new FeathersAdapter(feathers, {
+    pagination: { items: cursorPagination() },
+  })
+  const figbird = new Figbird({ schema, adapter, retry: false, eventBatchInterval: 0 })
+  return {
+    calls,
+    figbird,
+    replaceRows(next: Item[]) {
+      rows = next
+    },
+  }
+}
+
+test('window query: cursor strategy walks short pages and rebuilds invalid checkpoints', async t => {
+  const app = createCursorWindowApp(makeRows(8))
+  const ref = app.figbird.window(app.figbird.q.items.orderBy('rank', 'asc'), {
+    pageSize: 3,
+    preloadPages: 0,
+    maxPages: 4,
+  })
+  const range = { start: 5, end: 6 }
+  const read = readSettledWindow(ref, range)
+  const initial = await read.promise
+  t.is(initial.status, 'success')
+  if (initial.status !== 'success') return
+  t.is(initial.data.get(5)?.id, 6)
+  t.deepEqual(
+    app.calls.map(call => call.after),
+    [null, 'cursor:2', 'cursor:4'],
+  )
+
+  const cached = readSettledWindow(ref, { start: 2, end: 3 })
+  await cached.promise
+  t.is(app.calls.length, 3)
+  cached.unsubscribe()
+
+  const callsBeforeRefetch = app.calls.length
+  app.replaceRows([{ id: 99, ownerId: 1, rank: 0, title: 'Inserted' }, ...makeRows(8)])
+  ref.refetch()
+  await new Promise<void>(resolve => {
+    const unsubscribe = ref.subscribe(
+      state => {
+        if (state.status === 'success' && state.data.get(5)?.id === 5 && !state.isFetching) {
+          unsubscribe()
+          resolve()
+        }
+      },
+      { range },
+    )
+  })
+
+  t.true(app.calls.length > callsBeforeRefetch)
+  t.is(ref.getSnapshot(range).data.get(5)?.id, 5)
+  t.true(app.calls.slice(callsBeforeRefetch).some(call => call.after === null))
+  t.true(app.calls.slice(callsBeforeRefetch).some(call => call.after === 'cursor:4'))
+  read.unsubscribe()
+})


### PR DESCRIPTION
## What changed

- add `useWindowQuery` as a typed, Suspense-native hook for viewport-indexed relational lists
- return a sparse `ReadonlyMap<number, Item>` plus the server `total`, with per-reader end-exclusive ranges
- detect offset or cursor pagination from the adapter: offset windows jump directly, while cursor windows walk from retained index checkpoints
- preload neighboring blocks and evict distant block queries with configurable `pageSize`, `preloadPages`, and `maxPages`
- preserve Figbird query-builder composition for relations, server filters/search, sorting, definitions, nullable requests, `skip`, and `staleTime`
- refactor the Archive demo onto `useWindowQuery` + TanStack Virtual, including a real scrollbar, deep reload restoration, server search/sort, and assignee/team/label joins
- keep the Archive surface aligned with the existing demo's neutral visual system
- document virtualized-window behavior, including the different restore semantics for offset and cursor services

## Design notes

The visible range is subscriber state rather than query identity, so readers of the same list share one interned window controller. Root block queries are ephemeral and vacuum when evicted; normalized entities and relation data remain reusable by the rest of Figbird.

Cursor pages do not assume a response contains exactly `pageSize` rows. The controller tracks the actual absolute interval returned by each page, so short pages with `hasMore: true` still advance correctly.

## Validation

- `npm run test` — 349 tests pass, including typecheck, lint, formatting, and AVA
- demo TypeScript check
- demo Vite production build
- browser QA: initial load, deep offset jump, reload restoration without rebuilding the offset prefix, upward/downward loading, bounded mounted rows, server search, server sorting, and clean current runtime
- manual native-cursor smoke check, including short non-terminal pages

Built from the latest `origin/master` before publication.
