### PR TITLE
Improve DevTools inspection and connection diagnostics

### DIFF
--- a/DEVTOOLS_SPEC.md
+++ b/DEVTOOLS_SPEC.md
@@ -22,6 +22,20 @@ The bridge serializes values before they cross the browser DevTools evaluation b
 Errors retain their name and message, bigint values become strings, and circular values
 are marked instead of breaking the panel.
 
+## Connection diagnostics
+
+Adapters may expose transport lifecycle events through Figbird's adapter-neutral
+connection observer. The Feathers adapter maps Socket.IO `connect`, `disconnect`,
+connection failure, and Manager reconnection state into this observer. A successful
+reconnection remains the single trigger for Figbird's active-query sweep.
+
+The panel retains these lifecycle events in the bounded event log and renders a
+**Connection** timeline lane. Red spans show detected offline intervals; the reconnect
+marker carries the final attempt count and transport so the refetch activity immediately
+after it can be correlated visually. Individual retry attempts are deliberately
+coalesced instead of filling the event buffer. Authentication payloads and tokens are
+never collected.
+
 ## Extension architecture
 
 ```

--- a/extensions/src/panel.tsx
+++ b/extensions/src/panel.tsx
@@ -27,6 +27,8 @@ function Panel() {
     }
   }, [session])
 
+  useEffect(() => session.subscribeReset(() => collector.reset()), [collector, session])
+
   return (
     <FigbirdDevtoolsPanel collector={collector} inspection={session.inspection} status={status} />
   )

--- a/extensions/src/protocol.ts
+++ b/extensions/src/protocol.ts
@@ -59,7 +59,14 @@ export function decodeEvent(event: DevtoolsWireEvent): FigbirdEvent {
   switch (event.kind) {
     case 'fetch:error':
     case 'mutate:error':
-    case 'action:error': {
+    case 'action:error':
+    case 'connection:error': {
+      const error = new Error(event.error.message)
+      error.name = event.error.name
+      return { ...event, error }
+    }
+    case 'connection:reconnect-failed': {
+      if (!event.error) return event
       const error = new Error(event.error.message)
       error.name = event.error.name
       return { ...event, error }

--- a/extensions/src/remote.ts
+++ b/extensions/src/remote.ts
@@ -90,6 +90,15 @@ class RemoteFigbird implements FigbirdLikeForDevtools {
     this.#renderFrame = null
   }
 
+  reset(): void {
+    this.cancelPending()
+    this.#queries = []
+    this.#relational = []
+    this.#mutations = []
+    for (const listener of this.#stateListeners) listener(undefined)
+    for (const listener of this.#mutatingListeners) listener()
+  }
+
   #flush(): void {
     const read = this.#pending
     this.#pending = null
@@ -122,6 +131,7 @@ export class ExtensionSession {
   #statusListeners = new Set<() => void>()
   #timer: ReturnType<typeof setInterval> | null = null
   #version: number | null = null
+  #resetListeners = new Set<() => void>()
 
   constructor(evaluate: Evaluate = evaluateInspectedWindow) {
     this.#evaluate = evaluate
@@ -133,6 +143,11 @@ export class ExtensionSession {
   subscribeStatus = (listener: () => void): (() => void) => {
     this.#statusListeners.add(listener)
     return () => this.#statusListeners.delete(listener)
+  }
+
+  subscribeReset = (listener: () => void): (() => void) => {
+    this.#resetListeners.add(listener)
+    return () => this.#resetListeners.delete(listener)
   }
 
   start(): void {
@@ -182,8 +197,7 @@ export class ExtensionSession {
       )
       if (generation !== this.#generation) return
       if (!poll) {
-        this.#connection = null
-        this.#version = null
+        this.#resetConnection()
         this.inspection.reset()
         this.#setStatus('Reconnecting')
         return
@@ -193,13 +207,21 @@ export class ExtensionSession {
       await this.inspection.refresh()
     } catch {
       if (generation !== this.#generation) return
-      this.#connection = null
-      this.#version = null
+      this.#resetConnection()
       this.inspection.reset()
       this.#setStatus('Cannot inspect this page')
     } finally {
       this.#polling = false
     }
+  }
+
+  #resetConnection(): void {
+    const hadConnection = this.#connection !== null || this.#version !== null
+    this.#connection = null
+    this.#version = null
+    if (!hadConnection) return
+    this.figbird.reset()
+    for (const listener of this.#resetListeners) listener()
   }
 
   async #disconnect(sessionId: string): Promise<void> {

--- a/lib/adapters/adapter.ts
+++ b/lib/adapters/adapter.ts
@@ -61,6 +61,23 @@ export interface EventHandlers {
   removed: (item: unknown) => void
 }
 
+/** Transport lifecycle facts an adapter can expose for observability. */
+export type AdapterConnectionEvent =
+  | { type: 'connected'; transport?: string; connectionId?: string }
+  | {
+      type: 'disconnected'
+      reason?: string
+      reconnecting: boolean
+    }
+  | {
+      type: 'reconnected'
+      attempt?: number
+      transport?: string
+      connectionId?: string
+    }
+  | { type: 'error'; phase: 'connect' | 'reconnect'; error: Error }
+  | { type: 'reconnect-failed'; error?: Error }
+
 /** Service context supplied when the adapter evaluates a query locally. */
 export interface MatcherContext {
   serviceName: string
@@ -101,6 +118,9 @@ export interface Adapter<
   // Optional reconnect support. Adapters should call the handler when the transport
   // reconnects after a period where realtime events may have been missed.
   subscribeToReconnect?(handler: () => void): () => void
+
+  /** Optional detailed transport lifecycle for devtools and diagnostics. */
+  subscribeToConnectionEvents?(handler: (event: AdapterConnectionEvent) => void): () => void
 
   /**
    * Read an item's id, or `undefined` when absent. Pure extraction — whether a

--- a/lib/adapters/feathers.ts
+++ b/lib/adapters/feathers.ts
@@ -1,5 +1,6 @@
 import type {
   Adapter,
+  AdapterConnectionEvent,
   EventHandlers,
   MatcherContext,
   PageCursor,
@@ -226,6 +227,23 @@ interface ReconnectEventSource {
   on(event: string, listener: () => void): void
   off?: (event: string, listener: () => void) => void
   removeListener?: (event: string, listener: () => void) => void
+}
+
+type ConnectionEventListener = (...args: unknown[]) => void
+
+interface ConnectionEventSource {
+  on(event: string, listener: ConnectionEventListener): void
+  off?: (event: string, listener: ConnectionEventListener) => void
+  removeListener?: (event: string, listener: ConnectionEventListener) => void
+}
+
+interface SocketIoConnectionSource extends ConnectionEventSource {
+  active?: boolean
+  connected?: boolean
+  id?: string
+  io?: ConnectionEventSource & {
+    engine?: { transport?: { name?: string } }
+  }
 }
 
 /**
@@ -633,6 +651,124 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
     }
   }
 
+  subscribeToConnectionEvents(handler: (event: AdapterConnectionEvent) => void): () => void {
+    const socket = this.#getSocketIoConnectionSource()
+    if (!socket) {
+      const source = this.#getReconnectEventSource()
+      if (!source) return () => {}
+      const onReconnect = () => handler({ type: 'reconnected' })
+      source.on('reconnect', onReconnect)
+      return () => {
+        if (source.off) source.off('reconnect', onReconnect)
+        else source.removeListener?.('reconnect', onReconnect)
+      }
+    }
+
+    const manager = socket.io
+    let disconnected = false
+    let reconnectAttempt: number | undefined
+    let lastReconnectError: Error | undefined
+    const listeners: Array<{
+      source: ConnectionEventSource
+      event: string
+      listener: ConnectionEventListener
+    }> = []
+    const listen = (
+      source: ConnectionEventSource | undefined,
+      event: string,
+      listener: ConnectionEventListener,
+    ) => {
+      if (!source) return
+      source.on(event, listener)
+      listeners.push({ source, event, listener })
+    }
+    const connectionDetails = () => ({
+      ...(manager?.engine?.transport?.name ? { transport: manager.engine.transport.name } : {}),
+      ...(socket.id ? { connectionId: socket.id } : {}),
+    })
+
+    listen(socket, 'connect', () => {
+      if (disconnected || reconnectAttempt !== undefined) {
+        handler({
+          type: 'reconnected',
+          ...(reconnectAttempt === undefined ? {} : { attempt: reconnectAttempt }),
+          ...connectionDetails(),
+        })
+      } else {
+        handler({ type: 'connected', ...connectionDetails() })
+      }
+      disconnected = false
+      reconnectAttempt = undefined
+      lastReconnectError = undefined
+    })
+    listen(socket, 'disconnect', (reason: unknown) => {
+      disconnected = true
+      handler({
+        type: 'disconnected',
+        ...(typeof reason === 'string' ? { reason } : {}),
+        reconnecting: socket.active === true,
+      })
+    })
+    listen(socket, 'connect_error', (error: unknown) => {
+      const captured = connectionError(error)
+      if (disconnected || reconnectAttempt !== undefined || socket.active === true) {
+        lastReconnectError = captured
+      } else {
+        handler({ type: 'error', phase: 'connect', error: captured })
+      }
+    })
+    listen(manager, 'reconnect_attempt', (attempt: unknown) => {
+      if (typeof attempt !== 'number') return
+      reconnectAttempt = attempt
+    })
+    listen(manager, 'reconnect_error', (error: unknown) => {
+      lastReconnectError = connectionError(error)
+    })
+    listen(manager, 'reconnect_failed', () =>
+      handler({
+        type: 'reconnect-failed',
+        ...(lastReconnectError ? { error: lastReconnectError } : {}),
+      }),
+    )
+    if (!manager) {
+      listen(socket, 'reconnect', (attempt: unknown) => {
+        handler({
+          type: 'reconnected',
+          ...(typeof attempt === 'number' ? { attempt } : {}),
+          ...connectionDetails(),
+        })
+        disconnected = false
+        reconnectAttempt = undefined
+        lastReconnectError = undefined
+      })
+    }
+
+    return () => {
+      for (const { source, event, listener } of listeners) {
+        if (source.off) source.off(event, listener)
+        else source.removeListener?.(event, listener)
+      }
+    }
+  }
+
+  #getSocketIoConnectionSource(): SocketIoConnectionSource | null {
+    const candidates = [
+      (this.feathers as { io?: unknown }).io,
+      (this.feathers as { socket?: unknown }).socket,
+    ]
+    for (const candidate of candidates) {
+      if (
+        candidate &&
+        typeof candidate === 'object' &&
+        'on' in candidate &&
+        typeof candidate.on === 'function'
+      ) {
+        return candidate as SocketIoConnectionSource
+      }
+    }
+    return null
+  }
+
   #getReconnectEventSource(): ReconnectEventSource | null {
     const io = (this.feathers as { io?: { io?: unknown } }).io
     const candidates = [
@@ -750,4 +886,12 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
   findMeta(window: { total: number; limit: number; skip: number }): FeathersFindMeta {
     return window
   }
+}
+
+function connectionError(value: unknown): Error {
+  if (value instanceof Error) return value
+  if (typeof value === 'object' && value !== null && 'message' in value) {
+    return new Error(String(value.message))
+  }
+  return new Error(String(value))
 }

--- a/lib/core/devtoolsBridge.ts
+++ b/lib/core/devtoolsBridge.ts
@@ -21,9 +21,12 @@ export interface DevtoolsWireError {
   name: string
 }
 
-type ToWireEvent<E> = E extends { error: Error }
-  ? Omit<E, 'error'> & { error: DevtoolsWireError }
-  : E
+type ToWireEvent<E> = E extends unknown
+  ? 'error' extends keyof E
+    ? Omit<E, 'error'> &
+        (E extends { error: Error } ? { error: DevtoolsWireError } : { error?: DevtoolsWireError })
+    : E
+  : never
 
 export type DevtoolsWireEvent = ToWireEvent<FigbirdEvent>
 
@@ -222,10 +225,15 @@ function toWireEvent(event: FigbirdEvent): DevtoolsWireEvent {
     case 'fetch:error':
     case 'mutate:error':
     case 'action:error':
+    case 'connection:error':
       return {
         ...event,
         error: { message: event.error.message, name: event.error.name },
       }
+    case 'connection:reconnect-failed':
+      return event.error
+        ? { ...event, error: { message: event.error.message, name: event.error.name } }
+        : event
     default:
       return event
   }

--- a/lib/core/events.ts
+++ b/lib/core/events.ts
@@ -17,9 +17,10 @@ export type MutationEventMethod = MutationMethod | (string & {})
  * Observability events emitted by a Figbird instance — the same signal a dev tool
  * panel or trace logger would want to subscribe to.
  *
- * Events are intentionally lightweight. Mutation and action starts carry their
- * original arguments so an attached devtool can inspect the write; no result or
- * cache diffs are emitted, and emit() drops everything when nothing is listening.
+ * Events are intentionally bounded by consumers. Realtime events and mutation/action
+ * starts carry their original payloads so an attached devtool can inspect what
+ * happened; no result or cache diffs are emitted, and emit() drops everything when
+ * nothing is listening.
  */
 export type FigbirdEvent =
   | {
@@ -59,7 +60,30 @@ export type FigbirdEvent =
       serviceName: string
       type: EventType
       itemId: string | number | undefined
+      item?: unknown
     }
+  | {
+      kind: 'connection:connected'
+      transport?: string
+      connectionId?: string
+    }
+  | {
+      kind: 'connection:disconnected'
+      reason?: string
+      reconnecting: boolean
+    }
+  | {
+      kind: 'connection:reconnected'
+      attempt?: number
+      transport?: string
+      connectionId?: string
+    }
+  | {
+      kind: 'connection:error'
+      phase: 'connect' | 'reconnect'
+      error: Error
+    }
+  | { kind: 'connection:reconnect-failed'; error?: Error }
   | {
       kind: 'mutate:start'
       /** Correlates the start/end/error/rollback events of one mutation. */

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -273,10 +273,10 @@ export class Figbird<
   }
 
   /**
-   * Returns the entire internal state map keyed by service name — including the
-   * cached entities themselves, which `inspect()` deliberately omits. Debug-grade:
-   * internal shapes may change between versions; prefer `inspect()` for anything
-   * built to last.
+   * Returns the entire internal state map keyed by service name — including cached
+   * entities that are not part of a current query result. Debug-grade: internal
+   * shapes may change between versions; prefer `inspect()` for anything built to
+   * last.
    */
   getState(): Map<string, ServiceState<AdapterFindMeta<A>>> {
     return this.queryStore.getState()
@@ -856,8 +856,10 @@ export class Figbird<
               }
             : {}),
           classification: query.classification,
+          skipped: query.config.skip === true,
           status: query.state.status,
           isFetching: query.state.isFetching,
+          data: query.state.data,
           itemCount: Array.isArray(query.state.data)
             ? query.state.data.length
             : query.state.data
@@ -903,8 +905,12 @@ export interface InspectedQuery {
   /** Native adapter page details. Offset pages remain visible in `query` as `$skip`/`$limit`. */
   page?: { request: PageRequest; info?: PageInfo }
   classification: QueryNodeClass | 'get'
+  /** True when this entry was materialized with `skip: true`. */
+  skipped?: boolean
   status: 'loading' | 'success' | 'error'
   isFetching: boolean
+  /** Current result for this query. Debug-only and safe to inspect, not mutate. */
+  data?: unknown
   itemCount: number
   fetchedAt: number | undefined
   subscriberCount: number

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -259,7 +259,50 @@ export class QueryStore<
     this.#reconnectJitter = this.#normalizeReconnectJitter(reconnectJitter)
     this.#visibility = visibility ?? documentVisibility()
     this.#visibility.onChange(() => this.#drainDeferredReconciles())
-    this.#adapter.subscribeToReconnect?.(() => this.#scheduleReconnectSweep())
+    if (this.#adapter.subscribeToConnectionEvents) {
+      this.#adapter.subscribeToConnectionEvents(event => {
+        switch (event.type) {
+          case 'connected':
+            this.#events.emit({
+              kind: 'connection:connected',
+              ...(event.transport ? { transport: event.transport } : {}),
+              ...(event.connectionId ? { connectionId: event.connectionId } : {}),
+            })
+            break
+          case 'disconnected':
+            this.#events.emit({
+              kind: 'connection:disconnected',
+              ...(event.reason ? { reason: event.reason } : {}),
+              reconnecting: event.reconnecting,
+            })
+            break
+          case 'reconnected':
+            this.#events.emit({
+              kind: 'connection:reconnected',
+              ...(event.attempt === undefined ? {} : { attempt: event.attempt }),
+              ...(event.transport ? { transport: event.transport } : {}),
+              ...(event.connectionId ? { connectionId: event.connectionId } : {}),
+            })
+            this.#scheduleReconnectSweep()
+            break
+          case 'error':
+            this.#events.emit({
+              kind: 'connection:error',
+              phase: event.phase,
+              error: event.error,
+            })
+            break
+          case 'reconnect-failed':
+            this.#events.emit({
+              kind: 'connection:reconnect-failed',
+              ...(event.error ? { error: event.error } : {}),
+            })
+            break
+        }
+      })
+    } else {
+      this.#adapter.subscribeToReconnect?.(() => this.#scheduleReconnectSweep())
+    }
   }
 
   // Public store API
@@ -1581,6 +1624,7 @@ export class QueryStore<
         serviceName,
         type,
         itemId: this.#getIdWarn(serviceName, item),
+        item,
       })
     }
   }

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -162,6 +162,8 @@ export interface InspectedRelationalQuery {
   service: string
   ast: QueryAST
   pagination?: InspectedPagination
+  /** Current assembled result when the relational query has settled successfully. */
+  data?: unknown
   nodes: Array<{
     path: string
     role?: 'junction'
@@ -299,12 +301,14 @@ export class RelationalQueryRef<
           break
       }
     }
+    const snapshot = this.getSnapshot()
     return {
       key: this.#queryId,
       ...(this.#name ? { name: this.#name } : {}),
       service: this.#ast.service,
       ast: this.#ast,
       ...(this.#pagedRoot ? { pagination: this.#pagedRoot.inspectPagination() } : {}),
+      ...(snapshot.status === 'success' ? { data: snapshot.data } : {}),
       nodes,
     }
   }

--- a/lib/devtools/Devtools.tsx
+++ b/lib/devtools/Devtools.tsx
@@ -17,6 +17,7 @@ import {
 } from './ui.js'
 
 type Tab = 'queries' | 'timeline' | 'events' | 'writes'
+export type QueryVisibility = 'active' | 'all' | 'skipped'
 
 export type DevtoolsInspectionSnapshot =
   | { kind: 'idle'; version: number }
@@ -61,7 +62,7 @@ export function FigbirdDevtoolsPanel({
   const themeValue = useMemo(() => ({ colors, styles }), [colors, styles])
   const [tab, setTab] = useState<Tab>('queries')
   const [queryFilter, setQueryFilter] = useState('')
-  const [queryActiveOnly, setQueryActiveOnly] = useState(true)
+  const [queryVisibility, setQueryVisibility] = useState<QueryVisibility>('active')
   const [eventFilter, setEventFilter] = useState('')
   const [timelineFollow, setTimelineFollow] = useState(true)
 
@@ -80,8 +81,10 @@ export function FigbirdDevtoolsPanel({
   )
 
   const model = useMemo(() => buildDevtoolsModel(snapshot), [snapshot])
+  const skippedQueryCount = model.operations.filter(operation => operation.summary.skipped).length
   const timelineEmpty =
     snapshot.timeline.realtime.length === 0 &&
+    snapshot.timeline.connection.length === 0 &&
     snapshot.queries.every(query => query.spans.length === 0)
   const clearTimeline = useCallback(() => {
     collector.clearTimeline()
@@ -133,22 +136,24 @@ export function FigbirdDevtoolsPanel({
                 onChange={event => setQueryFilter(event.currentTarget.value)}
                 placeholder='Filter service or query'
               />
-              <label
+              <select
+                aria-label='Query visibility'
+                title='Skipped queries are hidden from the live view'
+                value={queryVisibility}
+                onChange={event => setQueryVisibility(event.currentTarget.value as QueryVisibility)}
                 style={{
-                  color: colors.muted,
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 5,
-                  whiteSpace: 'nowrap',
+                  ...styles.input,
+                  width: 'auto',
+                  maxWidth: 'none',
+                  paddingRight: 24,
                 }}
               >
-                <input
-                  type='checkbox'
-                  checked={queryActiveOnly}
-                  onChange={event => setQueryActiveOnly(event.currentTarget.checked)}
-                />
-                active only
-              </label>
+                <option value='active'>Live queries</option>
+                <option value='all'>All queries</option>
+                <option value='skipped'>
+                  Skipped queries{skippedQueryCount > 0 ? ` (${skippedQueryCount})` : ''}
+                </option>
+              </select>
               {inspection ? (
                 <button
                   type='button'
@@ -201,6 +206,14 @@ export function FigbirdDevtoolsPanel({
               placeholder='Filter events'
             />
           ) : null}
+          {tab === 'events' ? (
+            <span
+              title='The oldest event is discarded when the bounded buffer is full'
+              style={{ color: colors.muted, whiteSpace: 'nowrap' }}
+            >
+              {snapshot.events.length} / {collector.eventLimit} retained
+            </span>
+          ) : null}
           {tab === 'timeline' ? (
             <TimelineFollowControl value={timelineFollow} onChange={setTimelineFollow} />
           ) : null}
@@ -217,7 +230,7 @@ export function FigbirdDevtoolsPanel({
             <QueriesTab
               model={model}
               filter={queryFilter}
-              activeOnly={queryActiveOnly}
+              visibility={queryVisibility}
               inspectedQueryCounts={inspected?.queryCounts ?? null}
             />
           ) : null}

--- a/lib/devtools/EventsTab.tsx
+++ b/lib/devtools/EventsTab.tsx
@@ -1,7 +1,15 @@
+import { useState, type MouseEvent as ReactMouseEvent } from 'react'
 import type { DevtoolsEvent } from './collector.js'
-import { compactJson, formatClock, formatMs } from './format.js'
+import { compactJson, formatClock, formatMs, prettyJson } from './format.js'
 import type { EventQueryScope } from './model.js'
-import { toneColor, useDevtoolsTheme } from './ui.js'
+import {
+  DetailSection,
+  DetailStat,
+  DetailsPane,
+  toneColor,
+  useDetailsPaneWidth,
+  useDevtoolsTheme,
+} from './ui.js'
 
 export function EventsTab({
   events,
@@ -13,6 +21,8 @@ export function EventsTab({
   scopes: ReadonlyMap<string, readonly EventQueryScope[]>
 }) {
   const { colors, styles } = useDevtoolsTheme()
+  const [selectedEventId, setSelectedEventId] = useState<number | null>(null)
+  const [detailsWidth, onDetailsResizeStart] = useDetailsPaneWidth()
   const rows = events
     .filter(item => {
       if (!filter) return true
@@ -21,52 +31,188 @@ export function EventsTab({
         .includes(filter.toLowerCase())
     })
     .reverse()
+  const selectedEvent = events.find(item => item.id === selectedEventId)
   return (
-    <div style={styles.scroll}>
+    <section style={{ height: '100%', display: 'flex', minWidth: 0 }}>
+      <div style={{ ...styles.scroll, flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            ...styles.eventRow,
+            position: 'sticky',
+            top: 0,
+            zIndex: 1,
+            background: colors.bg,
+            color: colors.muted,
+            fontWeight: 600,
+            borderBottom: `1px solid ${colors.border}`,
+          }}
+        >
+          <span>Time</span>
+          <span>Event</span>
+          <span>Scope</span>
+          <span>Details</span>
+        </div>
+        {rows.length === 0 ? (
+          <div style={{ padding: 16, color: colors.muted }}>No matching events recorded.</div>
+        ) : null}
+        {rows.map(item => {
+          const queryId = eventQueryId(item.event)
+          const queryScopes = queryId ? scopes.get(queryId) : undefined
+          const details = eventDetails(item)
+          return (
+            <div
+              key={item.id}
+              role='button'
+              tabIndex={0}
+              aria-pressed={item.id === selectedEventId}
+              title='Select event details'
+              onClick={() => setSelectedEventId(item.id)}
+              onKeyDown={event => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault()
+                  setSelectedEventId(item.id)
+                }
+              }}
+              style={{
+                ...styles.eventRow,
+                cursor: 'pointer',
+                outline: 'none',
+                background: item.id === selectedEventId ? colors.activeButtonBg : undefined,
+                boxShadow: item.id === selectedEventId ? `inset 3px 0 ${colors.blue}` : undefined,
+              }}
+            >
+              <span style={{ ...styles.code, color: colors.faint }}>
+                {formatClock(item.wallAt, { milliseconds: true })}
+              </span>
+              <EventKind kind={item.event.kind} />
+              <EventScopeBadge scopes={queryScopes} queryId={queryId} />
+              <span
+                style={{
+                  ...styles.code,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+                title={details}
+              >
+                {details}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+      {selectedEvent ? (
+        <EventDetails
+          item={selectedEvent}
+          width={detailsWidth}
+          onResizeStart={onDetailsResizeStart}
+          onClose={() => setSelectedEventId(null)}
+        />
+      ) : null}
+    </section>
+  )
+}
+
+function EventDetails({
+  item,
+  width,
+  onResizeStart,
+  onClose,
+}: {
+  item: DevtoolsEvent
+  width: number
+  onResizeStart: (event: ReactMouseEvent<HTMLDivElement>) => void
+  onClose: () => void
+}) {
+  const { colors, styles } = useDevtoolsTheme()
+  const queryId = eventQueryId(item.event)
+  const payload = eventPayload(item.event)
+  return (
+    <DetailsPane
+      title={item.event.kind}
+      subtitle={formatClock(item.wallAt, { milliseconds: true })}
+      width={width}
+      onResizeStart={onResizeStart}
+      onClose={onClose}
+    >
       <div
         style={{
-          ...styles.eventRow,
-          position: 'sticky',
-          top: 0,
-          zIndex: 1,
-          background: colors.bg,
-          color: colors.muted,
-          fontWeight: 600,
-          borderBottom: `1px solid ${colors.border}`,
+          display: 'grid',
+          gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+          gap: '8px 16px',
+          marginBottom: 16,
         }}
       >
-        <span>Time</span>
-        <span>Event</span>
-        <span>Scope</span>
-        <span>Details</span>
+        {'serviceName' in item.event ? (
+          <DetailStat label='Service' value={item.event.serviceName} />
+        ) : null}
+        {'type' in item.event ? <DetailStat label='Type' value={item.event.type} /> : null}
+        {'method' in item.event ? <DetailStat label='Method' value={item.event.method} /> : null}
+        {queryId ? <DetailStat label='Query ID' value={queryId} /> : null}
       </div>
-      {rows.map(item => {
-        const queryId = eventQueryId(item.event)
-        const queryScopes = queryId ? scopes.get(queryId) : undefined
-        const details = eventDetails(item)
-        return (
-          <div key={item.id} style={styles.eventRow}>
-            <span style={{ ...styles.code, color: colors.faint }}>
-              {formatClock(item.wallAt, { milliseconds: true })}
-            </span>
-            <EventKind kind={item.event.kind} />
-            <EventScopeBadge scopes={queryScopes} queryId={queryId} />
-            <span
-              style={{
-                ...styles.code,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-              title={details}
-            >
-              {details}
-            </span>
-          </div>
-        )
-      })}
-    </div>
+      <DetailSection label={item.event.kind === 'realtime' ? 'Realtime payload' : 'Event payload'}>
+        <pre
+          style={{
+            ...styles.code,
+            whiteSpace: 'pre-wrap',
+            overflowWrap: 'anywhere',
+            margin: 0,
+            padding: 10,
+            color: payload === undefined ? colors.faint : colors.text,
+            background: colors.panel2,
+            borderRadius: 4,
+          }}
+        >
+          {payload === undefined ? 'No payload' : prettyJson(payload)}
+        </pre>
+      </DetailSection>
+      <DetailSection label='Full event'>
+        <pre
+          style={{
+            ...styles.code,
+            whiteSpace: 'pre-wrap',
+            overflowWrap: 'anywhere',
+            margin: 0,
+            color: colors.muted,
+          }}
+        >
+          {prettyJson(displayEvent(item.event))}
+        </pre>
+      </DetailSection>
+    </DetailsPane>
   )
+}
+
+function eventPayload(event: DevtoolsEvent['event']): unknown {
+  switch (event.kind) {
+    case 'realtime':
+      return event.item
+    case 'fetch:start':
+      return event.params
+    case 'mutate:start':
+    case 'mutate:update':
+    case 'action:start':
+      return event.args
+    case 'fetch:error':
+    case 'mutate:error':
+    case 'action:error':
+    case 'connection:error':
+      return { name: event.error.name, message: event.error.message }
+    case 'connection:connected':
+    case 'connection:disconnected':
+    case 'connection:reconnected':
+    case 'connection:reconnect-failed':
+      return displayEvent(event)
+    default:
+      return undefined
+  }
+}
+
+function displayEvent(event: DevtoolsEvent['event']): unknown {
+  if ('error' in event && event.error) {
+    return { ...event, error: { name: event.error.name, message: event.error.message } }
+  }
+  return event
 }
 
 function EventScopeBadge({
@@ -162,6 +308,30 @@ function eventDetails(item: DevtoolsEvent): string {
         event.type,
         event.itemId === undefined ? '' : `#${event.itemId}`,
       ])
+    case 'connection:connected':
+      return joinEventParts([
+        'connected',
+        event.transport ?? '',
+        event.connectionId ? `socket ${event.connectionId}` : '',
+      ])
+    case 'connection:disconnected':
+      return joinEventParts([
+        event.reason ?? 'connection lost',
+        event.reconnecting ? 'will reconnect' : 'reconnect disabled',
+      ])
+    case 'connection:reconnected':
+      return joinEventParts([
+        event.attempt === undefined ? 'reconnected' : `reconnected after attempt ${event.attempt}`,
+        event.transport ?? '',
+        event.connectionId ? `socket ${event.connectionId}` : '',
+      ])
+    case 'connection:error':
+      return joinEventParts([event.phase, errorMessage(event.error)])
+    case 'connection:reconnect-failed':
+      return joinEventParts([
+        'reconnection attempts exhausted',
+        event.error ? errorMessage(event.error) : '',
+      ])
     case 'mutate:start':
     case 'mutate:update':
     case 'mutate:end':
@@ -218,6 +388,14 @@ function EventKind({ kind }: { kind: string }) {
 }
 
 function eventTone(kind: string): 'green' | 'amber' | 'red' | 'blue' | 'neutral' {
+  if (kind === 'connection:connected' || kind === 'connection:reconnected') return 'green'
+  if (
+    kind === 'connection:disconnected' ||
+    kind === 'connection:error' ||
+    kind === 'connection:reconnect-failed'
+  ) {
+    return 'red'
+  }
   if (kind.endsWith(':error') || kind.endsWith(':rollback')) return 'red'
   if (kind === 'realtime') return 'blue'
   if (kind.endsWith(':update')) return 'blue'

--- a/lib/devtools/QueriesTab.tsx
+++ b/lib/devtools/QueriesTab.tsx
@@ -1,4 +1,5 @@
-import { useState, type CSSProperties } from 'react'
+import { useState, type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react'
+import type { QueryVisibility } from './Devtools.js'
 import { compactJson, formatAge, formatMs } from './format.js'
 import type { DevtoolsModel, DevtoolsOperation, QuerySummary } from './model.js'
 import { QueryDetails } from './QueryDetails.js'
@@ -13,42 +14,49 @@ interface QueryRow {
 const QUERY_COLUMNS = [
   {
     label: 'query',
-    width: '18%',
+    width: 250,
+    minWidth: 150,
     description:
-      'Root query operation. The dot shows its state: green active, amber cached, blue fetching, red error, or gray retained history.',
+      'Root query operation. The dot shows its state: green active, amber cached, blue fetching, red error, or gray skipped/retained history.',
   },
   {
     label: 'shape',
-    width: '38%',
+    width: 420,
+    minWidth: 180,
     description:
       'Query method, parameters, related data, and the number of underlying relation fetches.',
   },
   {
     label: 'class',
-    width: '12%',
+    width: 160,
+    minWidth: 105,
     description:
       'How Figbird maintains the result.\nlocal-exact: membership and ordering are provable locally.\nserver-window: a limited or sorted server result; uncertain changes trigger a refetch.\nserver-authoritative: the server decides membership; cursor queries may still merge updates proven not to move page boundaries.\nget: a direct lookup by ID.',
   },
   {
     label: 'rows',
-    width: '7%',
+    width: 75,
+    minWidth: 55,
     description: 'Number of items currently in the query result.',
   },
   {
     label: 'fetches',
-    width: '11%',
+    width: 175,
+    minWidth: 100,
     description:
       'Completed fetch attempts · realtime service events observed while the query was active · event-driven refetches · failed fetches. Extra counts appear only when non-zero.',
   },
   {
     label: 'last',
-    width: '7%',
+    width: 90,
+    minWidth: 65,
     description:
       'Duration of the most recently completed fetch. "cached" or "warm" means data was available without a measured fetch in this devtools session.',
   },
   {
     label: 'age',
-    width: '7%',
+    width: 80,
+    minWidth: 60,
     description: "Time since this query's data was last fetched.",
   },
 ] as const
@@ -56,45 +64,82 @@ const QUERY_COLUMNS = [
 export function QueriesTab({
   model,
   filter,
-  activeOnly,
+  visibility,
   inspectedQueryCounts,
 }: {
   model: DevtoolsModel
   filter: string
-  activeOnly: boolean
+  visibility: QueryVisibility
   inspectedQueryCounts: ReadonlyMap<string, number> | null
 }) {
   const { colors, styles } = useDevtoolsTheme()
   const [selectedOperationKey, setSelectedOperationKey] = useState<string | null>(null)
+  const [columnWidths, setColumnWidths] = useState<number[]>(() =>
+    QUERY_COLUMNS.map(column => column.width),
+  )
   const [detailsWidth, onDetailsResizeStart] = useDetailsPaneWidth()
-  const rows: QueryRow[] = model.operations.flatMap(operation => {
-    const query = operation.summary
-    const localSubscriberCount = inspectedQueryCounts?.get(operation.key) ?? 0
-    if (inspectedQueryCounts && localSubscriberCount === 0) return []
-    if (
-      activeOnly &&
-      query.subscriberCount === 0 &&
-      operation.underlying.every(item => item.query.subscriberCount === 0)
-    ) {
-      return []
+  const rows: QueryRow[] = model.operations
+    .flatMap(operation => {
+      const query = operation.summary
+      const localSubscriberCount = inspectedQueryCounts?.get(operation.key) ?? 0
+      if (inspectedQueryCounts && localSubscriberCount === 0) return []
+      if (visibility === 'skipped' && query.skipped !== true) return []
+      if (visibility === 'active' && query.skipped === true) return []
+      if (
+        visibility === 'active' &&
+        query.subscriberCount === 0 &&
+        operation.underlying.every(item => item.query.subscriberCount === 0)
+      ) {
+        return []
+      }
+      const haystack = [
+        query.serviceName,
+        query.method,
+        operation.composition?.detail ?? '',
+        JSON.stringify(query.query ?? {}),
+        ...operation.underlying.map(item =>
+          [
+            item.path,
+            item.query.serviceName,
+            item.query.method,
+            JSON.stringify(item.query.query ?? {}),
+          ].join(' '),
+        ),
+      ].join(' ')
+      if (!haystack.toLowerCase().includes(filter.toLowerCase())) return []
+      return [{ operation, localSubscriberCount }]
+    })
+    .sort((a, b) => {
+      const aQuery = a.operation.summary
+      const bQuery = b.operation.summary
+      return `${aQuery.serviceName}.${aQuery.method}`.localeCompare(
+        `${bQuery.serviceName}.${bQuery.method}`,
+        undefined,
+        { sensitivity: 'base' },
+      )
+    })
+
+  const onColumnResizeStart = (index: number, event: ReactMouseEvent<HTMLSpanElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    const ownerWindow = event.currentTarget.ownerDocument.defaultView ?? window
+    const startX = event.clientX
+    const startWidth = columnWidths[index]!
+    const minWidth = QUERY_COLUMNS[index]!.minWidth
+    const onMove = (move: MouseEvent) => {
+      setColumnWidths(current =>
+        current.map((width, columnIndex) =>
+          columnIndex === index ? Math.max(minWidth, startWidth + move.clientX - startX) : width,
+        ),
+      )
     }
-    const haystack = [
-      query.serviceName,
-      query.method,
-      operation.composition?.detail ?? '',
-      JSON.stringify(query.query ?? {}),
-      ...operation.underlying.map(item =>
-        [
-          item.path,
-          item.query.serviceName,
-          item.query.method,
-          JSON.stringify(item.query.query ?? {}),
-        ].join(' '),
-      ),
-    ].join(' ')
-    if (!haystack.toLowerCase().includes(filter.toLowerCase())) return []
-    return [{ operation, localSubscriberCount }]
-  })
+    const onUp = () => {
+      ownerWindow.removeEventListener('mousemove', onMove)
+      ownerWindow.removeEventListener('mouseup', onUp)
+    }
+    ownerWindow.addEventListener('mousemove', onMove)
+    ownerWindow.addEventListener('mouseup', onUp)
+  }
 
   const ellipsizedCode: CSSProperties = {
     ...styles.code,
@@ -108,16 +153,22 @@ export function QueriesTab({
   return (
     <section style={{ height: '100%', display: 'flex', minWidth: 0 }}>
       <div style={{ ...styles.scroll, flex: 1, minHeight: 0 }}>
-        <table style={styles.table}>
+        <table
+          style={{ ...styles.table, minWidth: columnWidths.reduce((sum, width) => sum + width, 0) }}
+        >
           <colgroup>
-            {QUERY_COLUMNS.map(column => (
-              <col key={column.label} style={{ width: column.width }} />
+            {QUERY_COLUMNS.map((column, index) => (
+              <col key={column.label} style={{ width: columnWidths[index] }} />
             ))}
           </colgroup>
           <thead>
             <tr>
-              {QUERY_COLUMNS.map(column => (
-                <th key={column.label} style={styles.th} title={column.description}>
+              {QUERY_COLUMNS.map((column, index) => (
+                <th
+                  key={column.label}
+                  style={{ ...styles.th, position: 'sticky' }}
+                  title={column.description}
+                >
                   <span
                     style={{
                       borderBottom: `1px dotted ${colors.faint}`,
@@ -126,6 +177,24 @@ export function QueriesTab({
                   >
                     {column.label}
                   </span>
+                  {index < QUERY_COLUMNS.length - 1 ? (
+                    <span
+                      role='separator'
+                      aria-label={`Resize ${column.label} column`}
+                      aria-orientation='vertical'
+                      onMouseDown={event => onColumnResizeStart(index, event)}
+                      style={{
+                        position: 'absolute',
+                        top: 0,
+                        right: -3,
+                        bottom: 0,
+                        width: 7,
+                        cursor: 'col-resize',
+                        zIndex: 2,
+                        borderRight: `1px solid ${colors.rowBorder}`,
+                      }}
+                    />
+                  ) : null}
                 </th>
               ))}
             </tr>

--- a/lib/devtools/QueryDetails.tsx
+++ b/lib/devtools/QueryDetails.tsx
@@ -234,6 +234,27 @@ export function QueryDetails({
           ) : null}
         </QueryDetailSection>
       ) : null}
+      <QueryDetailSection
+        label='Query data'
+        meta={activeQuery.skipped ? 'skipped' : plural(activeQuery.itemCount, 'row', 'rows')}
+      >
+        <pre
+          style={{
+            ...styles.code,
+            maxHeight: 360,
+            overflow: 'auto',
+            whiteSpace: 'pre-wrap',
+            overflowWrap: 'anywhere',
+            margin: 0,
+            padding: 10,
+            color: activeQuery.data === undefined ? colors.faint : colors.text,
+            background: colors.panel2,
+            borderRadius: 4,
+          }}
+        >
+          {activeQuery.data === undefined ? 'No data available' : prettyJson(activeQuery.data)}
+        </pre>
+      </QueryDetailSection>
       <details
         key={activeQueryId ?? operation.key}
         style={{

--- a/lib/devtools/QueryPresentation.tsx
+++ b/lib/devtools/QueryPresentation.tsx
@@ -35,11 +35,13 @@ export function QueryStatusDot({ query }: { query: QuerySummary }) {
       ? colors.red
       : status.kind === 'fetching'
         ? colors.blue
-        : status.kind === 'retained'
+        : status.kind === 'skipped'
           ? colors.faint
-          : status.kind === 'cached'
-            ? colors.amber
-            : colors.green
+          : status.kind === 'retained'
+            ? colors.faint
+            : status.kind === 'cached'
+              ? colors.amber
+              : colors.green
   return (
     <span
       title={status.label}
@@ -57,11 +59,14 @@ export function QueryStatusDot({ query }: { query: QuerySummary }) {
 }
 
 export function queryStatus(query: QuerySummary): {
-  kind: 'active' | 'cached' | 'error' | 'fetching' | 'retained'
+  kind: 'active' | 'cached' | 'error' | 'fetching' | 'retained' | 'skipped'
   label: string
 } {
   if (!query.present) {
     return { kind: 'retained', label: statusLabel(query, 'retained history') }
+  }
+  if (query.skipped) {
+    return { kind: 'skipped', label: statusLabel(query, 'skipped intentionally') }
   }
   if (query.status === 'error') {
     return { kind: 'error', label: statusLabel(query, 'error') }

--- a/lib/devtools/TimelineCanvas.tsx
+++ b/lib/devtools/TimelineCanvas.tsx
@@ -1,16 +1,28 @@
-import { useCallback, useLayoutEffect, useRef, useState } from 'react'
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from 'react'
 import type { QuerySpan } from './collector.js'
 import { formatClock, formatMs } from './format.js'
-import {
-  TimelineOverview,
-  TIMELINE_LABEL_WIDTH as LABEL_WIDTH,
-  type TimelineViewport,
-} from './TimelineOverview.js'
-import { useDevtoolsTheme, type DevtoolsColors } from './ui.js'
+import { TimelineOverview, type TimelineViewport } from './TimelineOverview.js'
+import { toneColor, useDevtoolsTheme, type DevtoolsColors } from './ui.js'
 
 const FOLLOW_THRESHOLD = 24
 const GRID_TICK_MS = 5_000
+const DEFAULT_LABEL_WIDTH = 340
+const MIN_LABEL_WIDTH = 240
+const MAX_LABEL_WIDTH = 640
+const TIMELINE_LANE_HEIGHT = 46
 export const TIMELINE_PIXELS_PER_SECOND = 64
+
+export interface TimelineMarker {
+  at: number
+  label: string
+  tone: 'green' | 'amber' | 'red' | 'blue' | 'neutral'
+}
 
 export type TimelineLane =
   | {
@@ -27,8 +39,19 @@ export type TimelineLane =
       id: string
       label: string
       detail: string
+      context: string
       firstAt: number
       ticks: number[]
+    }
+  | {
+      kind: 'connection'
+      id: string
+      label: string
+      detail: string
+      context: string
+      firstAt: number
+      bars: QuerySpan[]
+      markers: TimelineMarker[]
     }
 
 export interface TimelineLayout {
@@ -61,6 +84,7 @@ export function TimelineCanvas({
   const axisScrollRef = useRef<HTMLDivElement>(null)
   const [viewport, setViewport] = useState<TimelineViewport>({ left: 0, width: 0 })
   const [availableTrackWidth, setAvailableTrackWidth] = useState(0)
+  const [labelWidth, setLabelWidth] = useState(DEFAULT_LABEL_WIDTH)
   const hasLayout = layout !== null
   const trackWidth = layout ? Math.max(layout.trackWidth, availableTrackWidth) : undefined
   const renderedLayout: RenderedTimelineLayout | null =
@@ -85,6 +109,23 @@ export function TimelineCanvas({
         : next,
     )
   }, [trackWidth])
+  const onLabelResizeStart = (event: ReactMouseEvent<HTMLSpanElement>) => {
+    event.preventDefault()
+    const ownerWindow = event.currentTarget.ownerDocument.defaultView ?? window
+    const startX = event.clientX
+    const startWidth = labelWidth
+    const onMove = (move: MouseEvent) => {
+      setLabelWidth(
+        Math.max(MIN_LABEL_WIDTH, Math.min(MAX_LABEL_WIDTH, startWidth + move.clientX - startX)),
+      )
+    }
+    const onUp = () => {
+      ownerWindow.removeEventListener('mousemove', onMove)
+      ownerWindow.removeEventListener('mouseup', onUp)
+    }
+    ownerWindow.addEventListener('mousemove', onMove)
+    ownerWindow.addEventListener('mouseup', onUp)
+  }
 
   useLayoutEffect(() => {
     const horizontalScroll = trackScrollRef.current
@@ -136,6 +177,7 @@ export function TimelineCanvas({
         layout={renderedLayout}
         nowPoint={nowPoint}
         viewport={viewport}
+        labelWidth={labelWidth}
         onNavigate={ratio => {
           const scroll = trackScrollRef.current
           if (!scroll) return
@@ -155,7 +197,7 @@ export function TimelineCanvas({
       <div
         style={{
           display: 'grid',
-          gridTemplateColumns: `${LABEL_WIDTH}px minmax(0, 1fr)`,
+          gridTemplateColumns: `${labelWidth}px minmax(0, 1fr)`,
           minHeight: 38,
           flexShrink: 0,
           background: colors.bg,
@@ -164,6 +206,7 @@ export function TimelineCanvas({
         <div
           title={`Recording started ${formatTimelineClock(renderedLayout.start, wallClockOffset, true)}`}
           style={{
+            position: 'relative',
             color: colors.muted,
             padding: '7px 10px 0',
             borderBottom: `1px solid ${colors.border}`,
@@ -171,6 +214,23 @@ export function TimelineCanvas({
           }}
         >
           <TimelineLegend />
+          <span
+            role='separator'
+            aria-label='Resize timeline labels'
+            aria-orientation='vertical'
+            title='Resize timeline labels'
+            onMouseDown={onLabelResizeStart}
+            style={{
+              position: 'absolute',
+              top: 0,
+              right: -4,
+              bottom: 0,
+              width: 8,
+              zIndex: 3,
+              cursor: 'col-resize',
+              borderRight: `1px solid ${colors.border}`,
+            }}
+          />
         </div>
         <div
           ref={axisScrollRef}
@@ -198,7 +258,7 @@ export function TimelineCanvas({
         <div
           style={{
             display: 'grid',
-            gridTemplateColumns: `${LABEL_WIDTH}px minmax(0, 1fr)`,
+            gridTemplateColumns: `${labelWidth}px minmax(0, 1fr)`,
             alignItems: 'start',
           }}
         >
@@ -207,7 +267,7 @@ export function TimelineCanvas({
               <TimelineLaneLabel
                 key={lane.id}
                 label={lane.label}
-                {...(lane.kind === 'query' ? { context: lane.context } : {})}
+                context={lane.context}
                 detail={lane.detail}
               />
             ))}
@@ -230,8 +290,10 @@ export function TimelineCanvas({
                 <TimelineLaneTrack
                   key={lane.id}
                   layout={renderedLayout}
-                  bars={lane.kind === 'query' ? lane.bars : []}
+                  bars={lane.kind === 'query' || lane.kind === 'connection' ? lane.bars : []}
                   ticks={lane.kind === 'realtime' ? lane.ticks : []}
+                  markers={lane.kind === 'connection' ? lane.markers : []}
+                  barLabel={lane.kind === 'connection' ? 'Offline' : 'Fetch'}
                   nowPoint={nowPoint}
                   wallClockOffset={wallClockOffset}
                 />
@@ -298,7 +360,7 @@ function TimelineLegend() {
     <span style={{ display: 'inline-flex', alignItems: 'center', gap: 9, color: colors.muted }}>
       <TimelineLegendItem color={colors.green} shape='bar' label='fetch' />
       <TimelineLegendItem color={colors.blue} shape='dot' label='realtime' />
-      <TimelineLegendItem color={colors.red} shape='bar' label='failed' />
+      <TimelineLegendItem color={colors.red} shape='bar' label='failed / offline' />
     </span>
   )
 }
@@ -344,16 +406,37 @@ function TimelineLaneLabel({
       data-timeline-lane={label}
       style={{
         ...styles.laneLabel,
-        height: 32,
+        height: TIMELINE_LANE_HEIGHT,
         boxSizing: 'border-box',
-        paddingLeft: 10,
+        padding: '6px 10px 4px',
         borderBottom: `1px solid ${colors.rowBorder}`,
       }}
       title={detail ? `${label} ${detail}` : label}
     >
-      <span style={{ color: colors.text, fontWeight: 600 }}>{label}</span>
+      <span
+        style={{
+          display: 'block',
+          color: colors.text,
+          fontWeight: 650,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        {label}
+      </span>
       {context ? (
-        <span style={{ color: colors.faint, marginLeft: 6, whiteSpace: 'nowrap' }}>{context}</span>
+        <span
+          style={{
+            display: 'block',
+            color: colors.faint,
+            marginTop: 3,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {context}
+        </span>
       ) : null}
     </div>
   )
@@ -363,12 +446,16 @@ function TimelineLaneTrack({
   layout,
   bars,
   ticks,
+  markers,
+  barLabel,
   nowPoint,
   wallClockOffset,
 }: {
   layout: TimelineLayout
   bars: Array<{ startAt: number; endAt?: number; ok?: boolean }>
   ticks: number[]
+  markers: TimelineMarker[]
+  barLabel: 'Fetch' | 'Offline'
   nowPoint: number
   wallClockOffset: number
 }) {
@@ -378,7 +465,7 @@ function TimelineLaneTrack({
       style={{
         ...styles.laneTrack,
         width: layout.trackWidth,
-        height: 32,
+        height: TIMELINE_LANE_HEIGHT,
         boxSizing: 'border-box',
         borderBottom: `1px solid ${colors.rowBorder}`,
         ...timelineGridStyle(colors),
@@ -392,14 +479,16 @@ function TimelineLaneTrack({
         return (
           <span
             key={`${bar.startAt}:${index}`}
-            data-timeline-fetch={bar.ok === false ? 'failed' : 'success'}
+            {...(barLabel === 'Fetch'
+              ? { 'data-timeline-fetch': bar.ok === false ? 'failed' : 'success' }
+              : { 'data-timeline-outage': 'offline' })}
             title={[
-              `${bar.ok === false ? 'Failed fetch' : 'Fetch'} · ${formatMs(barEnd - bar.startAt)}`,
+              `${barLabel === 'Offline' ? 'Offline' : bar.ok === false ? 'Failed fetch' : 'Fetch'} · ${formatMs(barEnd - bar.startAt)}`,
               formatTimelineClock(bar.startAt, wallClockOffset, true),
             ].join('\n')}
             style={{
               position: 'absolute',
-              top: 13,
+              top: 19,
               left,
               width,
               height: 8,
@@ -430,7 +519,7 @@ function TimelineLaneTrack({
           title={`Realtime event\n${formatTimelineClock(tick, wallClockOffset, true)}`}
           style={{
             position: 'absolute',
-            top: 9,
+            top: 15,
             left: timeToPixels(tick, layout.start),
             width: 7,
             height: 7,
@@ -439,6 +528,24 @@ function TimelineLaneTrack({
             background: colors.blue,
             boxShadow: `0 0 0 1px ${colors.bg}`,
             transform: 'rotate(45deg)',
+          }}
+        />
+      ))}
+      {markers.map((marker, index) => (
+        <span
+          key={`${marker.at}:${marker.label}:${index}`}
+          title={`${marker.label}\n${formatTimelineClock(marker.at, wallClockOffset, true)}`}
+          style={{
+            position: 'absolute',
+            top: 14,
+            left: timeToPixels(marker.at, layout.start),
+            width: 9,
+            height: 9,
+            marginLeft: -5,
+            borderRadius: 999,
+            background: toneColor(colors, marker.tone),
+            border: `2px solid ${colors.bg}`,
+            boxSizing: 'border-box',
           }}
         />
       ))}

--- a/lib/devtools/TimelineOverview.tsx
+++ b/lib/devtools/TimelineOverview.tsx
@@ -2,8 +2,6 @@ import { useEffect, useRef } from 'react'
 import type { QuerySpan } from './collector.js'
 import { useDevtoolsTheme } from './ui.js'
 
-export const TIMELINE_LABEL_WIDTH = 220
-
 const OVERVIEW_HEIGHT = 42
 
 export interface TimelineViewport {
@@ -14,6 +12,7 @@ export interface TimelineViewport {
 type TimelineOverviewLane =
   | { kind: 'query'; id: string; bars: QuerySpan[] }
   | { kind: 'realtime'; id: string; ticks: number[] }
+  | { kind: 'connection'; id: string; bars: QuerySpan[]; markers: Array<{ at: number }> }
 
 interface TimelineOverviewLayout {
   start: number
@@ -25,12 +24,14 @@ export function TimelineOverview({
   layout,
   nowPoint,
   viewport,
+  labelWidth,
   onNavigate,
 }: {
   lanes: TimelineOverviewLane[]
   layout: TimelineOverviewLayout
   nowPoint: number
   viewport: TimelineViewport
+  labelWidth: number
   onNavigate: (ratio: number) => void
 }) {
   const { colors } = useDevtoolsTheme()
@@ -51,7 +52,7 @@ export function TimelineOverview({
     <div
       style={{
         display: 'grid',
-        gridTemplateColumns: `${TIMELINE_LABEL_WIDTH}px minmax(0, 1fr)`,
+        gridTemplateColumns: `${labelWidth}px minmax(0, 1fr)`,
         minHeight: OVERVIEW_HEIGHT,
         flexShrink: 0,
         borderBottom: `1px solid ${colors.border}`,
@@ -130,16 +131,18 @@ function drawOverview(
   for (const [laneIndex, lane] of lanes.entries()) {
     const markHeight = Math.min(3, Math.max(1, laneHeight * 0.5))
     const top = 5 + laneIndex * laneHeight + Math.max(0, (laneHeight - markHeight) / 2)
-    if (lane.kind === 'query') {
+    if (lane.kind === 'query' || lane.kind === 'connection') {
       for (const bar of lane.bars) {
         const left = timelineRatio(bar.startAt, layout) * width
         const right = timelineRatio(bar.endAt ?? nowPoint, layout) * width
         context.fillStyle = bar.ok === false ? colors.red : colors.green
         context.fillRect(left, top, Math.max(1, right - left), markHeight)
       }
-    } else {
+    }
+    if (lane.kind === 'realtime' || lane.kind === 'connection') {
       context.fillStyle = colors.blue
-      for (const tick of lane.ticks) {
+      const ticks = lane.kind === 'realtime' ? lane.ticks : lane.markers.map(marker => marker.at)
+      for (const tick of ticks) {
         context.fillRect(timelineRatio(tick, layout) * width, top, 2, markHeight)
       }
     }

--- a/lib/devtools/TimelineTab.tsx
+++ b/lib/devtools/TimelineTab.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useMemo, useState } from 'react'
-import type { DevtoolsSnapshot, QueryRecord } from './collector.js'
-import { compactJson, now } from './format.js'
+import type { DevtoolsSnapshot, QueryRecord, TimelineConnectionEvent } from './collector.js'
+import { compactJson, formatMs, now } from './format.js'
 import type { DevtoolsModel, EventQueryScope } from './model.js'
 import {
   TimelineCanvas,
   TIMELINE_PIXELS_PER_SECOND as PIXELS_PER_SECOND,
   type TimelineLane,
   type TimelineLayout,
+  type TimelineMarker,
 } from './TimelineCanvas.js'
 import { buttonStyle, useDevtoolsTheme } from './ui.js'
 
@@ -26,9 +27,20 @@ type RawTimelineLane =
       kind: 'realtime'
       id: string
       label: string
+      context: string
       detail: string
       firstAt: number
       ticks: number[]
+    }
+  | {
+      kind: 'connection'
+      id: string
+      label: string
+      context: string
+      detail: string
+      firstAt: number
+      bars: QueryRecord['spans']
+      markers: TimelineMarker[]
     }
 
 export function TimelineFollowControl({
@@ -97,7 +109,14 @@ export function TimelineTab({
           kind: 'query',
           id: `query:${query.queryId}`,
           label: `${query.serviceName}.${query.method}`,
-          context: timelineScopeLabel(scopes),
+          context: [
+            timelineScopeLabel(scopes),
+            `${query.itemCount} ${query.itemCount === 1 ? 'row' : 'rows'}`,
+            `${query.fetchCount} ${query.fetchCount === 1 ? 'fetch' : 'fetches'}`,
+            query.lastDurationMs === undefined ? '' : `${formatMs(query.lastDurationMs)} last`,
+          ]
+            .filter(Boolean)
+            .join(' · '),
           detail: timelineQueryDetail(query, scopes),
           firstAt: Math.min(...query.spans.map(span => span.startAt)),
           query,
@@ -107,14 +126,23 @@ export function TimelineTab({
       kind: 'realtime',
       id: `realtime:${serviceName}`,
       label: `${serviceName} realtime`,
+      context: `${ticks.length} ${ticks.length === 1 ? 'event' : 'events'} retained`,
       detail: `All retained realtime events emitted by ${serviceName}`,
       firstAt: Math.min(...ticks),
       ticks,
     }))
-    return [...queryLanes, ...realtimeLanes]
-  }, [model.scopesByQueryId, snapshot.queries, snapshot.timeline.realtime])
+    const connectionLane = buildConnectionLane(snapshot.timeline.connection)
+    return [...queryLanes, ...realtimeLanes, ...(connectionLane ? [connectionLane] : [])]
+  }, [
+    model.scopesByQueryId,
+    snapshot.queries,
+    snapshot.timeline.connection,
+    snapshot.timeline.realtime,
+  ])
   const hasInFlight = rawLanes.some(
-    lane => lane.kind === 'query' && lane.query.spans.some(span => span.endAt === undefined),
+    lane =>
+      (lane.kind === 'query' && lane.query.spans.some(span => span.endAt === undefined)) ||
+      (lane.kind === 'connection' && lane.bars.some(span => span.endAt === undefined)),
   )
   const nowPoint = useTimelineNow(hasInFlight)
   const wallClockOffset = Date.now() - now()
@@ -178,8 +206,11 @@ function timelineLayout(
       for (const span of lane.query.spans) {
         points.push(span.startAt, span.endAt ?? nowPoint)
       }
-    } else {
+    } else if (lane.kind === 'realtime') {
       points.push(...lane.ticks)
+    } else {
+      for (const span of lane.bars) points.push(span.startAt, span.endAt ?? nowPoint)
+      points.push(...lane.markers.map(marker => marker.at))
     }
   }
   if (points.length === 0) return null
@@ -189,6 +220,89 @@ function timelineLayout(
   const duration = Math.max(END_GUTTER_MS, latest - start + END_GUTTER_MS)
   const trackWidth = Math.ceil((duration / 1_000) * PIXELS_PER_SECOND)
   return { start, trackWidth }
+}
+
+function buildConnectionLane(events: TimelineConnectionEvent[]): RawTimelineLane | null {
+  if (events.length === 0) return null
+  const bars: QueryRecord['spans'] = []
+  const markers: TimelineMarker[] = []
+  let offlineStart: number | undefined
+  let latestAttempt: number | undefined
+  let lastOutageDuration: number | undefined
+
+  for (const item of events) {
+    const event = item.event
+    switch (event.kind) {
+      case 'connection:connected':
+        markers.push({ at: item.at, label: connectionEventLabel(event), tone: 'green' })
+        break
+      case 'connection:disconnected':
+        if (offlineStart === undefined) offlineStart = item.at
+        latestAttempt = undefined
+        markers.push({ at: item.at, label: connectionEventLabel(event), tone: 'red' })
+        break
+      case 'connection:reconnected':
+        latestAttempt = event.attempt
+        if (offlineStart !== undefined) {
+          lastOutageDuration = item.at - offlineStart
+          bars.push({ startAt: offlineStart, endAt: item.at, ok: false })
+          offlineStart = undefined
+        }
+        markers.push({ at: item.at, label: connectionEventLabel(event), tone: 'green' })
+        break
+      case 'connection:error':
+      case 'connection:reconnect-failed':
+        markers.push({ at: item.at, label: connectionEventLabel(event), tone: 'red' })
+        break
+    }
+  }
+  if (offlineStart !== undefined) bars.push({ startAt: offlineStart, ok: false })
+
+  const latest = events.at(-1)!.event
+  const isOffline = offlineStart !== undefined
+  const transport =
+    latest.kind === 'connection:connected' || latest.kind === 'connection:reconnected'
+      ? latest.transport
+      : undefined
+  const context = [
+    isOffline ? 'offline' : 'connected',
+    transport ?? '',
+    latestAttempt === undefined ? '' : `attempt ${latestAttempt}`,
+    !isOffline && lastOutageDuration !== undefined ? `${formatMs(lastOutageDuration)} outage` : '',
+  ]
+    .filter(Boolean)
+    .join(' · ')
+
+  return {
+    kind: 'connection',
+    id: 'connection',
+    label: 'Connection',
+    context,
+    detail: `${events.length} retained connection ${events.length === 1 ? 'event' : 'events'}`,
+    firstAt: events[0]!.at,
+    bars,
+    markers,
+  }
+}
+
+function connectionEventLabel(event: TimelineConnectionEvent['event']): string {
+  switch (event.kind) {
+    case 'connection:connected':
+      return ['Connected', event.transport].filter(Boolean).join(' · ')
+    case 'connection:disconnected':
+      return ['Disconnected', event.reason].filter(Boolean).join(' · ')
+    case 'connection:reconnected':
+      return [
+        event.attempt === undefined ? 'Reconnected' : `Reconnected on attempt ${event.attempt}`,
+        event.transport,
+      ]
+        .filter(Boolean)
+        .join(' · ')
+    case 'connection:error':
+      return `${event.phase === 'connect' ? 'Connection' : 'Reconnect'} error · ${event.error.message}`
+    case 'connection:reconnect-failed':
+      return event.error ? `Reconnection failed · ${event.error.message}` : 'Reconnection failed'
+  }
 }
 
 function timelineQueryDetail(

--- a/lib/devtools/collector.ts
+++ b/lib/devtools/collector.ts
@@ -62,10 +62,28 @@ export interface TimelineRealtimeEvent {
   serviceName: string
 }
 
+type ConnectionFigbirdEvent = Extract<
+  FigbirdEvent,
+  {
+    kind:
+      | 'connection:connected'
+      | 'connection:disconnected'
+      | 'connection:reconnected'
+      | 'connection:error'
+      | 'connection:reconnect-failed'
+  }
+>
+
+export interface TimelineConnectionEvent {
+  at: number
+  event: ConnectionFigbirdEvent
+}
+
 export interface DevtoolsTimeline {
   startedAt: number
   laneOrder: string[]
   realtime: TimelineRealtimeEvent[]
+  connection: TimelineConnectionEvent[]
 }
 
 export interface WriteRecord {
@@ -96,6 +114,7 @@ export interface DevtoolsSnapshot {
 }
 
 export interface Collector {
+  readonly eventLimit: number
   start(): void
   stop(): void
   subscribe(fn: () => void): () => void
@@ -103,6 +122,7 @@ export interface Collector {
   clearEvents(): void
   clearTimeline(): void
   clearWrites(): void
+  reset(): void
 }
 
 type CapturedQueryState = Omit<
@@ -138,7 +158,7 @@ const EMPTY_SNAPSHOT: DevtoolsSnapshot = {
   queries: [],
   relational: [],
   events: [],
-  timeline: { startedAt: 0, laneOrder: [], realtime: [] },
+  timeline: { startedAt: 0, laneOrder: [], realtime: [], connection: [] },
   writes: [],
   inFlightWrites: 0,
 }
@@ -308,6 +328,7 @@ class FigbirdCollector implements Collector {
   #relational: Map<string, InternalRelationalQuery> = new Map()
   #events: CappedBuffer<DevtoolsEvent>
   #timelineRealtime: CappedBuffer<TimelineRealtimeEvent>
+  #timelineConnection: CappedBuffer<TimelineConnectionEvent>
   #timelineStartedAt = now()
   #timelineLaneOrder: string[] = []
   #timelineLaneIds = new Set<string>()
@@ -315,14 +336,18 @@ class FigbirdCollector implements Collector {
   #realtimeByService: Map<string, number> = new Map()
   #writes: Map<string, WriteRecord> = new Map()
 
+  readonly eventLimit: number
+
   constructor(figbird: FigbirdLikeForDevtools, options: ResolvedCollectorOptions) {
     this.#figbird = figbird
     this.#heartbeatMs = options.heartbeatMs
     this.#queryHistoryLimit = options.queryHistoryLimit
     this.#spanLimit = options.spanLimit
     this.#writeLimit = options.writeLimit
+    this.eventLimit = options.eventLimit
     this.#events = new CappedBuffer(options.eventLimit)
     this.#timelineRealtime = new CappedBuffer(options.eventLimit)
+    this.#timelineConnection = new CappedBuffer(options.eventLimit)
   }
 
   start(): void {
@@ -388,6 +413,7 @@ class FigbirdCollector implements Collector {
         startedAt: this.#timelineStartedAt,
         laneOrder: [...this.#timelineLaneOrder],
         realtime: this.#timelineRealtime.toArray(),
+        connection: this.#timelineConnection.toArray(),
       },
       writes,
       inFlightWrites: this.#figbird.mutating?.getSnapshot().length ?? 0,
@@ -403,6 +429,7 @@ class FigbirdCollector implements Collector {
 
   clearTimeline(): void {
     this.#timelineRealtime.clear()
+    this.#timelineConnection.clear()
     this.#timelineStartedAt = now()
     this.#timelineLaneOrder = []
     this.#timelineLaneIds.clear()
@@ -416,6 +443,21 @@ class FigbirdCollector implements Collector {
     for (const [id, write] of this.#writes) {
       if (write.status !== 'in-flight') this.#writes.delete(id)
     }
+    this.#scheduleNotify()
+  }
+
+  reset(): void {
+    this.#queries.clear()
+    this.#relational.clear()
+    this.#events.clear()
+    this.#timelineRealtime.clear()
+    this.#timelineConnection.clear()
+    this.#timelineStartedAt = now()
+    this.#timelineLaneOrder = []
+    this.#timelineLaneIds.clear()
+    this.#nextEventId = 1
+    this.#realtimeByService.clear()
+    this.#writes.clear()
     this.#scheduleNotify()
   }
 
@@ -459,6 +501,14 @@ class FigbirdCollector implements Collector {
           (this.#realtimeByService.get(event.serviceName) ?? 0) + 1,
         )
         break
+      case 'connection:connected':
+      case 'connection:disconnected':
+      case 'connection:reconnected':
+      case 'connection:error':
+      case 'connection:reconnect-failed':
+        this.#recordTimelineLane('connection')
+        this.#timelineConnection.push({ at, event: this.#captureConnectionEvent(event) })
+        break
       case 'reconcile:started':
         {
           const record = this.#queries.get(event.queryId)
@@ -493,7 +543,11 @@ class FigbirdCollector implements Collector {
       observedQueryIds.add(row.queryId)
       const serviceRealtime = this.#realtimeByService.get(row.serviceName) ?? 0
       const existing = this.#queries.get(row.queryId)
-      const capturedRow = { ...row, query: snapshotValue(row.query) }
+      const capturedRow = {
+        ...row,
+        query: snapshotValue(row.query),
+        ...(row.data === undefined ? {} : { data: snapshotValue(row.data) }),
+      }
       const capturedState = queryState(capturedRow)
       const record =
         existing ?? makeQueryRecord(capturedRow, serviceRealtime, observedAt, this.#spanLimit)
@@ -747,9 +801,12 @@ class FigbirdCollector implements Collector {
           ...event,
           ...(event.params === undefined ? {} : { params: snapshotValue(event.params) }),
         }
+      case 'realtime':
+        return { ...event, item: snapshotValue(event.item) }
       case 'fetch:error':
       case 'mutate:error':
       case 'action:error':
+      case 'connection:error':
         return { ...event, error: new Error(errorMessage(event.error)) }
       case 'mutate:start':
         return {
@@ -774,6 +831,14 @@ class FigbirdCollector implements Collector {
       default:
         return { ...event }
     }
+  }
+
+  #captureConnectionEvent(event: ConnectionFigbirdEvent): ConnectionFigbirdEvent {
+    if (event.kind === 'connection:error' || event.kind === 'connection:reconnect-failed') {
+      if (!event.error) return { ...event }
+      return { ...event, error: new Error(errorMessage(event.error)) }
+    }
+    return { ...event }
   }
 
   #trimWrites(): void {

--- a/lib/devtools/model.ts
+++ b/lib/devtools/model.ts
@@ -87,9 +87,17 @@ export function buildDevtoolsModel(snapshot: DevtoolsSnapshot): DevtoolsModel {
       })
     }
 
+    const summary = summarizeRootFetches(rootFetches)
     operations.push({
       key: group.key,
-      summary: summarizeRootFetches(rootFetches),
+      summary:
+        group.data === undefined
+          ? summary
+          : {
+              ...summary,
+              data: group.data,
+              itemCount: Array.isArray(group.data) ? group.data.length : 1,
+            },
       rootFetches,
       underlying: [...underlyingByPath.values()],
       composition: describeComposition(group.ast, group.name, group.pagination),
@@ -132,7 +140,19 @@ function summarizeRootFetches(roots: QueryRecord[]): QuerySummary {
     method: latest.method,
     ...(latest.resourceId !== undefined ? { resourceId: latest.resourceId } : {}),
     query: latest.query,
+    ...(roots.some(query => query.data !== undefined)
+      ? {
+          data: roots.flatMap(query =>
+            Array.isArray(query.data)
+              ? query.data
+              : query.data === undefined || query.data === null
+                ? []
+                : [query.data],
+          ),
+        }
+      : {}),
     classification: latest.classification,
+    skipped: roots.every(query => query.skipped === true),
     status: roots.some(query => query.status === 'error')
       ? 'error'
       : roots.some(query => query.status === 'loading')

--- a/test/devtools.test.tsx
+++ b/test/devtools.test.tsx
@@ -664,7 +664,7 @@ test('devtools model keeps operation identity separate from shared fetch identit
       },
     ],
     events: [],
-    timeline: { startedAt: 0, laneOrder: [], realtime: [] },
+    timeline: { startedAt: 0, laneOrder: [], realtime: [], connection: [] },
     writes: [],
     inFlightWrites: 0,
   }
@@ -740,11 +740,12 @@ test('query details show a cursor operation as one inspectable page chain', t =>
       },
     ],
     events: [],
-    timeline: { startedAt: 0, laneOrder: [], realtime: [] },
+    timeline: { startedAt: 0, laneOrder: [], realtime: [], connection: [] },
     writes: [],
     inFlightWrites: 0,
   }
   const collector: Collector = {
+    eventLimit: 500,
     start() {},
     stop() {},
     subscribe: () => () => {},
@@ -752,6 +753,7 @@ test('query details show a cursor operation as one inspectable page chain', t =>
     clearEvents() {},
     clearTimeline() {},
     clearWrites() {},
+    reset() {},
   }
 
   render(<FigbirdDevtoolsPanel collector={collector} theme='light' />)
@@ -950,6 +952,7 @@ test('panel shows root queries and nests relation fetches in details', async t =
         spans: [{ startAt: timelineAt - 20, endAt: timelineAt - 10, ok: true }],
         realtimeSeen: 0,
         reconciles: 0,
+        data: [{ id: 76, title: 'Visible issue' }],
       },
       {
         queryId: 'labels',
@@ -971,6 +974,10 @@ test('panel shows root queries and nests relation fetches in details', async t =
         spans: [{ startAt: timelineAt - 15, endAt: timelineAt - 5, ok: true }],
         realtimeSeen: 0,
         reconciles: 0,
+        data: [
+          { id: 1, issueId: 76, name: 'bug' },
+          { id: 2, issueId: 76, name: 'urgent' },
+        ],
       },
     ],
     relational: [
@@ -996,6 +1003,16 @@ test('panel shows root queries and nests relation fetches in details', async t =
           { path: '(root)', queryId: 'root' },
           { path: 'labels', queryId: 'labels' },
         ],
+        data: [
+          {
+            id: 76,
+            title: 'Visible issue',
+            labels: [
+              { id: 1, issueId: 76, name: 'bug' },
+              { id: 2, issueId: 76, name: 'urgent' },
+            ],
+          },
+        ],
       },
     ],
     events: [],
@@ -1003,6 +1020,7 @@ test('panel shows root queries and nests relation fetches in details', async t =
       startedAt: timelineAt - 25,
       laneOrder: ['query:root', 'query:labels', 'realtime:issues'],
       realtime: [{ at: timelineAt - 3, serviceName: 'issues' }],
+      connection: [],
     },
     writes: [],
     inFlightWrites: 0,
@@ -1069,6 +1087,18 @@ test('panel shows root queries and nests relation fetches in details', async t =
       serviceName: 'issues',
       type: 'patched',
       itemId: 76,
+      item: { id: 76, title: 'Updated issue' },
+    })
+    events.emit({
+      kind: 'connection:disconnected',
+      reason: 'transport close',
+      reconnecting: true,
+    })
+    events.emit({
+      kind: 'connection:reconnected',
+      attempt: 1,
+      transport: 'websocket',
+      connectionId: 'socket-2',
     })
     await Promise.resolve()
     await Promise.resolve()
@@ -1119,6 +1149,8 @@ test('panel shows root queries and nests relation fetches in details', async t =
 
   const devtoolsText = $('[aria-label="Figbird devtools"]')?.textContent ?? ''
   t.true(devtoolsText.includes('Query plan'))
+  t.true(devtoolsText.includes('Query data'))
+  t.true(devtoolsText.includes('Visible issue'))
   t.true(devtoolsText.includes('Parameters'))
   t.true(devtoolsText.includes('issueLabels'))
   t.false(devtoolsText.includes('Composition'))
@@ -1164,7 +1196,21 @@ test('panel shows root queries and nests relation fetches in details', async t =
   const timelineLanes = $all('[data-timeline-lane]').map(lane =>
     lane.getAttribute('data-timeline-lane'),
   )
-  t.deepEqual(timelineLanes, ['issues.find', 'issueLabels.find', 'issues realtime'])
+  t.deepEqual(timelineLanes, ['issues.find', 'issueLabels.find', 'issues realtime', 'Connection'])
+  t.is($all('[data-timeline-outage="offline"]').length, 1)
+  t.true(timelineText.includes('websocket'))
+
+  const eventsButton = $all('button').find(button => button.textContent === 'events')
+  t.truthy(eventsButton)
+  click(eventsButton!)
+  const realtimeEventRow = $all('[title="Select event details"]').find(row =>
+    row.textContent?.includes('realtime'),
+  )
+  t.truthy(realtimeEventRow)
+  click(realtimeEventRow!)
+  const eventDetails = $('[aria-label="Figbird devtools"]')?.textContent ?? ''
+  t.true(eventDetails.includes('Realtime payload'))
+  t.true(eventDetails.includes('Updated issue'))
 
   const largeElement = window.document.createElement('div')
   const largeHostFiber: Record<string, unknown> = { stateNode: largeElement }

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -975,6 +975,8 @@ test('figbird.query: reconnect refetches active queries after missed events', as
     reconnectJitter: 0,
   })
   const peopleService = feathers.service('people')
+  const connectionKinds: string[] = []
+  const unsubscribeEvents = figbird.events.subscribe(event => connectionKinds.push(event.kind))
   const queryRef = figbird.queryDesc({
     serviceName: 'people',
     method: 'find',
@@ -1002,8 +1004,10 @@ test('figbird.query: reconnect refetches active queries after missed events', as
 
   t.is(peopleService.counts.find, initialFindCount + 1)
   t.deepEqual(latestNames, ['Alicia'])
+  t.true(connectionKinds.includes('connection:reconnected'))
 
   unsubscribe()
+  unsubscribeEvents()
 })
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- reset collected DevTools state when the inspected page reloads and retain a configurable bounded realtime event history
- show query data on selection, sort query operations alphabetically, move skipped queries behind a filter, and make table/timeline columns resizable
- enrich timeline rows and surface Feathers socket connection, disconnection, reconnection, and failure lifecycle events

## Verification

- `npm run test`
- `npm run devtools:check`