### PR TITLE
Make DevTools publishing independently retryable

### DIFF
--- a/.github/workflows/devtools-release.yml
+++ b/.github/workflows/devtools-release.yml
@@ -29,8 +29,8 @@ concurrency:
   group: devtools-release
 
 jobs:
-  release:
-    environment: extension-release
+  build:
+    name: Build release inputs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -65,29 +65,37 @@ jobs:
               --title "Figbird Devtools ${version}" \
               --notes "Browser extension builds for developer distribution. Load the Chrome ZIP unpacked in developer mode, or install the Mozilla-signed Firefox XPI."
           fi
+
+  firefox:
+    name: Sign and publish Firefox
+    if: github.event_name == 'push' || inputs.sign_firefox
+    needs: build
+    environment: extension-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          cache: npm
+          node-version: 22
+      - run: npm ci
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: figbird-devtools-release-inputs
+          path: extensions/build
+      - name: Extract the unsigned Firefox extension
+        run: unzip -q extensions/build/figbird-devtools-firefox-unsigned.zip -d extensions/build/firefox
       - name: Sign the unlisted Firefox extension
-        if: github.event_name == 'push' || inputs.sign_firefox
         env:
           AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
           AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
-        run: |
-          npm exec -- web-ext sign \
-            --source-dir extensions/build/firefox \
-            --artifacts-dir extensions/build/firefox-signed \
-            --channel unlisted \
-            --api-key "$AMO_JWT_ISSUER" \
-            --api-secret "$AMO_JWT_SECRET" \
-            --upload-source-code extensions/build/figbird-devtools-source.zip \
-            --approval-timeout 900000 \
-            --timeout 900000
+        run: node tasks/sign-firefox-devtools.js
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: github.event_name == 'push' || inputs.sign_firefox
         with:
           if-no-files-found: error
           name: figbird-devtools-firefox-signed
           path: extensions/build/firefox-signed/*.xpi
       - name: Publish the signed Firefox extension
-        if: github.event_name == 'push' || inputs.sign_firefox
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -99,8 +107,23 @@ jobs:
           version=$(node -p "require('./extensions/version.json').version")
           tag="devtools-v${version}"
           gh release upload "$tag" "$asset" --clobber
+
+  chrome:
+    name: Upload and publish Chrome
+    if: github.event_name == 'push' || inputs.upload_chrome || inputs.submit_chrome
+    needs: build
+    environment: extension-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: figbird-devtools-release-inputs
+          path: extensions/build
       - id: google-auth
-        if: github.event_name == 'push' || inputs.upload_chrome || inputs.submit_chrome
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           access_token_scopes: https://www.googleapis.com/auth/chromewebstore
@@ -108,7 +131,6 @@ jobs:
           token_format: access_token
           workload_identity_provider: ${{ vars.CHROME_WORKLOAD_IDENTITY_PROVIDER }}
       - name: Upload the Chrome extension
-        if: github.event_name == 'push' || inputs.upload_chrome || inputs.submit_chrome
         env:
           CHROME_ACCESS_TOKEN: ${{ steps.google-auth.outputs.access_token }}
           CHROME_EXTENSION_ARCHIVE: extensions/build/figbird-devtools-chrome.zip

--- a/extensions/RELEASING.md
+++ b/extensions/RELEASING.md
@@ -67,6 +67,12 @@ for review. The release workflow saves the Chrome ZIP and signed Firefox XPI in 
 folder from `chrome://extensions` using **Developer mode → Load unpacked** while store review is
 pending.
 
+Firefox signing and Chrome submission run as independent jobs after the shared release build. A
+store outage therefore does not block the other browser, and rerunning failed jobs retries only the
+affected publisher. The Firefox signer retries temporary upload and validation responses;
+persistent failures include the safe AMO response status, content type, and request ID in the
+Actions log.
+
 To release only one browser, open **Actions → Release browser devtools → Run workflow** on the
 default branch and select the required inputs.
 

--- a/tasks/sign-firefox-devtools.js
+++ b/tasks/sign-firefox-devtools.js
@@ -1,0 +1,127 @@
+import { readFile } from 'node:fs/promises'
+import webExt from 'web-ext'
+
+const amoBaseUrl = 'https://addons.mozilla.org/api/v5/'
+const apiKey = requiredEnvironmentVariable('AMO_JWT_ISSUER')
+const apiSecret = requiredEnvironmentVariable('AMO_JWT_SECRET')
+const webExtPackage = JSON.parse(
+  await readFile(new URL('../node_modules/web-ext/package.json', import.meta.url), 'utf8'),
+)
+const maxAttempts = 3
+const originalFetch = globalThis.fetch
+let attemptState = createAttemptState()
+
+globalThis.fetch = async (input, init) => {
+  const url = requestUrl(input)
+  const method = requestMethod(input, init)
+  try {
+    const response = await originalFetch(input, init)
+    if (isAmoRequest(url)) inspectAmoResponse(url, method, response)
+    return response
+  } catch (error) {
+    if (isRetrySafeUploadRequest(url, method)) {
+      attemptState.retryable = true
+      console.error(`AMO ${requestStage(url, method)} request failed: ${errorMessage(error)}`)
+    }
+    throw error
+  }
+}
+
+try {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    attemptState = createAttemptState()
+    try {
+      await webExt.cmd.sign({
+        amoBaseUrl,
+        apiKey,
+        apiSecret,
+        approvalTimeout: 900_000,
+        artifactsDir: 'extensions/build/firefox-signed',
+        channel: 'unlisted',
+        sourceDir: 'extensions/build/firefox',
+        timeout: 900_000,
+        uploadSourceCode: 'extensions/build/figbird-devtools-source.zip',
+        webextVersion: webExtPackage.version,
+      })
+      break
+    } catch (error) {
+      if (!attemptState.retryable || attempt === maxAttempts) throw error
+      const delayMs = 5_000 * 2 ** (attempt - 1)
+      console.warn(
+        `Firefox signing attempt ${attempt} failed during the retry-safe AMO upload stage; ` +
+          `retrying in ${delayMs / 1_000}s`,
+      )
+      await delay(delayMs)
+    }
+  }
+} finally {
+  globalThis.fetch = originalFetch
+}
+
+function inspectAmoResponse(url, method, response) {
+  const contentType = response.headers.get('content-type') ?? '(missing)'
+  const requestId = response.headers.get('x-amo-request-id') ?? '(missing)'
+  const isJson = contentType.toLowerCase().includes('json')
+  if (!response.ok || !isJson) {
+    console.error(
+      `AMO ${requestStage(url, method)} returned ${response.status} ${response.statusText || ''}` +
+        `; content-type=${contentType}; request-id=${requestId}`,
+    )
+  }
+  if (
+    isRetrySafeUploadRequest(url, method) &&
+    (response.status === 429 || response.status >= 500 || !isJson)
+  ) {
+    attemptState.retryable = true
+  }
+}
+
+function requestUrl(input) {
+  if (input instanceof URL) return input
+  if (typeof input === 'string') return new URL(input)
+  return new URL(input.url)
+}
+
+function requestMethod(input, init) {
+  if (init?.method) return init.method.toUpperCase()
+  if (typeof input !== 'string' && !(input instanceof URL)) return input.method.toUpperCase()
+  return 'GET'
+}
+
+function isAmoRequest(url) {
+  return url.origin === 'https://addons.mozilla.org' && url.pathname.startsWith('/api/v5/addons/')
+}
+
+function isRetrySafeUploadRequest(url, method) {
+  return (
+    isAmoRequest(url) &&
+    (method === 'GET' || method === 'POST') &&
+    url.pathname.startsWith('/api/v5/addons/upload/')
+  )
+}
+
+function requestStage(url, method) {
+  if (url.pathname.startsWith('/api/v5/addons/upload/')) {
+    return method === 'POST' ? 'upload' : 'validation'
+  }
+  if (url.pathname.includes('/versions/')) return 'approval'
+  return 'submission'
+}
+
+function createAttemptState() {
+  return { retryable: false }
+}
+
+function requiredEnvironmentVariable(name) {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing ${name}`)
+  return value
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
## What changed

- split the DevTools release into a shared build plus independent Firefox and Chrome publisher jobs
- replace the opaque `web-ext sign` CLI call with a wrapper that reports the safe AMO HTTP status, content type, and request ID
- retry only upload and validation failures, before an add-on version can have been submitted
- document the independent retry behavior

## Why

The DevTools 0.3.0 release reached AMO signing but received an HTML response where `web-ext` expected JSON. The CLI hid the response status and request metadata, and the single sequential job prevented Chrome submission after Firefox failed.

This keeps publisher failures isolated and makes the next AMO run actionable without logging credentials or retrying a potentially-created extension version.

## Validation

- `npm run test` — 357 tests passed, including typecheck, lint, and formatting
- workflow YAML parsed locally
- signer exercised with dummy credentials: reported AMO `401`, JSON content type, and request ID without retrying or exposing credentials
- [branch workflow run](https://github.com/humaans/figbird/actions/runs/32068920857): shared build passed; GitHub correctly blocked the publisher because `extension-release` permits only `master`, so protected-secret verification must happen after merge
