### PR TITLE
Scale transport-path types to large schemas

### DIFF
--- a/lib/core/schema.ts
+++ b/lib/core/schema.ts
@@ -547,9 +547,11 @@ export type ServicePaths<S extends Schema> = {
   [N in ServiceNames<S>]: ServicePath<ServiceByName<S, N>>
 }[ServiceNames<S>]
 
-export type ServiceByPath<S extends Schema, P extends ServicePaths<S>> = {
-  [N in ServiceNames<S>]: P extends ServicePath<ServiceByName<S, N>> ? ServiceByName<S, N> : never
-}[ServiceNames<S>]
+type ServicesByPath<S extends Schema> = {
+  [N in ServiceNames<S> as ServicePath<ServiceByName<S, N>>]: ServiceByName<S, N>
+}
+
+export type ServiceByPath<S extends Schema, P extends ServicePaths<S>> = ServicesByPath<S>[P]
 
 /** The resolved service definition selected specifically through its transport path. */
 export type ServiceDefinitionByPath<


### PR DESCRIPTION
## Why

`ServiceByPath` currently resolves a transport path by distributing a conditional across every schema service. In a large schema, a generic path wrapper expands that entire union and loses the correlation between its path, query, and result types. Humaans hits this at 329 services, forcing otherwise unnecessary local hook redeclarations and casts.

## What changed

Build a path-keyed mapped type once and resolve services with an indexed access. This preserves the same public API and collision semantics while keeping generic path lookups correlated and tractable.

## Verification

- `npm run test` — 359 tests pass
- `npm run build`
- Full Humaans client typecheck with direct `createHooks(schema)` exports and no local `useFind` / `useGet` / `useMutation` redeclarations
