### PR TITLE
Add ordered adapter-backed transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ scheduling, retries, flush, and discard. `defineMutationQueue()` gives reconnect
 queues a stable policy and key namespace. Queue writes and ordinary writes share the same
 per-record ordering.
 
+Adapters can opt into atomic multi-service transactions. `figbird.transaction()` collects
+schema-typed CRUD calls, projects and rolls them back as one cache update, and coordinates the
+affected record lanes before making one adapter request. Operations execute in collection
+order, so records created with client-generated ids can be referenced by later writes.
+The Feathers adapter includes an
+opt-in `feathersBatchTransactions()` transport for `api/batch`-style services; adapters without
+an atomic capability never fall back to sequential requests.
+
 Writes can use `optimisticPatch` when the local projection differs from the server payload.
 Relational filters apply projected changes locally, then reconcile once after the record's
 writes settle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@ Adapters can opt into atomic multi-service transactions. `figbird.transaction()`
 schema-typed CRUD calls, projects and rolls them back as one cache update, and coordinates the
 affected record lanes before making one adapter request. Operations execute in collection
 order, so records created with client-generated ids can be referenced by later writes.
-The Feathers adapter includes an
-opt-in `feathersBatchTransactions()` transport for `api/batch`-style services; adapters without
-an atomic capability never fall back to sequential requests.
+The Feathers adapter includes an opt-in `feathersTransactions()` transport for an
+application-provided `api/transactions` service. Existing endpoints such as `api/batch` can
+be selected through `serviceName`. Adapters without an atomic capability never fall back to
+sequential requests.
 
 Writes can use `optimisticPatch` when the local projection differs from the server payload.
 Relational filters apply projected changes locally, then reconcile once after the record's

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -723,22 +723,35 @@ confirmed creates. An explicit `optimisticItem` must preserve that id. Multi-rec
 needs an identity before dispatch. The transaction DSL is
 CRUD-only; custom methods have adapter-specific argument and cache semantics.
 
-For Feathers, opt into the `api/batch` tuple contract explicitly:
+Bulk operations affect multiple records; transactions commit multiple operations atomically.
+For Feathers, configure an application-provided transaction endpoint. The recommended service
+name, and the helper's default, is `api/transactions`:
 
 ```ts
-import { FeathersAdapter, feathersBatchTransactions } from 'figbird'
+import { FeathersAdapter, feathersTransactions } from 'figbird'
 
 const adapter = new FeathersAdapter(feathers, {
-  transactions: feathersBatchTransactions(), // defaults to api/batch
+  transactions: feathersTransactions(),
 })
 ```
 
-The batch service must return one ordered `{ status: 'fulfilled', value }` or
-`{ status: 'rejected', reason }` entry per call and guarantee that any rejection rolls back the
-whole batch. `feathersBatchTransactions()` sends `serial: true` and rejects the Figbird
-transaction if any entry rejects. The service must honor serial execution inside its
-atomic transaction. Partial-success batches are outside this API.
-Use `serviceName` and `params` options when the batch endpoint differs.
+The helper does not create the server endpoint. It calls the service's `create` method with
+`{ serial: true, calls }`, where each call is a `[method, serviceName, ...args]` tuple.
+The service must return `{ data: [...] }` with one ordered `{ status: 'fulfilled', value }` or
+`{ status: 'rejected', reason }` entry per call. It must execute calls sequentially inside one
+atomic transaction and roll back every write if any call fails. `feathersTransactions()`
+rejects the Figbird transaction if any entry rejects. Partial success is outside this API.
+
+Existing endpoints can keep their names. For example, Humaans uses `api/batch` for this
+transaction contract:
+
+```ts
+const adapter = new FeathersAdapter(feathers, {
+  transactions: feathersTransactions({ serviceName: 'api/batch' }),
+})
+```
+
+Use the `params` option to pass Feathers params to the transaction service's `create` call.
 
 ### Ordered autosave with mutation queues
 
@@ -1942,7 +1955,7 @@ const adapter = new FeathersAdapter(feathers, options)
   - `defaultPageSizeWhenFetchingAll` — default `query.$limit` when fetching with `allPages`
   - `pagination` — cursor strategies keyed by service path; see [Cursor pagination](#cursor-pagination)
   - `operators` — custom query operators the client can evaluate (`{ $asOf: asOf => item => boolean }`); queries using them stay realtime-mergeable. See [Teaching the client custom operators](#teaching-the-client-custom-operators)
-  - `transactions` — optional atomic transaction transport; use `feathersBatchTransactions()` for an `api/batch`-style service
+  - `transactions` — optional atomic transaction transport; use `feathersTransactions()` for an application-provided `api/transactions` service, or set `serviceName` for an existing endpoint
 
 Meta behavior: `find` returns `{ data, meta }` (`FindMeta`: `{ total, limit, skip }`); `get` returns only the item.
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -675,6 +675,71 @@ queries update immediately. Relations assemble from cached data and fetch missin
 When the server must decide query membership or ordering, Figbird waits for the record's
 writes to settle before reconciling the query.
 
+### Adapter-backed transactions
+
+Use `figbird.transaction()` when several CRUD writes must commit or roll back as one server
+operation. Transactions are a capability, not an emulation: Figbird throws if the adapter
+does not provide an atomic transport and never falls back to sequential requests.
+
+```ts
+await figbird.transaction(tx => {
+  tx.m.tasks.patch(taskId, { columnId: nextColumnId })
+  tx.m.columns.patch(previousColumnId, { count: previousCount - 1 })
+  tx.m.columns.patch(nextColumnId, { count: nextCount + 1 })
+})
+```
+
+The callback collects synchronously; its methods return no result, and the outer promise settles
+when the transaction commits. Payloads, patches, service names, and `confirmed` options retain
+the same schema inference as `m`. Optimistic operations project as one observer-visible cache
+update and roll back together. `tx.m.columns.confirmed.patch(...)` keeps that operation hidden
+until commit.
+
+Generate ids before collecting writes, using your application's id generator
+(for example, NanoID). Pass them directly as foreign keys:
+
+```ts
+import { nanoid } from 'nanoid'
+
+const documentTypeId = nanoid()
+const documentId = nanoid()
+
+await figbird.transaction(tx => {
+  tx.m.documentTypes.create({ id: documentTypeId, name: 'Contract' })
+  tx.m.documents.create({ id: documentId, documentTypeId, name: 'Employment contract' })
+})
+```
+
+The adapter executes operations in collection order within the server transaction.
+Create referenced records first: the document type exists before the document is created.
+Figbird does not infer dependencies from payloads. The backend must accept and preserve
+the client-generated ids. The outer promise returns no records; read server-computed
+fields from the cache after commit.
+
+Transaction operations wait behind earlier writes to every affected record, then reserve those
+record lanes until the adapter transaction settles. Each entity can appear only once in a
+transaction. Create payloads must be collected one at a time and carry a stable id, including
+confirmed creates. An explicit `optimisticItem` must preserve that id. Multi-record ordering
+needs an identity before dispatch. The transaction DSL is
+CRUD-only; custom methods have adapter-specific argument and cache semantics.
+
+For Feathers, opt into the `api/batch` tuple contract explicitly:
+
+```ts
+import { FeathersAdapter, feathersBatchTransactions } from 'figbird'
+
+const adapter = new FeathersAdapter(feathers, {
+  transactions: feathersBatchTransactions(), // defaults to api/batch
+})
+```
+
+The batch service must return one ordered `{ status: 'fulfilled', value }` or
+`{ status: 'rejected', reason }` entry per call and guarantee that any rejection rolls back the
+whole batch. `feathersBatchTransactions()` sends `serial: true` and rejects the Figbird
+transaction if any entry rejects. The service must honor serial execution inside its
+atomic transaction. Partial-success batches are outside this API.
+Use `serviceName` and `params` options when the batch endpoint differs.
+
 ### Ordered autosave with mutation queues
 
 `m` sends independent records in parallel. A feature such as a workflow editor may instead
@@ -1848,6 +1913,7 @@ const figbird = new Figbird({
 | `prefetch(request, opts?)`                        | Idempotent speculative warming. Argumentless definitions can be passed directly. See [figbird.prefetch](#figbirdprefetch).                                      |
 | `refetch(service?)`                               | Manual refetch escape hatch for changes Figbird can’t observe, such as custom methods without events or out-of-band writes. Call `figbird.refetch(...)`.                  |
 | `m`                                               | The instance’s write proxy: `figbird.m.issues.patch(...)`, or `figbird.m(service)` for dynamic names. In React, access the provider instance through `useMutations()`. See [m](#m). |
+| `transaction(fn)`                                 | Adapter-backed atomic CRUD collector. Optimistic projection, commit, and rollback are grouped across services. See [Adapter-backed transactions](#adapter-backed-transactions). |
 | `createMutationQueue(config?)`                    | Explicitly owned serial writes across records or services. See [figbird.createMutationQueue](#figbirdcreatemutationqueue).                                |
 | `mutating`                                        | Synchronous active-mutation tracker (`subscribe`/`getSnapshot`) — `useMutating` is its React binding.                                                       |
 | `explain(...)`                                    | Static classification report — see [figbird.explain](#figbirdexplain).                                                                                      |
@@ -1876,6 +1942,7 @@ const adapter = new FeathersAdapter(feathers, options)
   - `defaultPageSizeWhenFetchingAll` — default `query.$limit` when fetching with `allPages`
   - `pagination` — cursor strategies keyed by service path; see [Cursor pagination](#cursor-pagination)
   - `operators` — custom query operators the client can evaluate (`{ $asOf: asOf => item => boolean }`); queries using them stay realtime-mergeable. See [Teaching the client custom operators](#teaching-the-client-custom-operators)
+  - `transactions` — optional atomic transaction transport; use `feathersBatchTransactions()` for an `api/batch`-style service
 
 Meta behavior: `find` returns `{ data, meta }` (`FindMeta`: `{ total, limit, skip }`); `get` returns only the item.
 

--- a/lib/adapters/adapter.ts
+++ b/lib/adapters/adapter.ts
@@ -83,6 +83,13 @@ export interface MatcherContext {
   serviceName: string
 }
 
+/** One mutation inside an adapter-backed atomic transaction. */
+export interface AdapterTransactionOperation {
+  serviceName: string
+  method: 'create' | 'update' | 'patch' | 'remove'
+  args: readonly unknown[]
+}
+
 /**
  * Unified adapter interface
  * The adapter is service-agnostic and works with unknown items
@@ -108,6 +115,18 @@ export interface Adapter<
   findAll(serviceName: string, params?: TParams): Promise<QueryResponse<unknown[], TMeta>>
 
   mutate(serviceName: string, method: string, args: unknown[]): Promise<unknown>
+
+  /**
+   * Execute mutations in array order within one atomic commit. Each operation
+   * must see earlier writes, so callers can create a record before referencing
+   * its client-generated id. Return one result per operation in the same order.
+   * Omit this capability when the backend cannot guarantee
+   * all-or-nothing commit semantics; Figbird never falls back to sequential
+   * requests.
+   */
+  transaction?:
+    | ((operations: readonly AdapterTransactionOperation[]) => Promise<readonly unknown[]>)
+    | undefined
 
   /** Return false when retrying a failed query cannot help. Errors retry by default. */
   isRetryableError?(error: Error): boolean

--- a/lib/adapters/feathers.ts
+++ b/lib/adapters/feathers.ts
@@ -314,22 +314,22 @@ export type FeathersTransaction = (
   operations: readonly AdapterTransactionOperation[],
 ) => Promise<readonly unknown[]>
 
-export interface FeathersBatchTransactionsOptions {
-  /** Feathers service implementing the batch contract. Defaults to `api/batch`. */
+export interface FeathersTransactionsOptions {
+  /** Application-provided atomic transaction service. Defaults to `api/transactions`. */
   serviceName?: string
-  /** Params passed to the batch service's `create` call. */
+  /** Params passed to the transaction service's `create` call. */
   params?: FeathersParams
 }
 
-interface FeathersBatchResult {
+interface FeathersTransactionResult {
   data: Array<{ status: 'fulfilled'; value?: unknown } | { status: 'rejected'; reason: unknown }>
 }
 
-/** Error returned when an atomic Feathers batch contains rejected operations. */
+/** Error returned when a Feathers transaction contains rejected operations. */
 export class FeathersTransactionError extends Error {
-  readonly result: FeathersBatchResult
+  readonly result: FeathersTransactionResult
 
-  constructor(result: FeathersBatchResult) {
+  constructor(result: FeathersTransactionResult) {
     const rejected = result.data.filter(entry => entry.status === 'rejected').length
     super(`Feathers transaction rejected ${rejected} operation${rejected === 1 ? '' : 's'}`)
     this.name = 'FeathersTransactionError'
@@ -338,15 +338,16 @@ export class FeathersTransactionError extends Error {
 }
 
 /**
- * Adapt a Feathers `api/batch`-style service to Figbird's atomic transaction
- * capability. The service must return ordered `{ status, value/reason }`
- * entries, honor serial execution, and roll the entire batch back when any
- * entry rejects.
+ * Adapt an application-provided Feathers service to Figbird's atomic transaction
+ * capability. The service receives `{ serial: true, calls }` with method/path/args
+ * tuples and returns `{ data }` with ordered `{ status, value/reason }` entries.
+ * It must honor serial execution and roll the entire transaction back when any
+ * entry rejects. This helper does not create the server endpoint.
  */
-export function feathersBatchTransactions({
-  serviceName = 'api/batch',
+export function feathersTransactions({
+  serviceName = 'api/transactions',
   params,
-}: FeathersBatchTransactionsOptions = {}): FeathersTransaction {
+}: FeathersTransactionsOptions = {}): FeathersTransaction {
   return async (feathers, operations) => {
     const result = await feathers.service(serviceName).create(
       {
@@ -359,7 +360,7 @@ export function feathersBatchTransactions({
       },
       params,
     )
-    if (!isFeathersBatchResult(result) || result.data.length !== operations.length) {
+    if (!isFeathersTransactionResult(result) || result.data.length !== operations.length) {
       throw new Error(`Feathers transaction service "${serviceName}" returned an invalid result`)
     }
     if (result.data.some(entry => entry.status === 'rejected')) {
@@ -369,11 +370,15 @@ export function feathersBatchTransactions({
   }
 }
 
-function isFeathersBatchResult(value: unknown): value is FeathersBatchResult {
-  if (!value || typeof value !== 'object' || !Array.isArray((value as FeathersBatchResult).data)) {
+function isFeathersTransactionResult(value: unknown): value is FeathersTransactionResult {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    !Array.isArray((value as FeathersTransactionResult).data)
+  ) {
     return false
   }
-  return (value as FeathersBatchResult).data.every(
+  return (value as FeathersTransactionResult).data.every(
     entry =>
       entry &&
       typeof entry === 'object' &&

--- a/lib/adapters/feathers.ts
+++ b/lib/adapters/feathers.ts
@@ -1,6 +1,7 @@
 import type {
   Adapter,
   AdapterConnectionEvent,
+  AdapterTransactionOperation,
   EventHandlers,
   MatcherContext,
   PageCursor,
@@ -307,6 +308,79 @@ export type CustomOperatorRegistration =
       byService: Record<string, CustomOperator>
     }
 
+/** Feathers-specific transport for an adapter-backed atomic transaction. */
+export type FeathersTransaction = (
+  feathers: FeathersClient,
+  operations: readonly AdapterTransactionOperation[],
+) => Promise<readonly unknown[]>
+
+export interface FeathersBatchTransactionsOptions {
+  /** Feathers service implementing the batch contract. Defaults to `api/batch`. */
+  serviceName?: string
+  /** Params passed to the batch service's `create` call. */
+  params?: FeathersParams
+}
+
+interface FeathersBatchResult {
+  data: Array<{ status: 'fulfilled'; value?: unknown } | { status: 'rejected'; reason: unknown }>
+}
+
+/** Error returned when an atomic Feathers batch contains rejected operations. */
+export class FeathersTransactionError extends Error {
+  readonly result: FeathersBatchResult
+
+  constructor(result: FeathersBatchResult) {
+    const rejected = result.data.filter(entry => entry.status === 'rejected').length
+    super(`Feathers transaction rejected ${rejected} operation${rejected === 1 ? '' : 's'}`)
+    this.name = 'FeathersTransactionError'
+    this.result = result
+  }
+}
+
+/**
+ * Adapt a Feathers `api/batch`-style service to Figbird's atomic transaction
+ * capability. The service must return ordered `{ status, value/reason }`
+ * entries, honor serial execution, and roll the entire batch back when any
+ * entry rejects.
+ */
+export function feathersBatchTransactions({
+  serviceName = 'api/batch',
+  params,
+}: FeathersBatchTransactionsOptions = {}): FeathersTransaction {
+  return async (feathers, operations) => {
+    const result = await feathers.service(serviceName).create(
+      {
+        serial: true,
+        calls: operations.map(operation => [
+          operation.method,
+          operation.serviceName,
+          ...operation.args,
+        ]),
+      },
+      params,
+    )
+    if (!isFeathersBatchResult(result) || result.data.length !== operations.length) {
+      throw new Error(`Feathers transaction service "${serviceName}" returned an invalid result`)
+    }
+    if (result.data.some(entry => entry.status === 'rejected')) {
+      throw new FeathersTransactionError(result)
+    }
+    return result.data.map(entry => (entry.status === 'fulfilled' ? entry.value : undefined))
+  }
+}
+
+function isFeathersBatchResult(value: unknown): value is FeathersBatchResult {
+  if (!value || typeof value !== 'object' || !Array.isArray((value as FeathersBatchResult).data)) {
+    return false
+  }
+  return (value as FeathersBatchResult).data.every(
+    entry =>
+      entry &&
+      typeof entry === 'object' &&
+      (entry.status === 'fulfilled' || entry.status === 'rejected'),
+  )
+}
+
 export interface FeathersAdapterOptions {
   idField?: IdFieldType
   updatedAtField?: UpdatedAtFieldType
@@ -335,6 +409,8 @@ export interface FeathersAdapterOptions {
   defaultPagination?: FeathersPagination
   /** Pagination overrides selected by Feathers service path. */
   pagination?: Record<string, FeathersPagination>
+  /** Opt-in atomic transaction transport. Omit when the backend has no such capability. */
+  transactions?: FeathersTransaction
 }
 
 /**
@@ -362,6 +438,7 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
   #operators: Record<string, CustomOperatorRegistration>
   #defaultPagination: FeathersPagination | undefined
   #pagination: Record<string, FeathersPagination>
+  transaction?: Adapter['transaction']
 
   /** Names of custom operators registered for every service. */
   get customOperators(): readonly string[] {
@@ -409,6 +486,7 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
       operators = {},
       defaultPagination,
       pagination = {},
+      transactions,
     }: FeathersAdapterOptions = {},
   ) {
     this.feathers = feathers
@@ -419,6 +497,9 @@ export class FeathersAdapter<TQuery = Record<string, unknown>> implements Adapte
     this.#operators = operators
     this.#defaultPagination = defaultPagination
     this.#pagination = pagination
+    if (transactions) {
+      this.transaction = operations => transactions(this.feathers, operations)
+    }
   }
 
   #paginationFor(serviceName: string): FeathersPagination | undefined {

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -76,6 +76,7 @@ import type {
 } from './schema.js'
 import { resolveServicePath } from './schema.js'
 import { isWithinStaleTime, validatePrefetchStaleTime, validateStaleTime } from './staleTime.js'
+import { createTransactionContext, type TransactionContext } from './transactions.js'
 
 const MAX_WINDOW_QUERY_CACHE_SIZE = 20
 
@@ -110,6 +111,11 @@ export type {
   MutationsProxy,
   WriteMutationOptions,
 } from './mutations.js'
+export type {
+  TransactionContext,
+  TransactionMutationsHandle,
+  TransactionMutationsProxy,
+} from './transactions.js'
 export {
   defineMutationQueue,
   MutationQueueDiscardedError,
@@ -784,6 +790,45 @@ export class Figbird<
       this.#mutationsProxy = createMutationsProxy(host) as MutationsProxy<S>
     }
     return this.#mutationsProxy
+  }
+
+  /**
+   * Atomically commit several typed CRUD mutations through the configured
+   * adapter. The callback is a synchronous collector: its calls project as one
+   * cache update, wait for affected record lanes, and execute in collection
+   * order within one server transaction. Generate create ids before collecting.
+   * No sequential-request fallback is provided.
+   */
+  transaction(collect: (transaction: TransactionContext<S>) => undefined): Promise<void> {
+    if (!this.queryStore.supportsTransactions) {
+      throw new Error('figbird: the configured adapter does not support transactions')
+    }
+    const transaction = createTransactionContext<S>()
+    let returned: unknown
+    try {
+      returned = collect(transaction.context)
+    } catch (error) {
+      // Close on failure too, so a leaked handle cannot append work later.
+      transaction.close()
+      throw error
+    }
+    if (
+      returned !== null &&
+      (typeof returned === 'object' || typeof returned === 'function') &&
+      'then' in returned &&
+      typeof (returned as { then?: unknown }).then === 'function'
+    ) {
+      transaction.close()
+      // The callback may continue after its first await and hit the closed
+      // collector. Observe that misuse promise so it cannot become unhandled.
+      void Promise.resolve(returned).catch(() => {})
+      throw new Error('figbird: transaction callbacks must be synchronous')
+    }
+    const descs = transaction.close().map(desc => ({
+      ...desc,
+      serviceName: resolveServicePath(this.schema, desc.serviceName),
+    }))
+    return this.queryStore.transaction(descs)
   }
 
   /**

--- a/lib/core/mutationLanes.ts
+++ b/lib/core/mutationLanes.ts
@@ -142,6 +142,22 @@ export class MutationLanes<TEntry extends MutationLaneEntry> {
     entry: TEntry,
     outcome: MutationOutcome,
   ): LaneSettlement<TEntry> | null {
+    return this.#complete(lane, entry, outcome)
+  }
+
+  /**
+   * Remove an entry that will never reach the adapter while preserving the
+   * create/remove lifetime rules that apply to an ordinary failed mutation.
+   */
+  abort(lane: MutationLane, entry: TEntry, error: Error): LaneSettlement<TEntry> | null {
+    return this.#complete(lane, entry, { ok: false, error })
+  }
+
+  #complete(
+    lane: MutationLane,
+    entry: TEntry,
+    outcome: MutationOutcome,
+  ): LaneSettlement<TEntry> | null {
     const state = this.#lanes.get(lane.key)
     if (state !== lane) return null
     const index = state.entries.indexOf(entry)
@@ -149,18 +165,22 @@ export class MutationLanes<TEntry extends MutationLaneEntry> {
     if (index === -1) return null
 
     state.entries.splice(index, 1)
-    state.running = false
+    if (index === 0) state.running = false
 
     let cancelled: TEntry[] = []
     if (!outcome.ok && entry.desc.method === 'create') {
-      cancelled = state.entries.splice(0)
+      cancelled = state.entries.splice(index)
     } else if (!outcome.ok && entry.desc.method === 'remove') {
-      const nextCreate = state.entries.findIndex(queued => queued.desc.method === 'create')
+      const nextCreate = state.entries.findIndex(
+        (queued, queuedIndex) => queuedIndex >= index && queued.desc.method === 'create',
+      )
       if (nextCreate !== -1) cancelled = state.entries.splice(nextCreate)
     } else if (outcome.ok && entry.desc.method === 'remove') {
-      const nextCreate = state.entries.findIndex(queued => queued.desc.method === 'create')
+      const nextCreate = state.entries.findIndex(
+        (queued, queuedIndex) => queuedIndex >= index && queued.desc.method === 'create',
+      )
       const end = nextCreate === -1 ? state.entries.length : nextCreate
-      cancelled = state.entries.splice(0, end)
+      cancelled = state.entries.splice(index, end - index)
     }
     let authoritativeEvent: ProcessedServerEvent | null = null
 

--- a/lib/core/mutations.ts
+++ b/lib/core/mutations.ts
@@ -96,11 +96,11 @@ type CustomMethods<S extends Schema, N extends ServiceNames<S>> = {
   ) => Promise<MethodData<ServiceMethods<S, N>[M]>>
 }
 
-type CreateOptionsFor<TItem, TOptimistic extends boolean> = TOptimistic extends true
+export type CreateOptionsFor<TItem, TOptimistic extends boolean> = TOptimistic extends true
   ? CreateMutationOptions<TItem>
   : MutationParamsOptions
 
-type WriteOptionsFor<TItem, TOptimistic extends boolean> = TOptimistic extends true
+export type WriteOptionsFor<TItem, TOptimistic extends boolean> = TOptimistic extends true
   ? WriteMutationOptions<TItem>
   : MutationParamsOptions
 
@@ -164,7 +164,7 @@ export interface MutationsHost {
   call(serviceName: string, method: string, args: unknown[]): Promise<unknown>
 }
 
-interface HandleConfig {
+export interface CrudHandleConfig {
   /** false → confirmed variant: the cache updates only after the server acks. */
   optimistic: boolean
 }
@@ -174,7 +174,19 @@ type RuntimeMutationOptions = MutationParamsOptions & {
   optimisticPatch?: unknown
 }
 
-function createHandle(host: MutationsHost, serviceName: string, config: HandleConfig): object {
+type CrudHandleDecorator = (base: Record<string, unknown>) => object
+
+/**
+ * Build the canonical CRUD descriptor surface shared by ordinary mutations and
+ * transaction collectors. A decorator may add custom-method behavior without
+ * duplicating descriptor construction or confirmed-handle policy. @internal
+ */
+export function createCrudHandle(
+  dispatch: (desc: MutationDescriptor) => unknown,
+  serviceName: string,
+  config: CrudHandleConfig,
+  decorate: CrudHandleDecorator = base => base,
+): object {
   const { optimistic } = config
 
   const resolveOptimistic = (options?: RuntimeMutationOptions) =>
@@ -182,7 +194,7 @@ function createHandle(host: MutationsHost, serviceName: string, config: HandleCo
 
   const base: Record<string, unknown> = {
     create: (data: unknown, options?: RuntimeMutationOptions) =>
-      host.mutate({
+      dispatch({
         serviceName,
         method: 'create',
         data,
@@ -190,7 +202,7 @@ function createHandle(host: MutationsHost, serviceName: string, config: HandleCo
         optimistic: resolveOptimistic(options),
       }),
     update: (id: string | number, data: unknown, options?: RuntimeMutationOptions) =>
-      host.mutate({
+      dispatch({
         serviceName,
         method: 'update',
         id,
@@ -202,7 +214,7 @@ function createHandle(host: MutationsHost, serviceName: string, config: HandleCo
           : {}),
       }),
     patch: (id: string | number, data: unknown, options?: RuntimeMutationOptions) =>
-      host.mutate({
+      dispatch({
         serviceName,
         method: 'patch',
         id,
@@ -214,7 +226,7 @@ function createHandle(host: MutationsHost, serviceName: string, config: HandleCo
           : {}),
       }),
     remove: (id: string | number, options?: RuntimeMutationOptions) =>
-      host.mutate({
+      dispatch({
         serviceName,
         method: 'remove',
         id,
@@ -222,7 +234,6 @@ function createHandle(host: MutationsHost, serviceName: string, config: HandleCo
         // remove has no payload to synthesize — optimistic is boolean-only here
         optimistic,
       }),
-    call: (method: string, ...args: unknown[]) => host.call(serviceName, method, args),
   }
 
   if (optimistic) {
@@ -230,24 +241,66 @@ function createHandle(host: MutationsHost, serviceName: string, config: HandleCo
     let confirmedVariant: object | null = null
     Object.defineProperty(base, 'confirmed', {
       enumerable: false,
-      get: () => (confirmedVariant ??= createHandle(host, serviceName, { optimistic: false })),
+      get: () =>
+        (confirmedVariant ??= createCrudHandle(
+          dispatch,
+          serviceName,
+          { optimistic: false },
+          decorate,
+        )),
     })
   }
 
-  return new Proxy(base, {
-    get(target, prop, receiver) {
-      // `in` includes the prototype chain, so Object.prototype members resolve
-      // normally instead of becoming calls.
-      if (typeof prop === 'symbol' || prop in target) {
-        return Reflect.get(target, prop, receiver)
-      }
-      // A callable `then` makes the handle thenable: returning one from an async
-      // function would make the `await` invoke it and hang forever, unsettled.
-      if (prop === 'then') return undefined
-      // A callable `toJSON` would turn JSON.stringify(handle) — logging, error
-      // reporting — into a phantom network write.
-      if (prop === 'toJSON') return undefined
-      return (...args: unknown[]) => host.call(serviceName, prop, args)
+  return decorate(base)
+}
+
+function createHandle(host: MutationsHost, serviceName: string, config: CrudHandleConfig): object {
+  return createCrudHandle(
+    desc => host.mutate(desc),
+    serviceName,
+    config,
+    base => {
+      base.call = (method: string, ...args: unknown[]) => host.call(serviceName, method, args)
+      return new Proxy(base, {
+        get(target, prop, receiver) {
+          // `in` includes the prototype chain, so Object.prototype members resolve
+          // normally instead of becoming calls.
+          if (typeof prop === 'symbol' || prop in target) {
+            return Reflect.get(target, prop, receiver)
+          }
+          // A callable `then` makes the handle thenable: returning one from an async
+          // function would make the `await` invoke it and hang forever, unsettled.
+          if (prop === 'then') return undefined
+          // A callable `toJSON` would turn JSON.stringify(handle) — logging, error
+          // reporting — into a phantom network write.
+          if (prop === 'toJSON') return undefined
+          return (...args: unknown[]) => host.call(serviceName, prop, args)
+        },
+      })
+    },
+  )
+}
+
+/** Build a callable, property-addressable proxy with interned service handles. @internal */
+export function createServiceHandleProxy(createHandle: (serviceName: string) => object): object {
+  const handles = new Map<string, object>()
+  const handleFor = (serviceName: string): object => {
+    let handle = handles.get(serviceName)
+    if (!handle) {
+      handle = createHandle(serviceName)
+      handles.set(serviceName, handle)
+    }
+    return handle
+  }
+
+  const callable = (serviceName: string) => handleFor(serviceName)
+  return new Proxy(callable as object, {
+    apply(_target, _thisArg, [serviceName]: [string]) {
+      return handleFor(serviceName)
+    },
+    get(_target, prop) {
+      if (typeof prop === 'symbol') return undefined
+      return handleFor(prop)
     },
   })
 }
@@ -259,28 +312,11 @@ function createHandle(host: MutationsHost, serviceName: string, config: HandleCo
  * known protocol prop becomes a call to that custom method. @internal
  */
 export function createMutationsProxy(host: MutationsHost): object {
-  const handles = new Map<string, object>()
-  const handleFor = (serviceName: string): object => {
-    let handle = handles.get(serviceName)
-    if (!handle) {
-      handle = createHandle(host, serviceName, { optimistic: true })
-      handles.set(serviceName, handle)
-    }
-    return handle
-  }
-
   // No protocol guards needed at this level: every string property resolves to a
   // handle OBJECT (not a function) — including function-target props like `call`
   // or `name` — so probes like `then` or `toJSON` are never callable here and
   // `await m` / JSON.stringify(m) behave inertly.
-  const callable = (serviceName: string) => handleFor(serviceName)
-  return new Proxy(callable as object, {
-    apply(_target, _thisArg, [serviceName]: [string]) {
-      return handleFor(serviceName)
-    },
-    get(_target, prop) {
-      if (typeof prop === 'symbol') return undefined
-      return handleFor(prop)
-    },
-  })
+  return createServiceHandleProxy(serviceName =>
+    createHandle(host, serviceName, { optimistic: true }),
+  )
 }

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -1,6 +1,7 @@
 import {
   locallySupportedOperators,
   type Adapter,
+  type AdapterTransactionOperation,
   type PageResponse,
   type QueryResponse,
 } from '../adapters/adapter.js'
@@ -27,7 +28,9 @@ import {
   ABSENT,
   MUTATION_EVENT_TYPE,
   MutationLanes,
+  type LaneSettlement,
   type MutationLane,
+  type MutationOutcome,
   type ProjectionChange,
 } from './mutationLanes.js'
 import {
@@ -36,7 +39,7 @@ import {
   applyVisibleEventToQuery,
   createServiceState,
   diffCompleteSet,
-  groupQueuedEvents,
+  groupEventsByService,
   isUnfilteredFindQuery,
   replayFetchedQueryFromEvents,
   reapplyQueryFromEntities,
@@ -141,6 +144,13 @@ interface QueuedMutation {
   optimistic: boolean
   attempt: GatedMutationAttempt
   cause?: MutationTraceCause
+  transaction?: QueuedTransaction
+}
+
+interface QueuedTransaction {
+  entries: Array<{ lane: MutationLane; entry: QueuedMutation }>
+  readyLaneKeys: Set<string>
+  status: 'waiting' | 'running' | 'settled' | 'aborted'
 }
 
 interface AppliedEventEffect {
@@ -251,6 +261,8 @@ export class QueryStore<
   #warnedMissingIdServices: Set<string> = new Set()
 
   #eventQueue: QueuedEvent[] = []
+  // Lane bases already contain these acknowledgements; only query publication remains.
+  #appliedEventQueue: ProcessedCacheEvent[] = []
   #eventBatchProcessingTimer: ReturnType<typeof setTimeout> | null = null
   #eventBatchInterval: number | undefined = 100
   #processingEventQueue = false
@@ -712,6 +724,110 @@ export class QueryStore<
     return this.registerMutation(desc).promise as Promise<InferMutationData<S, D>>
   }
 
+  /** Whether the configured adapter promises atomic multi-mutation commits. */
+  get supportsTransactions(): boolean {
+    return this.#adapter.transaction !== undefined
+  }
+
+  /** Commit several keyed CRUD mutations through the adapter's atomic capability. */
+  transaction(descs: readonly MutationDescriptor[]): Promise<void> {
+    if (!this.#adapter.transaction) {
+      throw new Error('figbird: the configured adapter does not support transactions')
+    }
+    if (descs.length === 0) return Promise.resolve()
+
+    const keys = new Set<string>()
+    const planned = descs.map(desc => {
+      if (desc.method === 'create' && Array.isArray(desc.data)) {
+        throw new Error(
+          'figbird: transaction create calls accept one item; collect multiple create calls instead',
+        )
+      }
+      const id = desc.method === 'create' ? this.#peekId(desc.data) : desc.id
+      if (id === undefined || id === null) {
+        throw new Error(
+          `figbird: transaction ${desc.method} on "${desc.serviceName}" requires a stable entity id`,
+        )
+      }
+      if (desc.method === 'create') {
+        const optimisticId = this.#peekId(resolveCreateOptimisticItem(desc))
+        if (optimisticId === undefined || entityKey(optimisticId) !== entityKey(id)) {
+          throw new Error(
+            `figbird: transaction create on "${desc.serviceName}" must preserve its payload id in the optimistic item`,
+          )
+        }
+      }
+      const key = JSON.stringify([desc.serviceName, entityKey(id)])
+      if (keys.has(key)) {
+        throw new Error(
+          `figbird: a transaction can mutate "${desc.serviceName}"/${String(id)} only once`,
+        )
+      }
+      keys.add(key)
+      return {
+        desc,
+        id,
+        args: this.#buildMutationArgs(desc),
+        optimistic: desc.optimistic != null && desc.optimistic !== false,
+      }
+    })
+
+    const transaction: QueuedTransaction = {
+      entries: [],
+      readyLaneKeys: new Set(),
+      status: 'waiting',
+    }
+    const promises: Promise<unknown>[] = []
+
+    for (const operation of planned) {
+      const lane = this.#mutationLanes.ensure(
+        operation.desc.serviceName,
+        operation.id,
+        this.#getEntity(operation.desc.serviceName, operation.id),
+      )
+      const entry: QueuedMutation = {
+        desc: operation.desc,
+        args: operation.args,
+        optimistic: operation.optimistic,
+        attempt: new GatedMutationAttempt(),
+        transaction,
+      }
+      transaction.entries.push({ lane, entry })
+      const tracked = this.#trackMutation(
+        {
+          serviceName: operation.desc.serviceName,
+          method: operation.desc.method,
+          id: operation.id,
+          optimistic: operation.optimistic,
+          args: operation.args,
+        },
+        () => entry.attempt.promise,
+        {
+          onError: (_error, { mutationId, cause }) => {
+            if (!operation.optimistic) return
+            this.#telemetry.emit({
+              kind: 'mutate:rollback',
+              mutationId,
+              ...(cause ? { traceId: cause.traceId } : {}),
+              serviceName: operation.desc.serviceName,
+              method: operation.desc.method,
+              id: operation.id,
+            })
+          },
+        },
+      )
+      if (tracked.cause) entry.cause = tracked.cause
+      promises.push(tracked.promise)
+      this.#applyProjection(this.#mutationLanes.enqueue(lane, entry), false, tracked.cause)
+    }
+
+    // All affected services are projected before observers are notified.
+    this.#processQueuedEvents()
+    for (const { lane } of transaction.entries) this.#drainMutationLane(lane)
+
+    return Promise.all(promises).then(() => undefined)
+  }
+
   /**
    * Run one confirmed mutation without record-lane scheduling. This preserves the
    * transport behavior of deprecated `useMutation`: a caller may time out a hung
@@ -949,11 +1065,95 @@ export class QueryStore<
       this.#releaseMutationLane(lane)
       return
     }
+    if (entry.transaction) {
+      entry.transaction.readyLaneKeys.add(lane.key)
+      if (entry.transaction.readyLaneKeys.size === entry.transaction.entries.length) {
+        this.#startTransaction(entry.transaction)
+      }
+      return
+    }
     entry.attempt.start(() =>
       this.#runControlledAttempt(entry.attempt.control, () =>
         this.#adapter.mutate(lane.serviceName, entry.desc.method, [...entry.args]),
       ),
     )
+  }
+
+  #startTransaction(transaction: QueuedTransaction): void {
+    if (transaction.status !== 'waiting') return
+    transaction.status = 'running'
+
+    const operations: AdapterTransactionOperation[] = transaction.entries.map(
+      ({ lane, entry }) => ({
+        serviceName: lane.serviceName,
+        method: entry.desc.method,
+        args: [...entry.args],
+      }),
+    )
+    let transport: Promise<readonly unknown[]>
+    try {
+      transport = Promise.resolve(this.#adapter.transaction!(operations))
+    } catch (error) {
+      transport = Promise.reject(error)
+    }
+
+    const checked = transport.then(results => {
+      if (!Array.isArray(results) || results.length !== transaction.entries.length) {
+        throw new Error(
+          `figbird: adapter transaction returned ${Array.isArray(results) ? results.length : 'an invalid number of'} results for ${transaction.entries.length} operations`,
+        )
+      }
+      return results
+    })
+    const settled = checked.then(
+      results => {
+        this.#settleTransaction(transaction, { ok: true, results })
+        return results
+      },
+      (err: unknown) => {
+        const error = err instanceof Error ? err : new Error(String(err))
+        this.#settleTransaction(transaction, { ok: false, error })
+        throw error
+      },
+    )
+
+    transaction.entries.forEach(({ entry }, index) => {
+      entry.attempt.start(() => settled.then(results => results[index]))
+    })
+  }
+
+  #abortTransaction(transaction: QueuedTransaction, error: Error, lanes: Set<MutationLane>): void {
+    if (transaction.status !== 'waiting') return
+    transaction.status = 'aborted'
+
+    for (const { lane, entry } of transaction.entries) {
+      const outcome = { ok: false, error } as const
+      const settlement = this.#mutationLanes.abort(lane, entry, error)
+      if (settlement) {
+        this.#applyLaneSettlement(lane, entry, outcome, settlement, lanes)
+      }
+      entry.attempt.cancel(error)
+    }
+  }
+
+  #settleTransaction(
+    transaction: QueuedTransaction,
+    outcome: { ok: true; results: readonly unknown[] } | { ok: false; error: Error },
+  ): void {
+    if (transaction.status !== 'running') return
+    transaction.status = 'settled'
+    const lanes = new Set<MutationLane>()
+    transaction.entries.forEach(({ lane, entry }, index) => {
+      const entryOutcome = outcome.ok
+        ? ({ ok: true, item: outcome.results[index] } as const)
+        : ({ ok: false, error: outcome.error } as const)
+      const settlement = this.#mutationLanes.settle(lane, entry, entryOutcome)
+      if (!settlement) return
+      this.#applyLaneSettlement(lane, entry, entryOutcome, settlement, lanes)
+    })
+
+    // Success and rollback are each one observer-visible cache transition across services.
+    this.#finishLaneSettlements(lanes)
   }
 
   #expediteMutationPredecessors(lane: MutationLane, entry: QueuedMutation): void {
@@ -1003,6 +1203,21 @@ export class QueryStore<
     const settlement = this.#mutationLanes.settle(lane, entry, outcome)
     if (!settlement) return
 
+    const lanes = new Set<MutationLane>()
+    this.#applyLaneSettlement(lane, entry, outcome, settlement, lanes, cause)
+    this.#finishLaneSettlements(lanes)
+  }
+
+  #applyLaneSettlement(
+    lane: MutationLane,
+    entry: QueuedMutation,
+    outcome: MutationOutcome,
+    settlement: LaneSettlement<QueuedMutation>,
+    lanes: Set<MutationLane>,
+    cause: TraceCause | undefined = entry.cause,
+  ): void {
+    lanes.add(lane)
+
     // A mutation acknowledgement is authoritative even when remaining overlays
     // keep the visible projection unchanged. Recording it protects fetches that
     // began before the acknowledgement from replacing the newer server state.
@@ -1010,27 +1225,49 @@ export class QueryStore<
       this.#fetchEventJournal.record([settlement.authoritativeEvent])
     }
 
-    const projected = this.#applyProjection(settlement.projection, true, cause)
+    const projected = this.#applyProjection(settlement.projection, false, cause)
     if (!projected && settlement.authoritativeEvent && !this.#mutationLanes.peekNext(lane)) {
-      this.#publishAppliedEvent(settlement.authoritativeEvent)
+      this.#appliedEventQueue.push(settlement.authoritativeEvent)
     }
 
-    if (settlement.cancelled.length > 0) {
-      const reason = outcome.ok
-        ? 'because the record was removed'
-        : entry.desc.method === 'create'
-          ? 'because its create mutation failed'
-          : 'because the preceding remove mutation failed'
-      for (const queued of settlement.cancelled) {
-        queued.attempt.cancel(
+    this.#cancelSettledDependants(lane, entry, outcome, settlement.cancelled, lanes)
+  }
+
+  #finishLaneSettlements(lanes: ReadonlySet<MutationLane>): void {
+    this.#processQueuedEvents()
+    for (const lane of lanes) this.#drainMutationLane(lane)
+  }
+
+  #cancelSettledDependants(
+    lane: MutationLane,
+    entry: QueuedMutation,
+    outcome: { ok: true; item: unknown } | { ok: false; error: Error },
+    cancelled: readonly QueuedMutation[],
+    lanes: Set<MutationLane>,
+  ): void {
+    if (cancelled.length === 0) return
+    const reason = outcome.ok
+      ? 'because the record was removed'
+      : entry.desc.method === 'create'
+        ? 'because its create mutation failed'
+        : 'because the preceding remove mutation failed'
+    for (const queued of cancelled) {
+      if (queued.transaction) {
+        this.#abortTransaction(
+          queued.transaction,
           new MutationSupersededError(
-            `figbird: cancelled queued mutations for "${lane.serviceName}"/${String(lane.id)} ${reason}`,
+            `figbird: cancelled transaction for "${lane.serviceName}"/${String(lane.id)} ${reason}`,
           ),
+          lanes,
         )
+        continue
       }
+      queued.attempt.cancel(
+        new MutationSupersededError(
+          `figbird: cancelled queued mutations for "${lane.serviceName}"/${String(lane.id)} ${reason}`,
+        ),
+      )
     }
-
-    this.#drainMutationLane(lane)
   }
 
   #applyProjection(change: ProjectionChange, immediate: boolean, cause?: TraceCause): boolean {
@@ -2214,38 +2451,21 @@ export class QueryStore<
     return cause ? { causes: [cause] } : {}
   }
 
-  /** Publish an authoritative transition whose entity-cache effect already happened. */
-  #publishAppliedEvent(event: ProcessedCacheEvent): void {
-    let effects: AppliedEventEffect[] = []
-    const touched = this.#transactOverServiceByName(event.serviceName, (service, touch) => {
-      effects = this.#updateQueriesForEvents({
-        service,
-        serviceName: event.serviceName,
-        processedEvents: [event],
-        touch,
-      })
-    })
-    this.#notify(touched)
-    const published = this.#publishServiceEventEffects(event.serviceName, effects, 'realtime')
-    for (const queryId of published.reconcileQueryIds) {
-      this.#requestReconcile(queryId, {
-        ...(published.reconcileCauses.has(queryId)
-          ? { causes: published.reconcileCauses.get(queryId)! }
-          : {}),
-      })
-    }
-  }
-
   #processQueuedEvents(): void {
-    if (this.#processingEventQueue || this.#eventQueue.length === 0) {
+    if (
+      this.#processingEventQueue ||
+      (this.#eventQueue.length === 0 && this.#appliedEventQueue.length === 0)
+    ) {
       return
     }
 
     this.#processingEventQueue = true
     try {
-      while (this.#eventQueue.length > 0) {
-        const eventsByService = groupQueuedEvents(this.#eventQueue)
+      while (this.#eventQueue.length > 0 || this.#appliedEventQueue.length > 0) {
+        const eventsByService = groupEventsByService(this.#eventQueue)
+        const appliedEventsByService = groupEventsByService(this.#appliedEventQueue)
         this.#eventQueue = []
+        this.#appliedEventQueue = []
 
         const touchedQueryIds = new Set<string>()
         const followups: Array<{
@@ -2258,16 +2478,33 @@ export class QueryStore<
         // query spanning services A and B compute a wasted intermediate snapshot
         // after A's events but before B's, and non-React subscribers would observe
         // the intermediate state.
-        for (const [serviceName, events] of Object.entries(eventsByService)) {
+        const serviceNames = new Set([
+          ...Object.keys(eventsByService),
+          ...Object.keys(appliedEventsByService),
+        ])
+        for (const serviceName of serviceNames) {
+          const events = eventsByService[serviceName] ?? []
+          const appliedEvents = appliedEventsByService[serviceName] ?? []
           let effects: AppliedEventEffect[] = []
+          let appliedEffects: AppliedEventEffect[] = []
 
           const modifiedQueries = this.#transactOverServiceByName(serviceName, (service, touch) => {
-            effects = this.#applyServiceEvents({
-              service,
-              serviceName,
-              events,
-              touch,
-            })
+            if (events.length > 0) {
+              effects = this.#applyServiceEvents({
+                service,
+                serviceName,
+                events,
+                touch,
+              })
+            }
+            if (appliedEvents.length > 0) {
+              appliedEffects = this.#updateQueriesForEvents({
+                service,
+                serviceName,
+                processedEvents: appliedEvents,
+                touch,
+              })
+            }
           })
 
           // Record only events that actually changed the entity cache. The fetch
@@ -2277,7 +2514,7 @@ export class QueryStore<
           for (const queryId of modifiedQueries) {
             touchedQueryIds.add(queryId)
           }
-          followups.push({ serviceName, effects })
+          followups.push({ serviceName, effects: [...effects, ...appliedEffects] })
         }
 
         // Notify once per batch, after all services have applied.

--- a/lib/core/transactions.ts
+++ b/lib/core/transactions.ts
@@ -1,0 +1,82 @@
+import type { MutationDescriptor } from './queryTypes.js'
+import type {
+  Schema,
+  ServiceCreate,
+  ServiceItem,
+  ServiceNames,
+  ServicePatch,
+  ServiceUpdate,
+} from './schema.js'
+import type { CreateOptionsFor, MutationParamsOptions, WriteOptionsFor } from './mutations.js'
+import { createCrudHandle, createServiceHandleProxy } from './mutations.js'
+
+interface TransactionHandleVerbs<
+  S extends Schema,
+  N extends ServiceNames<S>,
+  TOptimistic extends boolean,
+> {
+  create(
+    data: ServiceCreate<S, N>,
+    options?: CreateOptionsFor<ServiceItem<S, N>, TOptimistic>,
+  ): undefined
+  update(
+    id: string | number,
+    data: ServiceUpdate<S, N>,
+    options?: WriteOptionsFor<ServiceItem<S, N>, TOptimistic>,
+  ): undefined
+  patch(
+    id: string | number,
+    data: ServicePatch<S, N>,
+    options?: WriteOptionsFor<ServiceItem<S, N>, TOptimistic>,
+  ): undefined
+  remove(id: string | number, options?: MutationParamsOptions): undefined
+}
+
+/** Typed CRUD collector for one service inside a transaction. */
+export type TransactionMutationsHandle<
+  S extends Schema,
+  N extends ServiceNames<S>,
+> = TransactionHandleVerbs<S, N, true> & {
+  /** Collect a mutation without projecting it before the transaction commits. */
+  readonly confirmed: TransactionHandleVerbs<S, N, false>
+}
+
+/** The transaction-scoped counterpart of `figbird.m`. Calls collect work without a result. */
+export type TransactionMutationsProxy<S extends Schema> = {
+  <N extends ServiceNames<S>>(serviceName: N): TransactionMutationsHandle<S, N>
+  (serviceName: string): TransactionMutationsHandle<S, ServiceNames<S>>
+} & {
+  readonly [N in ServiceNames<S>]: TransactionMutationsHandle<S, N>
+}
+
+/** Context passed to `figbird.transaction()`. */
+export interface TransactionContext<S extends Schema> {
+  readonly m: TransactionMutationsProxy<S>
+}
+
+/** Build a transaction-scoped collector and expose the descriptors after the callback. @internal */
+export function createTransactionContext<S extends Schema>(): {
+  context: TransactionContext<S>
+  close(): readonly MutationDescriptor[]
+} {
+  const descriptors: MutationDescriptor[] = []
+  let active = true
+
+  const collect = (desc: MutationDescriptor): undefined => {
+    if (!active) {
+      throw new Error('figbird: transaction mutations can only be collected synchronously')
+    }
+    descriptors.push(desc)
+  }
+  const m = createServiceHandleProxy(serviceName =>
+    createCrudHandle(collect, serviceName, { optimistic: true }),
+  ) as TransactionMutationsProxy<S>
+
+  return {
+    context: { m },
+    close: () => {
+      active = false
+      return descriptors
+    },
+  }
+}

--- a/lib/core/windowMaintenance.ts
+++ b/lib/core/windowMaintenance.ts
@@ -140,8 +140,10 @@ function findInsertIndex(
   return lo
 }
 
-export function groupQueuedEvents(events: QueuedEvent[]): Record<string, QueuedEvent[]> {
-  const eventsByService: Record<string, QueuedEvent[]> = {}
+export function groupEventsByService<TEvent extends { serviceName: string }>(
+  events: readonly TEvent[],
+): Record<string, TEvent[]> {
+  const eventsByService: Record<string, TEvent[]> = {}
   for (const event of events) {
     if (!eventsByService[event.serviceName]) {
       eventsByService[event.serviceName] = []

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -106,7 +106,7 @@ export type { RelationalQueryState } from './core/figbird.js'
 export {
   cursorPagination,
   FeathersAdapter,
-  feathersBatchTransactions,
+  feathersTransactions,
   FeathersTransactionError,
   offsetPagination,
 } from './adapters/feathers.js'
@@ -116,11 +116,11 @@ export type {
   CustomOperatorContext,
   CustomOperatorRegistration,
   FeathersAdapterOptions,
-  FeathersBatchTransactionsOptions,
   FeathersCursorPagination,
   FeathersOffsetPagination,
   FeathersPagination,
   FeathersTransaction,
+  FeathersTransactionsOptions,
 } from './adapters/feathers.js'
 export { matcher } from './adapters/matcher.js'
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -44,6 +44,9 @@ export type {
   ReconnectJitter,
   RetryDelay,
   StandardSchemaV1,
+  TransactionContext,
+  TransactionMutationsHandle,
+  TransactionMutationsProxy,
   VisibilitySource,
   WriteMutationOptions,
 } from './core/figbird.js'
@@ -100,16 +103,24 @@ export { RelationalQueryRef } from './core/figbird.js'
 export type { RelationalQueryState } from './core/figbird.js'
 
 // adapters
-export { cursorPagination, FeathersAdapter, offsetPagination } from './adapters/feathers.js'
+export {
+  cursorPagination,
+  FeathersAdapter,
+  feathersBatchTransactions,
+  FeathersTransactionError,
+  offsetPagination,
+} from './adapters/feathers.js'
 export type {
   CursorPaginationOptions,
   CustomOperator,
   CustomOperatorContext,
   CustomOperatorRegistration,
   FeathersAdapterOptions,
+  FeathersBatchTransactionsOptions,
   FeathersCursorPagination,
   FeathersOffsetPagination,
   FeathersPagination,
+  FeathersTransaction,
 } from './adapters/feathers.js'
 export { matcher } from './adapters/matcher.js'
 
@@ -119,6 +130,7 @@ export type {
   AdapterFindMeta,
   AdapterParams,
   AdapterQuery,
+  AdapterTransactionOperation,
   EventHandlers,
   MatcherContext,
   PageCursor,

--- a/test/fixtures/mutations-inference.ts
+++ b/test/fixtures/mutations-inference.ts
@@ -25,6 +25,7 @@ interface SendDocumentResult {
 
 interface EsignInstanceService {
   item: EsignInstance
+  patch: Partial<EsignInstance>
   methods: {
     requestSendDocument: (id: string, options?: SendDocumentOptions) => Promise<SendDocumentResult>
     voidDocument: (id: string, reason: string) => Promise<{ id: string; voided: true }>
@@ -64,6 +65,25 @@ export type ConfirmedResult = Awaited<typeof confirmedPromise>
 // CRUD stays typed from the service definition.
 const patchPromise = m['api/esign-instances'].patch('esign_1', { status: 'sent' })
 export type PatchResult = Awaited<typeof patchPromise>
+
+// Transactions reuse the schema-typed CRUD surface but collect synchronously.
+export const transactionPromise = figbird.transaction(tx => {
+  tx.m['api/esign-instances'].patch('esign_1', { status: 'sent' })
+  tx.m['api/messages'].confirmed.create({ id: 'message_1', body: 'Ready' })
+  // @ts-expect-error - transaction patches retain the service patch type
+  tx.m['api/esign-instances'].patch('esign_1', { status: 'void' })
+  // @ts-expect-error - the transaction DSL does not imply custom methods are atomic
+  tx.m['api/esign-instances'].requestSendDocument('esign_1')
+})
+
+export const conciseTransactionPromise = figbird.transaction(tx =>
+  tx.m['api/messages'].create({ id: 'message_2', body: 'Ready' }),
+)
+
+// @ts-expect-error - transaction callbacks must collect synchronously
+figbird.transaction(async tx => {
+  tx.m['api/esign-instances'].patch('esign_1', { status: 'sent' })
+})
 
 // Projection options are available only where the runtime applies them.
 m['api/esign-instances'].create(

--- a/test/mutations.test.ts
+++ b/test/mutations.test.ts
@@ -1,5 +1,10 @@
 import test from 'ava'
-import type { FigbirdEvent, QueryState } from '../lib'
+import {
+  feathersBatchTransactions,
+  FeathersTransactionError,
+  type FigbirdEvent,
+  type QueryState,
+} from '../lib'
 import { createTestApp } from './helpers'
 import {
   collectEvents,
@@ -13,8 +18,11 @@ import {
 
 // ----- the m proxy -----
 
-test('m: writes are optimistic by default; confirmed opts out per handle or inline', async t => {
-  const { figbird } = createTestApp(schema, services())
+test('m: write policies and ordered transactions share record lanes', async t => {
+  const { figbird, adapter, feathers } = createTestApp(schema, {
+    ...services(),
+    'api/batch': { data: {} },
+  })
   const { m } = figbird
   const events = collectEvents(figbird, 'mutate:')
 
@@ -26,12 +34,211 @@ test('m: writes are optimistic by default; confirmed opts out per handle or inli
   const policies = m.notes.confirmed // named surface handle
   await policies.patch(1, { content: 'third' })
 
+  let transactionOperations: readonly unknown[] = []
+  let transactionCalls = 0
+  const parent = { id: 10, content: 'parent' }
+  const child = { id: 11, content: 'child', parentId: parent.id }
+  let batchPayload: unknown
+  feathers.service('api/batch').create = ((data: unknown) => {
+    batchPayload = data
+    return Promise.resolve({
+      id: 'batch_1',
+      data: [
+        { status: 'fulfilled', value: { id: 1, content: 'transactional' } },
+        { status: 'fulfilled', value: { id: 1, name: 'Grace' } },
+        { status: 'fulfilled', value: parent },
+        { status: 'fulfilled', value: child },
+      ],
+    })
+  }) as never
+  const transact = feathersBatchTransactions()
+  adapter.transaction = operations => {
+    transactionCalls += 1
+    transactionOperations = operations
+    return transact(feathers, operations)
+  }
+  await figbird.transaction(tx => {
+    tx.m.notes.patch(1, { content: 'transactional' })
+    tx.m.people.confirmed.patch(1, { name: 'Grace' })
+    tx.m.notes.create(parent)
+    tx.m.notes.create(child)
+  })
+  t.deepEqual(transactionOperations, [
+    { serviceName: 'notes', method: 'patch', args: [1, { content: 'transactional' }] },
+    { serviceName: 'api/people', method: 'patch', args: [1, { name: 'Grace' }] },
+    { serviceName: 'notes', method: 'create', args: [parent] },
+    { serviceName: 'notes', method: 'create', args: [child] },
+  ])
+  t.deepEqual(batchPayload, {
+    serial: true,
+    calls: [
+      ['patch', 'notes', 1, { content: 'transactional' }],
+      ['patch', 'api/people', 1, { name: 'Grace' }],
+      ['create', 'notes', parent],
+      ['create', 'notes', child],
+    ],
+  })
+
   await Promise.resolve()
   const starts = events.filter(e => e.kind === 'mutate:start')
   t.deepEqual(
     starts.map(e => e.optimistic),
-    [true, false, false],
+    [true, false, false, true, false, true, true],
   )
+
+  // If one lane invalidates a transaction before another lane reaches the
+  // barrier, an aborted create must still cancel mutations queued behind it.
+  const notePredecessorGate = deferred<MockItem>()
+  const failingPersonCreateGate = deferred<{ id: number; name: string }>()
+  feathers.service('notes').patch = (() => notePredecessorGate.promise) as never
+  feathers.service('api/people').create = (() => failingPersonCreateGate.promise) as never
+
+  const notePredecessor = m.notes.confirmed.patch(99, { content: 'predecessor' })
+  const failingPersonCreate = m.people.create({ id: 77, name: 'draft' })
+  const abortedTransaction = figbird.transaction(tx => {
+    tx.m.notes.create({ id: 99, content: 'transaction create' })
+    tx.m.people.patch(77, { name: 'transaction patch' })
+  })
+  const dependentNotePatch = m.notes.patch(99, { content: 'dependent' })
+
+  const createError = t.throwsAsync(failingPersonCreate, { message: 'create failed' })
+  const transactionError = t.throwsAsync(abortedTransaction, { message: /cancelled transaction/ })
+  const dependentError = t.throwsAsync(dependentNotePatch, {
+    message: /cancelled queued mutations/,
+  })
+  failingPersonCreateGate.reject(new Error('create failed'))
+  await Promise.all([createError, transactionError, dependentError])
+  t.is(transactionCalls, 1, 'the invalidated transaction never reaches the adapter')
+
+  notePredecessorGate.resolve({ id: 99, content: 'predecessor' })
+  await notePredecessor
+})
+
+test('transactions: validate stable, unique entity ids before reserving lanes', t => {
+  const { figbird, adapter } = createTestApp(schema, services())
+  let transactionCalls = 0
+  adapter.transaction = () => {
+    transactionCalls += 1
+    return Promise.resolve([])
+  }
+
+  const error = t.throws(() =>
+    figbird.transaction(tx => {
+      tx.m.notes.patch(1, { content: 'numeric id' })
+      tx.m.notes.patch('1', { content: 'string id' })
+    }),
+  )
+
+  t.regex(error!.message, /can mutate "notes"\/1 only once/)
+  t.throws(
+    () =>
+      figbird.transaction(tx =>
+        tx.m.notes.create({ content: 'missing id' }, { optimisticItem: { id: 10, content: '' } }),
+      ),
+    { message: /requires a stable entity id/ },
+  )
+  t.throws(
+    () =>
+      figbird.transaction(tx =>
+        tx.m.notes.create({ id: 10, content: '' }, { optimisticItem: { id: 11, content: '' } }),
+      ),
+    { message: /must preserve its payload id/ },
+  )
+  t.is(transactionCalls, 0)
+  t.is(figbird.mutating.getSnapshot().length, 0)
+})
+
+test('transactions: commit, cascading cancellation and rollback publish grouped settlements', async t => {
+  const { figbird, adapter, feathers } = createTestApp(schema, {
+    ...services(),
+    'api/batch': { data: {} },
+  })
+  const notesRef = figbird.queryDesc({ serviceName: 'notes', method: 'find' })
+  const peopleRef = figbird.queryDesc({ serviceName: 'api/people', method: 'find' })
+  const unsubscribeNotes = notesRef.subscribe(() => {})
+  const unsubscribePeople = peopleRef.subscribe(() => {})
+  await new Promise(resolve => setTimeout(resolve, 10))
+
+  const transactionGate = deferred<readonly unknown[]>()
+  let transactionCalls = 0
+  adapter.transaction = () => {
+    transactionCalls += 1
+    return transactionGate.promise
+  }
+
+  const committing = figbird.transaction(tx => {
+    tx.m.notes.remove(1)
+    tx.m.people.patch(1, { name: 'optimistic name' })
+  })
+  const cancelled = figbird.transaction(tx => {
+    tx.m.notes.patch(1, { content: 'old lifetime' })
+    tx.m.notes.patch(2, { content: 'doomed sibling' })
+  })
+
+  const snapshots: Array<{
+    hasRemovedNote: boolean
+    siblingContent: string | undefined
+    personName: string | undefined
+  }> = []
+  const unsubscribeState = figbird.subscribeToStateChanges(state => {
+    const notes = state.get('notes')?.entities
+    const people = state.get('api/people')?.entities
+    snapshots.push({
+      hasRemovedNote: notes?.has('1') ?? false,
+      siblingContent: (notes?.get('2') as Note | undefined)?.content,
+      personName: (people?.get('1') as { name: string } | undefined)?.name,
+    })
+  })
+
+  const cancelledError = t.throwsAsync(cancelled, { message: /cancelled transaction/ })
+  transactionGate.resolve([
+    { id: 1, content: 'hello' },
+    { id: 1, name: 'server name' },
+  ])
+  await Promise.all([committing, cancelledError])
+
+  t.is(transactionCalls, 1, 'the cancelled transaction never reaches the adapter')
+  t.deepEqual(snapshots, [
+    {
+      hasRemovedNote: false,
+      siblingContent: 'world',
+      personName: 'server name',
+    },
+  ])
+
+  snapshots.length = 0
+  feathers.service('api/batch').create = (() =>
+    Promise.resolve({
+      data: [
+        { status: 'fulfilled', value: { id: 2, content: 'rolled back on server' } },
+        { status: 'rejected', reason: 'Permission denied' },
+      ],
+    })) as never
+  const transact = feathersBatchTransactions()
+  adapter.transaction = operations => transact(feathers, operations)
+  await t.throwsAsync(
+    figbird.transaction(tx => {
+      tx.m.notes.patch(2, { content: 'optimistic note' })
+      tx.m.people.patch(1, { name: 'optimistic person' })
+    }),
+    { instanceOf: FeathersTransactionError },
+  )
+  t.deepEqual(snapshots, [
+    {
+      hasRemovedNote: false,
+      siblingContent: 'optimistic note',
+      personName: 'optimistic person',
+    },
+    {
+      hasRemovedNote: false,
+      siblingContent: 'world',
+      personName: 'server name',
+    },
+  ])
+
+  unsubscribeState()
+  unsubscribePeople()
+  unsubscribeNotes()
 })
 
 test('m: handles are interned and the confirmed variant is stable', t => {

--- a/test/mutations.test.ts
+++ b/test/mutations.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava'
 import {
-  feathersBatchTransactions,
+  feathersTransactions,
   FeathersTransactionError,
   type FigbirdEvent,
   type QueryState,
@@ -21,7 +21,7 @@ import {
 test('m: write policies and ordered transactions share record lanes', async t => {
   const { figbird, adapter, feathers } = createTestApp(schema, {
     ...services(),
-    'api/batch': { data: {} },
+    'api/transactions': { data: {} },
   })
   const { m } = figbird
   const events = collectEvents(figbird, 'mutate:')
@@ -38,11 +38,11 @@ test('m: write policies and ordered transactions share record lanes', async t =>
   let transactionCalls = 0
   const parent = { id: 10, content: 'parent' }
   const child = { id: 11, content: 'child', parentId: parent.id }
-  let batchPayload: unknown
-  feathers.service('api/batch').create = ((data: unknown) => {
-    batchPayload = data
+  let transactionPayload: unknown
+  feathers.service('api/transactions').create = ((data: unknown) => {
+    transactionPayload = data
     return Promise.resolve({
-      id: 'batch_1',
+      id: 'transaction_1',
       data: [
         { status: 'fulfilled', value: { id: 1, content: 'transactional' } },
         { status: 'fulfilled', value: { id: 1, name: 'Grace' } },
@@ -51,7 +51,7 @@ test('m: write policies and ordered transactions share record lanes', async t =>
       ],
     })
   }) as never
-  const transact = feathersBatchTransactions()
+  const transact = feathersTransactions()
   adapter.transaction = operations => {
     transactionCalls += 1
     transactionOperations = operations
@@ -69,7 +69,7 @@ test('m: write policies and ordered transactions share record lanes', async t =>
     { serviceName: 'notes', method: 'create', args: [parent] },
     { serviceName: 'notes', method: 'create', args: [child] },
   ])
-  t.deepEqual(batchPayload, {
+  t.deepEqual(transactionPayload, {
     serial: true,
     calls: [
       ['patch', 'notes', 1, { content: 'transactional' }],
@@ -214,7 +214,7 @@ test('transactions: commit, cascading cancellation and rollback publish grouped 
         { status: 'rejected', reason: 'Permission denied' },
       ],
     })) as never
-  const transact = feathersBatchTransactions()
+  const transact = feathersTransactions({ serviceName: 'api/batch' })
   adapter.transaction = operations => transact(feathers, operations)
   await t.throwsAsync(
     figbird.transaction(tx => {


### PR DESCRIPTION
## What this adds

`figbird.transaction(tx => ...)` collects schema-typed CRUD writes and commits them through an optional adapter transaction capability. Unsupported adapters fail locally. There is no sequential-request fallback.

Bulk operations affect multiple records. Transactions commit multiple operations atomically, matching a user action whose changes must succeed or fail together.

```ts
const documentTypeId = nanoid()
const documentId = nanoid()

await figbird.transaction(tx => {
  tx.m.documentTypes.create({ id: documentTypeId, name: 'Contract' })
  tx.m.documents.create({ id: documentId, documentTypeId, name: 'Employment contract' })
})
```

## Ordering and identity

- Collection order is execution order inside one atomic server transaction. Later operations must see earlier writes.
- Generate IDs on the client and create referenced records first. There is no dependency inference or result-reference DSL.
- Create payloads must include stable IDs. Explicit optimistic items must preserve those IDs.
- Transactions wait behind earlier writes to every affected record and hold those record lanes until settlement.

## Feathers integration

```ts
new FeathersAdapter(feathers, {
  transactions: feathersTransactions(),
})
```

`feathersTransactions()` defaults to the recommended `api/transactions` service name. This is an application-provided atomic endpoint; the helper does not create it. Requests contain `{ serial: true, calls }` with `[method, serviceName, ...args]` tuples. Responses contain `{ data: [...] }` with ordered settled results. The backend must execute calls sequentially and roll back the whole transaction if any operation fails. Any rejected entry rejects the Figbird transaction. Other atomic backends can implement the adapter capability directly.

Existing endpoint names remain configurable. Humaans can keep `api/batch` without renaming its backend:

```ts
new FeathersAdapter(feathers, {
  transactions: feathersTransactions({ serviceName: 'api/batch' }),
})
```

The public helper and options type are `feathersTransactions` and `FeathersTransactionsOptions`. The previous draft's batch-named exports have been removed.

## Client behavior and limits

Optimistic projection, commit, and rollback each publish grouped cache updates across services. Confirmed operations remain hidden until commit. Cancellation of an invalidated queued transaction also cancels dependent writes without exposing a half-settled cache.

The callback is synchronous and returns no records. This first version supports keyed CRUD only, one operation per entity, and individual create calls. It does not support partial success, custom service methods, or awaiting server-generated values inside the callback. Pending/error UI can use the existing action APIs; no new React hook is required.

## Review notes

Rebased onto `master` at `7df42f6`, including the current mutation tracing and cache-event changes. The main integration is in `queryStore.ts`; collection/types live in `transactions.ts`, and the Feathers protocol mapping stays in the adapter.

Extended the existing tests to check serial payload ordering with client-generated foreign keys, stable-ID validation, cross-service rollback from rejected transaction results, and cascading cancellation. They cover both the default `api/transactions` endpoint and an explicit `api/batch` override. These are client/adapter contract tests, not an integration run against the Humaans database.

## Validation

- `npm run tsc`
- `npm run lint`
- `npm run ava`: 365 tests passed
- `npm run test`: type checking, lint, formatting, and 365 tests with coverage
- `npm run build`
