### PR TITLE
Add global stale time and prepared query adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@ Also included:
   preparations hand their result to mounting subscribers without another revalidation;
   reconnects mark inactive cache entries pending, and returning from a hidden tab after
   `staleTime` reconciles active queries. Invalid durations now fail at the API boundary,
-  route preparations can release automatically from an `AbortSignal`, and visibility
-  recovery skips queries refreshed while hidden while retaining its cause in telemetry.
+  while visibility recovery skips queries refreshed while hidden and retains its cause
+  in telemetry.
 - Import-safe schema bindings through `createHooks(schema)`. The generated hooks resolve their
   runtime from `FigbirdProvider`, and `useMutations()` returns that instance's typed write proxy.
   Imperative code uses `figbird.m`, `figbird.prepare`, and other instance methods directly, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ return `ItemRemovedError`; use `isItemRemovedError()` to handle this case.
 
 Also included:
 
+- Successful query results now remain fresh for five minutes by default. Configure
+  `staleTime` once on `new Figbird(...)` or override it per reader. Active route
+  preparations hand their result to mounting subscribers without another revalidation;
+  reconnects mark inactive cache entries pending, and returning from a hidden tab after
+  `staleTime` reconciles active queries.
 - Import-safe schema bindings through `createHooks(schema)`. The generated hooks resolve their
   runtime from `FigbirdProvider`, and `useMutations()` returns that instance's typed write proxy.
   Imperative code uses `figbird.m`, `figbird.prepare`, and other instance methods directly, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,9 @@ Also included:
   `staleTime` once on `new Figbird(...)` or override it per reader. Active route
   preparations hand their result to mounting subscribers without another revalidation;
   reconnects mark inactive cache entries pending, and returning from a hidden tab after
-  `staleTime` reconciles active queries.
+  `staleTime` reconciles active queries. Invalid durations now fail at the API boundary,
+  route preparations can release automatically from an `AbortSignal`, and visibility
+  recovery skips queries refreshed while hidden while retaining its cause in telemetry.
 - Import-safe schema bindings through `createHooks(schema)`. The generated hooks resolve their
   runtime from `FigbirdProvider`, and `useMutations()` returns that instance's typed write proxy.
   Imperative code uses `figbird.m`, `figbird.prepare`, and other instance methods directly, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,11 @@ Also included:
 
 - Successful query results now remain fresh for five minutes by default. Configure
   `staleTime` once on `new Figbird(...)` or override it per reader. Active route
-  preparations hand their result to mounting subscribers without another revalidation;
-  reconnects mark inactive cache entries pending, and returning from a hidden tab after
-  `staleTime` reconciles active queries. Invalid durations now fail at the API boundary,
-  while visibility recovery skips queries refreshed while hidden and retains its cause
-  in telemetry.
+  preparations hand their result to the destination's first subscriber wave without
+  another revalidation; reconnects mark inactive cache entries pending, and returning
+  from a hidden tab after `staleTime` reconciles active queries. Invalid durations now
+  fail at the API boundary, while visibility recovery skips queries refreshed while
+  hidden and retains its cause in telemetry.
 - Import-safe schema bindings through `createHooks(schema)`. The generated hooks resolve their
   runtime from `FigbirdProvider`, and `useMutations()` returns that instance's typed write proxy.
   Imperative code uses `figbird.m`, `figbird.prepare`, and other instance methods directly, so

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ code outside React uses the instance directly: `figbird.m`, `figbird.prepare`, a
 
 Cold reads suspend into your `<Suspense>` boundary; warm reads render synchronously.
 Transient fetch failures retry up to three times with exponential backoff before Figbird exposes the error. Client errors fail immediately, except for `408` and `429` responses.
+Successful results stay fresh for five minutes by default, so short remounts reuse the
+cache without another request. Set `staleTime` on `new Figbird(...)` to change the app-wide
+default, or pass it to an individual query reader.
 
 ## Features
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -944,9 +944,10 @@ const data = {
 
 Preparation is an _earlier read_, not a different one. The component calls
 `useQuery(request)` and converges on the same cache key. Keep the preparation handle active
-until the destination commits. Subscribers that mount while that lease is active adopt its
+through the destination's first subscriber commit. That initial subscriber wave adopts its
 result without another freshness check, even when other queries or code took longer to load.
-Later mounts use the ordinary `staleTime` policy again.
+The adoption window then closes: retaining the handle longer only keeps the query pinned,
+and later mounts use the ordinary `staleTime` policy again.
 
 ### prefetch
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -943,7 +943,10 @@ const data = {
 ```
 
 Preparation is an _earlier read_, not a different one. The component calls
-`useQuery(request)` and converges on the same cache key.
+`useQuery(request)` and converges on the same cache key. Keep the preparation handle active
+until the destination commits. Subscribers that mount while that lease is active adopt its
+result without another freshness check, even when other queries or code took longer to load.
+Later mounts use the ordinary `staleTime` policy again.
 
 ### prefetch
 
@@ -1088,11 +1091,14 @@ is no per-query throttle config) via two built-in guards on event-driven refetch
   deferred (queries show as `pending` in `inspect()`) and reconcile once on
   `visibilitychange`. The reconnect sweep is gated too, so a background tab riding
   through network blips stops replaying refetch storms. Local-exact merges keep flowing
-  while hidden (they're free); only network reconciliation pauses. Inject a custom
+  while hidden (they're free); only network reconciliation pauses. Returning after a
+  hidden interval at least as long as the instance `staleTime` also reconciles active
+  queries and marks inactive cached queries pending as a safety check. Inject a custom
   `visibility` source in the constructor for non-browser environments.
 - **Reconnects are staggered.** Visible clients wait a random `reconnectJitter`
-  before sweeping active queries, defaulting to `[0, 3000]` ms. Reconnects during
-  the wait coalesce into one sweep. Set `reconnectJitter: 0` for immediate sweeps.
+  before sweeping active queries, defaulting to `[0, 3000]` ms. Inactive cached queries
+  are marked pending and refresh when they are next read. Reconnects during the wait
+  coalesce into one sweep. Set `reconnectJitter: 0` for immediate sweeps.
 
 Manual `refetch()`, first fetches, and SWR revalidation are user/loader intent and are
 never gated.
@@ -1101,16 +1107,29 @@ One practical consequence: an **unwindowed** relation like `.related('comments')
 
 ### Freshness tolerance: staleTime
 
-By default every mount revalidates cached data in the background (SWR). `staleTime` is the
-reader's tolerance: data younger than it skips the revalidation.
+Successful data stays fresh for five minutes by default. A mount within that window reuses
+the cached result without a request; after it, the cached result renders immediately while
+Figbird revalidates in the background. Set the app-wide policy on the instance:
+
+```ts
+const figbird = new Figbird({ adapter, schema, staleTime: 5 * 60_000 })
+```
+
+A reader can override the instance policy. Use `0` to revalidate on every mount or
+`Infinity` for cache-first data:
 
 ```ts
 useQuery(q.currencies, { staleTime: 60_000 }) // revalidate at most once a minute
 useQuery(q.currencies, { staleTime: Infinity }) // cache-first
 ```
 
-It is a read-site option, not query identity: readers with different tolerances share one cache
-entry, and the most demanding one keeps it freshest. `prepare()` and `prefetch()` accept it too.
+`staleTime` is measured from the last successful response. It does not poll an already-mounted
+query. Explicit refetches, pending reconciliation, and errors always win over the timer.
+
+The value is not query identity: readers with different tolerances share one cache entry, and
+the most demanding one keeps it freshest. `prepare()` inherits the instance default and accepts
+an override. `prefetch()` keeps a separate 30-second default because its timer also controls the
+speculative pin's lifetime.
 
 ### Fetch retries
 
@@ -1798,6 +1817,7 @@ The core instance holding the adapter, schema, and shared query state.
 const figbird = new Figbird({
   adapter,
   schema,
+  staleTime?,
   eventBatchInterval?,
   retry?,
   retryDelay?,

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -937,8 +937,7 @@ queries: ({ params }) => [issueDetail({ id: Number(params.id) })]
 queries: [customFieldsQuery, rolesQuery]
 
 const data = {
-  prepare: (request: AnyQueryInput<typeof schema>, signal: AbortSignal) =>
-    figbird.prepare(request, { signal }),
+  prepare: (request: AnyQueryInput<typeof schema>) => figbird.prepare(request),
   prefetch: (request: AnyQueryInput<typeof schema>) => figbird.prefetch(request),
 }
 ```
@@ -947,10 +946,7 @@ Preparation is an _earlier read_, not a different one. The component calls
 `useQuery(request)` and converges on the same cache key. Keep the preparation handle active
 until the destination commits. Subscribers that mount while that lease is active adopt its
 result without another freshness check, even when other queries or code took longer to load.
-Later mounts use the ordinary `staleTime` policy again. Pass the navigation's `AbortSignal`
-to release the lease automatically when navigation is cancelled. This releases Figbird's
-ownership of the query. If readiness is still pending, `promise` rejects with the signal's
-reason. A request shared with another subscriber is not cancelled.
+Later mounts use the ordinary `staleTime` policy again.
 
 ### prefetch
 
@@ -1705,7 +1701,7 @@ The `createHooks` kit returns a schema-typed version; the standalone export from
 ## figbird.prepare
 
 ```ts
-const { key, promise, release } = figbird.prepare(definition(args), { staleTime?, signal? })
+const { key, promise, release } = figbird.prepare(definition(args), { staleTime? })
 ```
 
 Starts a query and returns an awaitable lease, the router-grade primitive. Argumentless

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -937,7 +937,8 @@ queries: ({ params }) => [issueDetail({ id: Number(params.id) })]
 queries: [customFieldsQuery, rolesQuery]
 
 const data = {
-  prepare: (request: AnyQueryInput<typeof schema>) => figbird.prepare(request),
+  prepare: (request: AnyQueryInput<typeof schema>, signal: AbortSignal) =>
+    figbird.prepare(request, { signal }),
   prefetch: (request: AnyQueryInput<typeof schema>) => figbird.prefetch(request),
 }
 ```
@@ -946,7 +947,10 @@ Preparation is an _earlier read_, not a different one. The component calls
 `useQuery(request)` and converges on the same cache key. Keep the preparation handle active
 until the destination commits. Subscribers that mount while that lease is active adopt its
 result without another freshness check, even when other queries or code took longer to load.
-Later mounts use the ordinary `staleTime` policy again.
+Later mounts use the ordinary `staleTime` policy again. Pass the navigation's `AbortSignal`
+to release the lease automatically when navigation is cancelled. This releases Figbird's
+ownership of the query. If readiness is still pending, `promise` rejects with the signal's
+reason. A request shared with another subscriber is not cancelled.
 
 ### prefetch
 
@@ -961,6 +965,10 @@ Safe to call at any frequency: if the query was prefetched within `staleTime` (d
 ```ts
 prefetch(issueDetail({ id }), { staleTime: 60_000 })
 ```
+
+Prefetch `staleTime` must fit JavaScript's timer range, from `0` through `2_147_483_647`
+milliseconds, because it also controls automatic release. Ordinary query readers and
+`prepare()` accept `Infinity` for cache-first data.
 
 Rule of thumb: `prepare()` when you need to _await_ readiness or control the lease; `prefetch()` when you just want things warm.
 
@@ -1093,8 +1101,11 @@ is no per-query throttle config) via two built-in guards on event-driven refetch
   through network blips stops replaying refetch storms. Local-exact merges keep flowing
   while hidden (they're free); only network reconciliation pauses. Returning after a
   hidden interval at least as long as the instance `staleTime` also reconciles active
-  queries and marks inactive cached queries pending as a safety check. Inject a custom
-  `visibility` source in the constructor for non-browser environments.
+  queries and marks inactive cached queries pending as a safety check. That safety sweep
+  leaves queries fetched within the freshness window alone; a known deferred event still
+  wins. Safety-sweep fetches carry a `visibility` trace cause in `figbird.events` and
+  devtools. Inject a custom `visibility` source in the constructor for non-browser
+  environments.
 - **Reconnects are staggered.** Visible clients wait a random `reconnectJitter`
   before sweeping active queries, defaulting to `[0, 3000]` ms. Inactive cached queries
   are marked pending and refresh when they are next read. Reconnects during the wait
@@ -1122,6 +1133,8 @@ A reader can override the instance policy. Use `0` to revalidate on every mount 
 useQuery(q.currencies, { staleTime: 60_000 }) // revalidate at most once a minute
 useQuery(q.currencies, { staleTime: Infinity }) // cache-first
 ```
+
+Values must be non-negative numbers. `NaN` and negative values throw at the API boundary.
 
 `staleTime` is measured from the last successful response. It does not poll an already-mounted
 query. Explicit refetches, pending reconciliation, and errors always win over the timer.
@@ -1692,7 +1705,7 @@ The `createHooks` kit returns a schema-typed version; the standalone export from
 ## figbird.prepare
 
 ```ts
-const { key, promise, release } = figbird.prepare(definition(args), { staleTime? })
+const { key, promise, release } = figbird.prepare(definition(args), { staleTime?, signal? })
 ```
 
 Starts a query and returns an awaitable lease, the router-grade primitive. Argumentless

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -40,6 +40,7 @@ import {
 export type { ExplainNode, ExplainReport } from './queryClassification.js'
 import { QueryRef } from './queryRef.js'
 import {
+  DEFAULT_STALE_TIME,
   QueryStore,
   type DevtoolsCacheEditResult,
   type QueryFetchHistoryEntry,
@@ -199,6 +200,7 @@ export class Figbird<
   adapter: A
   queryStore: QueryStore<S, AdapterParams<A>, AdapterFindMeta<A>, AdapterQuery<A>>
   schema: S | undefined
+  #staleTime: number
 
   // Cache of active RelationalQueryRef instances, keyed by AST hash. This is critical for
   // React 18 Suspense interop: on suspense retries React discards render-state (including
@@ -227,6 +229,8 @@ export class Figbird<
    * @param adapter Data adapter (e.g. FeathersAdapter)
    * @param eventBatchInterval Optional interval (ms) for batching realtime events
    * @param schema Optional schema to enable full TypeScript inference
+   * @param staleTime Default age (ms) for reusing successful data without a
+   *   mount-time revalidation. Defaults to 5 minutes; readers can override it.
    * @param reconcileCooldown Burst safety: minimum interval (ms) between event-driven
    *   refetches of one query. First event refetches immediately; further events within
    *   the window coalesce into one guaranteed trailing refetch. Default 2000; 0 disables.
@@ -249,6 +253,7 @@ export class Figbird<
     adapter,
     eventBatchInterval,
     schema,
+    staleTime = DEFAULT_STALE_TIME,
     reconcileCooldown,
     retry,
     retryDelay,
@@ -259,6 +264,7 @@ export class Figbird<
     adapter: A
     eventBatchInterval?: number
     schema?: S
+    staleTime?: number
     reconcileCooldown?: number
     retry?: number | false
     retryDelay?: RetryDelay
@@ -268,9 +274,11 @@ export class Figbird<
   }) {
     this.adapter = adapter
     this.schema = schema
+    this.#staleTime = staleTime
     this.queryStore = new QueryStore<S, AdapterParams<A>, AdapterFindMeta<A>, AdapterQuery<A>>({
       adapter,
       eventBatchInterval,
+      staleTime,
       ...(reconcileCooldown !== undefined ? { reconcileCooldown } : {}),
       ...(retry !== undefined ? { retry } : {}),
       ...(retryDelay !== undefined ? { retryDelay } : {}),
@@ -407,6 +415,7 @@ export class Figbird<
             this.#relationalQueryCache.delete(hash)
           }
         },
+        { defaultStaleTime: this.#staleTime },
       )
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any
       this.#relationalQueryCache.set(hash, ref as RelationalQueryRef<any, S, any, any, any>)
@@ -463,6 +472,7 @@ export class Figbird<
         this.schema,
         config,
         {
+          defaultStaleTime: this.#staleTime,
           onEvict: () => {
             if (this.#windowQueryCache.get(hash) === ref) this.#windowQueryCache.delete(hash)
           },
@@ -497,7 +507,8 @@ export class Figbird<
    *
    * Designed for router preparation, hover prefetch, and parents that can see child needs
    * earlier than the child itself. The component still reads via `useQuery(request)` —
-   * preparation is an earlier read, not a different read.
+   * preparation is an earlier read, not a different read. Keep the handle active until
+   * the destination commits so its subscribers adopt the prepared result without revalidation.
    *
    * @example
    * ```ts

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -509,8 +509,9 @@ export class Figbird<
    *
    * Designed for router preparation, hover prefetch, and parents that can see child needs
    * earlier than the child itself. The component still reads via `useQuery(request)` —
-   * preparation is an earlier read, not a different read. Keep the handle active until
-   * the destination commits so its subscribers adopt the prepared result without revalidation.
+   * preparation is an earlier read, not a different read. Keep the handle active through
+   * the destination's first subscriber commit. That subscriber wave adopts the prepared
+   * result without revalidation; retaining the handle longer only keeps the query pinned.
    *
    * @example
    * ```ts

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -75,8 +75,16 @@ import type {
   ServicePaths,
 } from './schema.js'
 import { resolveServicePath } from './schema.js'
+import { validatePrefetchStaleTime, validateStaleTime } from './staleTime.js'
 
 const MAX_WINDOW_QUERY_CACHE_SIZE = 20
+
+function preparationAbortReason(signal: AbortSignal): unknown {
+  if (signal.reason !== undefined) return signal.reason
+  const error = new Error('Query preparation was aborted')
+  error.name = 'AbortError'
+  return error
+}
 
 type DescriptorWriteProjection<TItem> =
   | {
@@ -272,6 +280,7 @@ export class Figbird<
     visibility?: VisibilitySource
     defaultSort?: Record<string, 1 | -1>
   }) {
+    staleTime = validateStaleTime(staleTime, 'Figbird(): staleTime')
     this.adapter = adapter
     this.schema = schema
     this.#staleTime = staleTime
@@ -509,6 +518,9 @@ export class Figbird<
    * earlier than the child itself. The component still reads via `useQuery(request)` —
    * preparation is an earlier read, not a different read. Keep the handle active until
    * the destination commits so its subscribers adopt the prepared result without revalidation.
+   * Pass the navigation's `AbortSignal` to release the lease automatically when navigation
+   * is cancelled. Aborting releases ownership; if readiness is still pending, the returned
+   * promise rejects with the signal's reason. Shared network work is not cancelled.
    *
    * @example
    * ```ts
@@ -524,18 +536,51 @@ export class Figbird<
    */
   prepare<Args, B extends AnyQueryBuilder<S>>(
     query: QueryInput<B, Args>,
-    options?: { staleTime?: number },
+    options?: { staleTime?: number; signal?: AbortSignal },
   ): PreparedQuery {
+    const staleTime =
+      options?.staleTime === undefined
+        ? undefined
+        : validateStaleTime(options.staleTime, 'prepare(): staleTime')
     const ref = this.query(query)
     // No-op listener — purely a pin. The promise drives readiness; release() drops the pin.
     // While pinned, subsequent useQuery subscribers join the same ref. When everyone has
     // released and unsubscribed, RelationalQueryRef cleans up and evicts the cache entry.
     // A staleTime skips the SWR revalidation when the data is already fresh enough.
-    const unsub = ref.subscribe(() => {}, { ...options, source: 'prepare' })
+    const unsubscribe = ref.subscribe(() => {}, {
+      ...(staleTime === undefined ? {} : { staleTime }),
+      source: 'prepare',
+    })
+    const readiness = ref.suspensePromise()
+    const signal = options?.signal
+    let rejectAbort: ((reason?: unknown) => void) | undefined
+    const promise =
+      signal === undefined
+        ? readiness
+        : Promise.race([
+            readiness,
+            new Promise<void>((_resolve, reject) => {
+              rejectAbort = reject
+            }),
+          ])
+    let released = false
+    function release() {
+      if (released) return
+      released = true
+      signal?.removeEventListener('abort', abort)
+      unsubscribe()
+    }
+    function abort() {
+      if (!signal) return
+      release()
+      rejectAbort?.(preparationAbortReason(signal))
+    }
+    if (signal?.aborted) abort()
+    else signal?.addEventListener('abort', abort, { once: true })
     return {
       key: ref.hash(),
-      promise: ref.suspensePromise(),
-      release: unsub,
+      promise,
+      release,
     }
   }
 
@@ -554,6 +599,7 @@ export class Figbird<
    * `staleTime` — the fetched data stays in the QueryStore either way, so a later
    * `useQuery` gets a warm synchronous read. If a component subscribes in the
    * meantime, its own subscription keeps the query alive past the pin.
+   * Because the pin must release itself, `staleTime` must be finite for prefetches.
    *
    * Use `prepare()` instead when you need to await readiness or control the lease
    * explicitly (router navigation).
@@ -567,8 +613,8 @@ export class Figbird<
     query: QueryInput<B, Args>,
     options?: { staleTime?: number },
   ): void {
+    const staleTime = validatePrefetchStaleTime(options?.staleTime ?? 30_000)
     const ref = this.query(query)
-    const staleTime = options?.staleTime ?? 30_000
     const hash = ref.hash()
 
     const now = Date.now()

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -75,7 +75,7 @@ import type {
   ServicePaths,
 } from './schema.js'
 import { resolveServicePath } from './schema.js'
-import { validatePrefetchStaleTime, validateStaleTime } from './staleTime.js'
+import { isWithinStaleTime, validatePrefetchStaleTime, validateStaleTime } from './staleTime.js'
 
 const MAX_WINDOW_QUERY_CACHE_SIZE = 20
 
@@ -619,7 +619,7 @@ export class Figbird<
 
     const now = Date.now()
     const existing = this.#prefetches.get(hash)
-    if (existing && now - existing.at < staleTime) return
+    if (existing && isWithinStaleTime(existing.at, staleTime, now)) return
     if (existing) {
       clearTimeout(existing.timer)
       existing.release()

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -79,13 +79,6 @@ import { isWithinStaleTime, validatePrefetchStaleTime, validateStaleTime } from 
 
 const MAX_WINDOW_QUERY_CACHE_SIZE = 20
 
-function preparationAbortReason(signal: AbortSignal): unknown {
-  if (signal.reason !== undefined) return signal.reason
-  const error = new Error('Query preparation was aborted')
-  error.name = 'AbortError'
-  return error
-}
-
 type DescriptorWriteProjection<TItem> =
   | {
       optimistic?: true
@@ -518,9 +511,6 @@ export class Figbird<
    * earlier than the child itself. The component still reads via `useQuery(request)` —
    * preparation is an earlier read, not a different read. Keep the handle active until
    * the destination commits so its subscribers adopt the prepared result without revalidation.
-   * Pass the navigation's `AbortSignal` to release the lease automatically when navigation
-   * is cancelled. Aborting releases ownership; if readiness is still pending, the returned
-   * promise rejects with the signal's reason. Shared network work is not cancelled.
    *
    * @example
    * ```ts
@@ -536,7 +526,7 @@ export class Figbird<
    */
   prepare<Args, B extends AnyQueryBuilder<S>>(
     query: QueryInput<B, Args>,
-    options?: { staleTime?: number; signal?: AbortSignal },
+    options?: { staleTime?: number },
   ): PreparedQuery {
     const staleTime =
       options?.staleTime === undefined
@@ -547,39 +537,13 @@ export class Figbird<
     // While pinned, subsequent useQuery subscribers join the same ref. When everyone has
     // released and unsubscribed, RelationalQueryRef cleans up and evicts the cache entry.
     // A staleTime skips the SWR revalidation when the data is already fresh enough.
-    const unsubscribe = ref.subscribe(() => {}, {
+    const release = ref.subscribe(() => {}, {
       ...(staleTime === undefined ? {} : { staleTime }),
       source: 'prepare',
     })
-    const readiness = ref.suspensePromise()
-    const signal = options?.signal
-    let rejectAbort: ((reason?: unknown) => void) | undefined
-    const promise =
-      signal === undefined
-        ? readiness
-        : Promise.race([
-            readiness,
-            new Promise<void>((_resolve, reject) => {
-              rejectAbort = reject
-            }),
-          ])
-    let released = false
-    function release() {
-      if (released) return
-      released = true
-      signal?.removeEventListener('abort', abort)
-      unsubscribe()
-    }
-    function abort() {
-      if (!signal) return
-      release()
-      rejectAbort?.(preparationAbortReason(signal))
-    }
-    if (signal?.aborted) abort()
-    else signal?.addEventListener('abort', abort, { once: true })
     return {
       key: ref.hash(),
-      promise,
+      promise: ref.suspensePromise(),
       release,
     }
   }

--- a/lib/core/queryDefinition.ts
+++ b/lib/core/queryDefinition.ts
@@ -283,6 +283,7 @@ export const defineQuery: DefineQuery = ((
  * query. `promise` resolves when the data is ready (rejects with what a Suspense read
  * would throw); `release()` drops the pin that keeps the underlying ref alive — when
  * no other subscriber remains, the ref tears down and the cache entry is evicted.
+ * Passing a signal to `prepare()` also releases the lease when navigation is aborted.
  *
  * Routers commonly attach their own metadata (e.g. a blocking/deferred priority) by
  * spreading: `{ ...figbird.prepare(def(args)), priority: 'route' }` — that vocabulary

--- a/lib/core/queryDefinition.ts
+++ b/lib/core/queryDefinition.ts
@@ -283,7 +283,6 @@ export const defineQuery: DefineQuery = ((
  * query. `promise` resolves when the data is ready (rejects with what a Suspense read
  * would throw); `release()` drops the pin that keeps the underlying ref alive — when
  * no other subscriber remains, the ref tears down and the cache entry is evicted.
- * Passing a signal to `prepare()` also releases the lease when navigation is aborted.
  *
  * Routers commonly attach their own metadata (e.g. a blocking/deferred priority) by
  * spreading: `{ ...figbird.prepare(def(args)), priority: 'route' }` — that vocabulary

--- a/lib/core/queryRef.ts
+++ b/lib/core/queryRef.ts
@@ -8,6 +8,17 @@ import type {
   QueryExecutionOptions,
   QueryState,
 } from './queryTypes.js'
+import { validateStaleTime } from './staleTime.js'
+
+function validateExecutionOptions(
+  options: QueryExecutionOptions | undefined,
+): QueryExecutionOptions {
+  if (options?.staleTime === undefined) return options ?? {}
+  return {
+    ...options,
+    staleTime: validateStaleTime(options.staleTime, 'query(): staleTime'),
+  }
+}
 
 // a lightweight query reference object to make it easy
 // subscribe to state changes and read query data
@@ -67,8 +78,9 @@ export class QueryRef<
     fn: (state: QueryState<T, TMeta>) => void,
     options?: QueryExecutionOptions,
   ): () => void {
+    const validatedOptions = validateExecutionOptions(options)
     this.#queryStore.materialize(this)
-    return this.#queryStore.subscribe<T>(this.#queryId, fn, options)
+    return this.#queryStore.subscribe<T>(this.#queryId, fn, validatedOptions)
   }
 
   /**
@@ -76,8 +88,9 @@ export class QueryRef<
    * Relational refs use this when a stricter subscriber joins an already-live tree.
    */
   ensureFresh(options?: QueryExecutionOptions): void {
+    const validatedOptions = validateExecutionOptions(options)
     this.#queryStore.materialize(this)
-    this.#queryStore.ensureFresh(this.#queryId, options)
+    this.#queryStore.ensureFresh(this.#queryId, validatedOptions)
   }
 
   /** Returns the latest known state for this query, if available. */

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -75,6 +75,7 @@ import {
 } from './queryTypes.js'
 import { defaultRetryDelay, resolveRetryDelay } from './retryDelay.js'
 import { normalizeError } from './errors.js'
+import { isWithinStaleTime } from './staleTime.js'
 
 /**
  * Where the store learns whether the tab is visible. Injectable for tests and
@@ -632,8 +633,7 @@ export class QueryStore<
     }
 
     const staleTime = options.staleTime ?? this.#staleTime
-    const isFresh =
-      staleTime > 0 && q.fetchedAt !== undefined && Date.now() - q.fetchedAt < staleTime
+    const isFresh = isWithinStaleTime(q.fetchedAt, staleTime)
     if (
       q.pending ||
       (q.state.status === 'success' &&
@@ -2474,7 +2474,9 @@ export class QueryStore<
     const now = Date.now()
     const sleptPastStaleTime = hiddenAt !== null && now - hiddenAt >= this.#staleTime
     if (sleptPastStaleTime) {
-      this.#markReconciliationPending(query => !this.#isFresh(query.fetchedAt, now))
+      this.#markReconciliationPending(
+        query => !isWithinStaleTime(query.fetchedAt, this.#staleTime, now),
+      )
     }
     const reconciled = this.#drainDeferredReconciles()
     if (!sleptPastStaleTime) return
@@ -2550,10 +2552,6 @@ export class QueryStore<
         }
       }
     }
-  }
-
-  #isFresh(fetchedAt: number | undefined, now: number): boolean {
-    return fetchedAt !== undefined && now - fetchedAt < this.#staleTime
   }
 
   #reconcilesAfterMissedEvents(query: Query<unknown, TMeta, unknown>): boolean {

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -181,6 +181,7 @@ export interface QueryFetchHistoryEntry {
 }
 
 export const QUERY_FETCH_HISTORY_LIMIT = 50
+export const DEFAULT_STALE_TIME = 5 * 60_000
 
 export interface DevtoolsCacheEditResult {
   ok: boolean
@@ -231,7 +232,9 @@ export class QueryStore<
   // Reconciliation gate state (see #requestReconcile): per-query cooldown windows
   // with trailing timers, and the set of reconciliations deferred while hidden.
   #reconcileCooldown: number
+  #staleTime: number
   #visibility: VisibilitySource
+  #hiddenAt: number | null
   #reconcileWindows: Map<
     string,
     { lastAt: number; trailing: ReturnType<typeof setTimeout> | null; causes?: TraceCause[] }
@@ -257,6 +260,7 @@ export class QueryStore<
   constructor({
     adapter,
     eventBatchInterval = 100,
+    staleTime = DEFAULT_STALE_TIME,
     reconcileCooldown = 2000,
     retry = DEFAULT_RETRIES,
     retryDelay = defaultRetryDelay,
@@ -266,6 +270,8 @@ export class QueryStore<
   }: {
     adapter: Adapter<TParams, TMeta, TQuery>
     eventBatchInterval?: number | undefined
+    /** Default age (ms) for skipping mount-time revalidation. */
+    staleTime?: number
     /**
      * Minimum interval (ms) between event-driven refetches of one query — burst
      * safety for server-window/server-authoritative reconciliation. The first
@@ -297,11 +303,13 @@ export class QueryStore<
     this.#telemetry = new QueryTelemetry()
     this.#mutations = new MutationTracker()
     this.#reconcileCooldown = reconcileCooldown
+    this.#staleTime = staleTime
     this.#retry = this.#normalizeRetry(retry)
     this.#retryDelay = retryDelay
     this.#reconnectJitter = this.#normalizeReconnectJitter(reconnectJitter)
     this.#visibility = visibility ?? documentVisibility()
-    this.#visibility.onChange(() => this.#drainDeferredReconciles())
+    this.#hiddenAt = this.#visibility.isHidden() ? Date.now() : null
+    this.#visibility.onChange(() => this.#visibilityChanged())
     if (this.#adapter.subscribeToConnectionEvents) {
       this.#adapter.subscribeToConnectionEvents(event => {
         const traceId = this.#telemetry.nextTraceId()
@@ -623,7 +631,7 @@ export class QueryStore<
       this.#telemetry.attachGraph(queryId, options.graph)
     }
 
-    const staleTime = options.staleTime ?? 0
+    const staleTime = options.staleTime ?? this.#staleTime
     const isFresh =
       staleTime > 0 && q.fetchedAt !== undefined && Date.now() - q.fetchedAt < staleTime
     if (
@@ -2455,15 +2463,37 @@ export class QueryStore<
     }
   }
 
+  #visibilityChanged(): void {
+    if (this.#visibility.isHidden()) {
+      this.#hiddenAt ??= Date.now()
+      return
+    }
+
+    const hiddenAt = this.#hiddenAt
+    this.#hiddenAt = null
+    const sleptPastStaleTime = hiddenAt !== null && Date.now() - hiddenAt >= this.#staleTime
+    if (sleptPastStaleTime) this.#markReconciliationPending()
+    const reconciled = this.#drainDeferredReconciles()
+    if (!sleptPastStaleTime) return
+
+    const queries = this.#activePendingReconciliationQueries().filter(
+      query => !reconciled.has(query.queryId),
+    )
+    this.#refetchActiveQueries(undefined, queries)
+  }
+
   /** On becoming visible, reconcile everything that deferred while hidden. */
-  #drainDeferredReconciles(): void {
-    if (this.#visibility.isHidden() || this.#deferredWhileHidden.size === 0) return
+  #drainDeferredReconciles(): Set<string> {
+    const reconciled = new Set<string>()
+    if (this.#visibility.isHidden() || this.#deferredWhileHidden.size === 0) return reconciled
     const deferred = Array.from(this.#deferredWhileHidden)
     this.#deferredWhileHidden.clear()
     for (const [queryId, causes] of deferred) {
       if (!this.#getQuery(queryId)) continue
+      reconciled.add(queryId)
       this.#requestReconcile(queryId, causes ? { causes } : {})
     }
+    return reconciled
   }
 
   #clearReconcileState(queryId: string): void {
@@ -2502,19 +2532,37 @@ export class QueryStore<
     }
   }
 
-  #activeReconnectQueries(): Array<{ queryId: string; force: boolean }> {
+  #markReconciliationPending(): void {
+    for (const service of this.getState().values()) {
+      if (service.materialized) this.#markQueryPending(service.materialized.queryId)
+      for (const query of service.queries.values()) {
+        if (query.queryId === service.materialized?.queryId) continue
+        if (this.#reconcilesAfterMissedEvents(query)) this.#markQueryPending(query.queryId)
+      }
+    }
+  }
+
+  #reconcilesAfterMissedEvents(query: Query<unknown, TMeta, unknown>): boolean {
+    return (
+      !query.config.skip &&
+      (query.config.realtime !== 'disabled' || this.#reconnectQueryIds.has(query.queryId))
+    )
+  }
+
+  #activePendingReconciliationQueries(): Array<{ queryId: string; force: boolean }> {
     const queryIds = new Map<string, boolean>()
     for (const service of this.getState().values()) {
       // Materialization roots reconcile even with no subscribers — every local read
       // depends on their completeness, and events may have been missed while offline.
       if (service.materialized) {
-        queryIds.set(service.materialized.queryId, true)
+        const root = service.queries.get(service.materialized.queryId)
+        if (root?.pending) queryIds.set(root.queryId, true)
       }
       for (const query of service.queries.values()) {
         if (query.queryId === service.materialized?.queryId) continue
         if (
-          !query.config.skip &&
-          (query.config.realtime !== 'disabled' || this.#reconnectQueryIds.has(query.queryId)) &&
+          query.pending &&
+          this.#reconcilesAfterMissedEvents(query) &&
           this.#listenerCount(query.queryId) > 0
         ) {
           queryIds.set(query.queryId, false)
@@ -2537,11 +2585,12 @@ export class QueryStore<
   }
 
   #scheduleReconnectSweep(traceId: number | undefined): void {
+    this.#markReconciliationPending()
     if (this.#reconnectSweepTimer) return
     const [min, max] = this.#reconnectJitter
     const delay = min === max ? min : min + Math.floor(Math.random() * (max - min + 1))
     if (delay === 0) {
-      const queries = this.#activeReconnectQueries()
+      const queries = this.#activePendingReconciliationQueries()
       this.#telemetry.emit({
         kind: 'reconnect:sweep',
         ...(traceId === undefined ? {} : { traceId }),
@@ -2562,7 +2611,7 @@ export class QueryStore<
 
     const timer = setTimeout(() => {
       this.#reconnectSweepTimer = null
-      const queries = this.#activeReconnectQueries()
+      const queries = this.#activePendingReconciliationQueries()
       this.#telemetry.emit({
         kind: 'reconnect:sweep',
         ...(traceId === undefined ? {} : { traceId }),

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -2471,15 +2471,18 @@ export class QueryStore<
 
     const hiddenAt = this.#hiddenAt
     this.#hiddenAt = null
-    const sleptPastStaleTime = hiddenAt !== null && Date.now() - hiddenAt >= this.#staleTime
-    if (sleptPastStaleTime) this.#markReconciliationPending()
+    const now = Date.now()
+    const sleptPastStaleTime = hiddenAt !== null && now - hiddenAt >= this.#staleTime
+    if (sleptPastStaleTime) {
+      this.#markReconciliationPending(query => !this.#isFresh(query.fetchedAt, now))
+    }
     const reconciled = this.#drainDeferredReconciles()
     if (!sleptPastStaleTime) return
 
     const queries = this.#activePendingReconciliationQueries().filter(
       query => !reconciled.has(query.queryId),
     )
-    this.#refetchActiveQueries(undefined, queries)
+    this.#refetchActiveQueries(queries, this.#telemetry.cause('visibility'))
   }
 
   /** On becoming visible, reconcile everything that deferred while hidden. */
@@ -2532,14 +2535,25 @@ export class QueryStore<
     }
   }
 
-  #markReconciliationPending(): void {
+  #markReconciliationPending(
+    shouldMark: (query: Query<unknown, TMeta, unknown>) => boolean = () => true,
+  ): void {
     for (const service of this.getState().values()) {
-      if (service.materialized) this.#markQueryPending(service.materialized.queryId)
+      if (service.materialized) {
+        const root = service.queries.get(service.materialized.queryId)
+        if (root && shouldMark(root)) this.#markQueryPending(root.queryId)
+      }
       for (const query of service.queries.values()) {
         if (query.queryId === service.materialized?.queryId) continue
-        if (this.#reconcilesAfterMissedEvents(query)) this.#markQueryPending(query.queryId)
+        if (this.#reconcilesAfterMissedEvents(query) && shouldMark(query)) {
+          this.#markQueryPending(query.queryId)
+        }
       }
     }
+  }
+
+  #isFresh(fetchedAt: number | undefined, now: number): boolean {
+    return fetchedAt !== undefined && now - fetchedAt < this.#staleTime
   }
 
   #reconcilesAfterMissedEvents(query: Query<unknown, TMeta, unknown>): boolean {
@@ -2573,13 +2587,13 @@ export class QueryStore<
   }
 
   #refetchActiveQueries(
-    traceId: number | undefined,
     queries: readonly { queryId: string; force: boolean }[],
+    cause?: TraceCause,
   ): void {
     for (const query of queries) {
       this.#requestReconcile(query.queryId, {
         force: query.force,
-        ...(traceId === undefined ? {} : { causes: [{ kind: 'reconnect' as const, traceId }] }),
+        ...(cause === undefined ? {} : { causes: [cause] }),
       })
     }
   }
@@ -2598,7 +2612,10 @@ export class QueryStore<
         delayMs: 0,
         queryCount: queries.length,
       })
-      this.#refetchActiveQueries(traceId, queries)
+      this.#refetchActiveQueries(
+        queries,
+        traceId === undefined ? undefined : { kind: 'reconnect', traceId },
+      )
       return
     }
 
@@ -2619,7 +2636,10 @@ export class QueryStore<
         delayMs: delay,
         queryCount: queries.length,
       })
-      this.#refetchActiveQueries(traceId, queries)
+      this.#refetchActiveQueries(
+        queries,
+        traceId === undefined ? undefined : { kind: 'reconnect', traceId },
+      )
     }, delay)
     ;(timer as { unref?: () => void }).unref?.()
     this.#reconnectSweepTimer = timer

--- a/lib/core/queryTelemetry.ts
+++ b/lib/core/queryTelemetry.ts
@@ -66,6 +66,8 @@ export class QueryTelemetry {
         return { kind, traceId }
       case 'reconnect':
         return { kind, traceId }
+      case 'visibility':
+        return { kind, traceId }
       case 'mutation':
         return { kind, traceId }
       case 'fetch-rebase':

--- a/lib/core/queryTypes.ts
+++ b/lib/core/queryTypes.ts
@@ -26,6 +26,7 @@ export interface Event {
 export type TraceCause =
   | { kind: 'realtime'; traceId: number }
   | { kind: 'reconnect'; traceId: number }
+  | { kind: 'visibility'; traceId: number }
   | { kind: 'mutation'; traceId: number; mutationId?: number }
   | { kind: 'fetch-rebase'; traceId: number }
   | { kind: 'manual'; traceId: number }

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -164,6 +164,14 @@ type GatherResult = {
   assembly: Map<string, AssembledRelationData>
 }
 
+type RelationalListener =
+  | { source: 'subscriber' | 'prefetch'; staleTime: number }
+  | { source: 'prepare'; staleTime: number; preparationGeneration: number }
+
+type PreparedAdoption =
+  | { kind: 'idle'; adoptedThrough: number }
+  | { kind: 'wave'; generation: number }
+
 export interface InspectedRelationalQuery {
   key: string
   name?: string
@@ -223,10 +231,9 @@ export class RelationalQueryRef<
   // "comments.reactions"). A relation is "synced" once its entry exists here — even a
   // kind:'empty' entry counts, so loading detection doesn't hang on empty relations.
   #relationSubs: Map<string, RelationSub<S, TParams, TMeta, TQuery>> = new Map()
-  #listeners: Map<
-    (state: RelationalQueryState<T>) => void,
-    { staleTime: number; source: 'subscriber' | 'prepare' | 'prefetch' }
-  > = new Map()
+  #listeners: Map<(state: RelationalQueryState<T>) => void, RelationalListener> = new Map()
+  #nextPreparationGeneration = 0
+  #preparedAdoption: PreparedAdoption = { kind: 'idle', adoptedThrough: 0 }
   #processedEventUnsub: (() => void) | null = null
   #relationalFilterRefetchQueued = false
   // Strictest active subscriber freshness tolerance — applied to newly-created
@@ -409,13 +416,20 @@ export class RelationalQueryRef<
       options?.staleTime === undefined
         ? this.#defaultStaleTime
         : validateStaleTime(options.staleTime, 'query(): staleTime')
-    // The active route preparation already made this query's freshness decision.
-    // Its lease covers the handoff to mounted readers, regardless of their normal policy.
-    const adoptsPreparation =
-      source === 'subscriber' &&
-      Array.from(this.#listeners.values()).some(listener => listener.source === 'prepare')
+    const listener: RelationalListener =
+      source === 'prepare'
+        ? {
+            source,
+            staleTime,
+            preparationGeneration: ++this.#nextPreparationGeneration,
+          }
+        : { source, staleTime }
+    // Preparation makes one freshness decision for the destination's initial React
+    // commit. Every subscriber in that synchronous wave adopts it; later mounts use
+    // their own staleTime even if the router keeps the preparation pinned.
+    const adoptsPreparation = source === 'subscriber' && this.#claimPreparedAdoption()
     const claimsColdStart = this.#coldStartAwaitingSubscriber
-    this.#listeners.set(fn, { staleTime, source })
+    this.#listeners.set(fn, listener)
     this.#staleTime = this.#currentStaleTime()
 
     if (!this.#root) {
@@ -459,6 +473,29 @@ export class RelationalQueryRef<
       staleTime = Math.min(staleTime, listener.staleTime)
     }
     return staleTime
+  }
+
+  #claimPreparedAdoption(): boolean {
+    const adoption = this.#preparedAdoption
+    const adoptedThrough = adoption.kind === 'wave' ? adoption.generation : adoption.adoptedThrough
+    let newestActive = adoptedThrough
+    for (const listener of this.#listeners.values()) {
+      if (listener.source === 'prepare') {
+        newestActive = Math.max(newestActive, listener.preparationGeneration)
+      }
+    }
+
+    if (newestActive > adoptedThrough) {
+      this.#preparedAdoption = { kind: 'wave', generation: newestActive }
+      queueMicrotask(() => {
+        const current = this.#preparedAdoption
+        if (current.kind === 'wave' && current.generation === newestActive) {
+          this.#preparedAdoption = { kind: 'idle', adoptedThrough: newestActive }
+        }
+      })
+    }
+
+    return this.#preparedAdoption.kind === 'wave'
   }
 
   #beginGraphRun(): string | null {
@@ -1642,6 +1679,12 @@ export class RelationalQueryRef<
     this.#lastRelationAssembly = null
     this.#lastGatherWasPartial = false
     this.#staleTime = 0
+    if (this.#preparedAdoption.kind === 'wave') {
+      this.#preparedAdoption = {
+        kind: 'idle',
+        adoptedThrough: this.#preparedAdoption.generation,
+      }
+    }
     // Evict from the figbird-level cache so a subsequent query rebuilds a fresh ref.
     // Reset the suspense promise state too — a fresh cold-start will need a fresh promise.
     this.#suspensePromise = null

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -41,6 +41,7 @@ import {
 } from './relationalFilters.js'
 import type { AnySchema, RelationshipDef, Schema } from './schema.js'
 import { resolveServicePath } from './schema.js'
+import { validateStaleTime } from './staleTime.js'
 
 export type { RelationalPaginationState } from './queryRoots.js'
 
@@ -404,7 +405,10 @@ export class RelationalQueryRef<
     },
   ): () => void {
     const source = options?.source ?? 'subscriber'
-    const staleTime = options?.staleTime ?? this.#defaultStaleTime
+    const staleTime =
+      options?.staleTime === undefined
+        ? this.#defaultStaleTime
+        : validateStaleTime(options.staleTime, 'query(): staleTime')
     // The active route preparation already made this query's freshness decision.
     // Its lease covers the handoff to mounted readers, regardless of their normal policy.
     const adoptsPreparation =

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -189,6 +189,7 @@ export interface RelationalRootOverride {
 }
 
 interface RelationalQueryOptions {
+  defaultStaleTime?: number
   root?: RelationalRootOverride
 }
 
@@ -274,6 +275,7 @@ export class RelationalQueryRef<
   #fanOutWarnedKeys: Set<string> = new Set()
 
   #onEvict: (() => void) | null = null
+  #defaultStaleTime: number
   #name: string | undefined
   #rootOverride: RelationalRootOverride | null
 
@@ -289,6 +291,7 @@ export class RelationalQueryRef<
     this.#schema = schema
     this.#queryId = `rq/${hashObject(options?.root ? { ast, root: options.root } : ast)}`
     this.#onEvict = onEvict ?? null
+    this.#defaultStaleTime = options?.defaultStaleTime ?? 0
     this.#rootOverride = options?.root ?? null
   }
 
@@ -400,9 +403,15 @@ export class RelationalQueryRef<
       source?: 'subscriber' | 'prepare' | 'prefetch'
     },
   ): () => void {
-    const staleTime = options?.staleTime ?? 0
+    const source = options?.source ?? 'subscriber'
+    const staleTime = options?.staleTime ?? this.#defaultStaleTime
+    // The active route preparation already made this query's freshness decision.
+    // Its lease covers the handoff to mounted readers, regardless of their normal policy.
+    const adoptsPreparation =
+      source === 'subscriber' &&
+      Array.from(this.#listeners.values()).some(listener => listener.source === 'prepare')
     const claimsColdStart = this.#coldStartAwaitingSubscriber
-    this.#listeners.set(fn, { staleTime, source: options?.source ?? 'subscriber' })
+    this.#listeners.set(fn, { staleTime, source })
     this.#staleTime = this.#currentStaleTime()
 
     if (!this.#root) {
@@ -416,7 +425,7 @@ export class RelationalQueryRef<
         queueMicrotask(() => {
           this.#coldStartAwaitingSubscriber = false
         })
-      } else {
+      } else if (!adoptsPreparation) {
         this.#ensureFresh(staleTime)
       }
     }

--- a/lib/core/staleTime.ts
+++ b/lib/core/staleTime.ts
@@ -1,5 +1,13 @@
 const MAX_TIMER_DELAY = 2_147_483_647
 
+export function isWithinStaleTime(
+  fetchedAt: number | undefined,
+  staleTime: number,
+  now = Date.now(),
+): boolean {
+  return staleTime > 0 && fetchedAt !== undefined && now - fetchedAt < staleTime
+}
+
 export function validateStaleTime(value: unknown, context: string): number {
   if (typeof value !== 'number' || Number.isNaN(value) || value < 0) {
     throw new RangeError(

--- a/lib/core/staleTime.ts
+++ b/lib/core/staleTime.ts
@@ -1,0 +1,24 @@
+const MAX_TIMER_DELAY = 2_147_483_647
+
+export function validateStaleTime(value: unknown, context: string): number {
+  if (typeof value !== 'number' || Number.isNaN(value) || value < 0) {
+    throw new RangeError(
+      `${context} must be a non-negative number or Infinity, got ${String(value)}`,
+    )
+  }
+  return value
+}
+
+export function validatePrefetchStaleTime(value: unknown): number {
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    value < 0 ||
+    value > MAX_TIMER_DELAY
+  ) {
+    throw new RangeError(
+      `prefetch(): staleTime must be between 0 and ${MAX_TIMER_DELAY}, got ${String(value)}`,
+    )
+  }
+  return value
+}

--- a/lib/core/windowQuery.ts
+++ b/lib/core/windowQuery.ts
@@ -3,6 +3,7 @@ import type { QueryAST } from './queryBuilder.js'
 import { RelationalQueryRef, type RelationalQueryHost } from './relationalQuery.js'
 import type { AnySchema, Schema } from './schema.js'
 import { resolveServicePath } from './schema.js'
+import { validateStaleTime } from './staleTime.js'
 import {
   CursorWindowPager,
   OffsetWindowPager,
@@ -206,10 +207,14 @@ export class WindowQueryRef<
     options: { range: WindowRange; staleTime?: number },
   ): () => void {
     const range = normalizeRange(options.range)
+    const staleTime =
+      options.staleTime === undefined
+        ? this.#defaultStaleTime
+        : validateStaleTime(options.staleTime, 'useWindowQuery(): staleTime')
     this.#subscribers.set(listener, {
       listener,
       range,
-      staleTime: options.staleTime ?? this.#defaultStaleTime,
+      staleTime,
     })
     const coldRead = this.#coldReads.get(rangeKey(range))
     if (coldRead?.status === 'settled') {

--- a/lib/core/windowQuery.ts
+++ b/lib/core/windowQuery.ts
@@ -77,7 +77,8 @@ interface SettledColdRead {
 
 type ColdRead = PendingColdRead | SettledColdRead
 
-interface WindowQueryLifecycle {
+interface WindowQueryOptions {
+  defaultStaleTime?: number
   onEvict?: () => void
   onIdle?: () => void
 }
@@ -123,6 +124,7 @@ export class WindowQueryRef<
   #pager: WindowPager
   #key: string
   #name: string | undefined
+  #defaultStaleTime: number
   #onEvict: (() => void) | null
   #onIdle: (() => void) | null
 
@@ -143,7 +145,7 @@ export class WindowQueryRef<
     ast: QueryAST,
     schema: S,
     config: WindowQueryConfig,
-    lifecycle?: WindowQueryLifecycle,
+    options?: WindowQueryOptions,
   ) {
     if (!Number.isInteger(config.pageSize) || config.pageSize <= 0) {
       throw new Error(
@@ -165,8 +167,9 @@ export class WindowQueryRef<
     this.#schema = schema
     this.#config = config
     this.#key = `wq/${hashObject({ ast, config })}`
-    this.#onEvict = lifecycle?.onEvict ?? null
-    this.#onIdle = lifecycle?.onIdle ?? null
+    this.#defaultStaleTime = options?.defaultStaleTime ?? 0
+    this.#onEvict = options?.onEvict ?? null
+    this.#onIdle = options?.onIdle ?? null
 
     const serviceName = resolveServicePath(schema, ast.service)
     const context = {
@@ -206,7 +209,7 @@ export class WindowQueryRef<
     this.#subscribers.set(listener, {
       listener,
       range,
-      staleTime: options.staleTime ?? 0,
+      staleTime: options.staleTime ?? this.#defaultStaleTime,
     })
     const coldRead = this.#coldReads.get(rangeKey(range))
     if (coldRead?.status === 'settled') {
@@ -364,7 +367,10 @@ export class WindowQueryRef<
       this.#ast,
       this.#schema,
       undefined,
-      { root: this.#pager.rootOverride(start) },
+      {
+        defaultStaleTime: this.#defaultStaleTime,
+        root: this.#pager.rootOverride(start),
+      },
     )
     ref.setDisplayName(this.#name ? `${this.#name} [${start}]` : undefined)
     const staleTime = this.#currentStaleTime()

--- a/lib/react/useQueries.ts
+++ b/lib/react/useQueries.ts
@@ -27,6 +27,7 @@ import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react'
 import type { RelationalQueryState } from '../core/figbird.js'
 import type { QueryInput, QueryInputBuilder } from '../core/queryDefinition.js'
 import { suspensePromiseAll } from '../core/relationalQuery.js'
+import { validateStaleTime } from '../core/staleTime.js'
 import type { AnyQueryBuilder, QueryBuilderKind, QueryBuilderResult } from '../core/queryBuilder.js'
 import type { Schema } from '../core/schema.js'
 import { useFigbird } from './context.js'
@@ -118,7 +119,10 @@ export function useQueryResultsImpl(
   queries: readonly SchemaQueryInput<Schema>[],
   options: UseQueriesOptions = {},
 ): SuspenseQueryResult<unknown>[] {
-  const { staleTime } = options
+  const staleTime =
+    options.staleTime === undefined
+      ? undefined
+      : validateStaleTime(options.staleTime, 'useQueries(): staleTime')
 
   // figbird.query() interns refs by AST hash, so each element is reference-stable
   // across renders while retained (same reasoning as useQueryRef — no memoization

--- a/lib/react/useQuery.ts
+++ b/lib/react/useQuery.ts
@@ -9,6 +9,7 @@ import {
   type RelationalQueryState,
 } from '../core/figbird.js'
 import type { Schema } from '../core/schema.js'
+import { validateStaleTime } from '../core/staleTime.js'
 import { useFigbird } from './context.js'
 
 /**
@@ -292,7 +293,11 @@ function useQueryResultForRef<T>(
   qRef: QueryRefLike<T> | null,
   options: UseQueryResultOptions,
 ): RelationalQueryResult<T> | SuspenseQueryResult<T> {
-  const { suspense = true, staleTime } = options
+  const { suspense = true } = options
+  const staleTime =
+    options.staleTime === undefined
+      ? undefined
+      : validateStaleTime(options.staleTime, 'useQuery(): staleTime')
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {

--- a/lib/react/useWindowQuery.ts
+++ b/lib/react/useWindowQuery.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useSyncExternalStore } from 'react'
 import type { AnyWindowQueryBuilder, QueryBuilderItem } from '../core/queryBuilder.js'
 import type { QueryInput, QueryRequest } from '../core/queryDefinition.js'
 import type { Schema } from '../core/schema.js'
+import { validateStaleTime } from '../core/staleTime.js'
 import type { WindowQueryConfig, WindowQueryState, WindowRange } from '../core/windowQuery.js'
 import { useFigbird } from './context.js'
 import type { UseQueryOptions } from './useQuery.js'
@@ -182,7 +183,11 @@ export function useWindowQueryImpl(
   query: QueryInput<AnyWindowQueryBuilder> | null,
   options: UseWindowQueryOptions,
 ): unknown {
-  const { range, suspense = true, staleTime, skip = false } = options
+  const { range, suspense = true, skip = false } = options
+  const staleTime =
+    options.staleTime === undefined
+      ? undefined
+      : validateStaleTime(options.staleTime, 'useWindowQuery(): staleTime')
   const config = normalizeConfig(options)
   const qRef = skip || query === null ? null : figbird.window(query, config)
   const reader = useMemo(() => (qRef ? new WindowQueryReader(qRef) : null), [qRef])

--- a/test/figbird.test.tsx
+++ b/test/figbird.test.tsx
@@ -64,14 +64,22 @@ interface AppOptions {
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   figbird?: Figbird<AppSchema, any>
   config?: Record<string, unknown>
+  staleTime?: number
 }
 
-function app({ feathers, figbird, config }: AppOptions = {}) {
+function app({ feathers, figbird, config, staleTime }: AppOptions = {}) {
   feathers = feathers || createFeathers()
   const adapter = new FeathersAdapter(feathers, config)
   // Create a properly typed figbird instance
   const figbirdInstance: Figbird<AppSchema, typeof adapter> =
-    figbird || new Figbird({ schema, adapter, eventBatchInterval: 0, retry: false })
+    figbird ||
+    new Figbird({
+      schema,
+      adapter,
+      eventBatchInterval: 0,
+      retry: false,
+      ...(staleTime === undefined ? {} : { staleTime }),
+    })
 
   // Create typed hooks from the schema. The provider selects the runtime instance.
   const { useGet, useFind, useMutation } = createHooks<typeof schema, typeof adapter>(schema)
@@ -945,7 +953,7 @@ test('useFind with refetch while already fetching', async t => {
 })
 
 test('refetch only works with active listeners', async t => {
-  const { App, useFind, feathers } = app()
+  const { App, useFind, feathers } = app({ staleTime: 0 })
   let refetch: () => void
   let calls = 0
 
@@ -1214,7 +1222,7 @@ test('useFind - realtime refetch', async t => {
 })
 
 test('useFind - realtime refetch only with active listeners', async t => {
-  const { App, useFind, feathers } = app()
+  const { App, useFind, feathers } = app({ staleTime: 0 })
   let findCallCount = 0
 
   function Note() {
@@ -1341,7 +1349,7 @@ test('useFind - realtime disabled', async t => {
 
 test('useFind - fetchPolicy swr', async t => {
   const { render, flush, unmount, $all } = dom()
-  const { App, useFind, feathers } = app()
+  const { App, useFind, feathers } = app({ staleTime: 0 })
 
   let renderNote: React.Dispatch<React.SetStateAction<boolean>>
 

--- a/test/reconcile.test.tsx
+++ b/test/reconcile.test.tsx
@@ -47,9 +47,11 @@ function fakeVisibility(initiallyHidden = false) {
 
 function createApp({
   reconcileCooldown,
+  staleTime,
   visibility,
 }: {
   reconcileCooldown?: number
+  staleTime?: number
   visibility?: VisibilitySource
 } = {}) {
   const feathers = mockFeathers({
@@ -61,6 +63,7 @@ function createApp({
     adapter,
     eventBatchInterval: 0,
     ...(reconcileCooldown !== undefined ? { reconcileCooldown } : {}),
+    ...(staleTime !== undefined ? { staleTime } : {}),
     ...(visibility !== undefined ? { visibility } : {}),
   })
   return { figbird, feathers }
@@ -258,6 +261,72 @@ test('hidden tabs: a reconnect while hidden defers the refetch-all until visible
   t.is(notes.counts.find, baseline + 2)
 
   unsub()
+})
+
+test('visibility: returning after staleTime reconciles active queries once', async t => {
+  const realNow = Date.now
+  let now = realNow()
+  Date.now = () => now
+  t.teardown(() => {
+    Date.now = realNow
+  })
+  const visibility = fakeVisibility(false)
+  const { figbird, feathers } = createApp({
+    reconcileCooldown: 0,
+    staleTime: 20,
+    visibility: visibility.source,
+  })
+  const notes = feathers.service('notes')
+  const ref = figbird.queryDesc({ serviceName: 'notes', method: 'find' })
+  const unsub = ref.subscribe(() => {})
+  await sleep(20)
+  const baseline = notes.counts.find
+
+  visibility.set(true)
+  now += 19
+  visibility.set(false)
+  await sleep(10)
+  t.is(notes.counts.find, baseline, 'a short background visit keeps the live result')
+
+  visibility.set(true)
+  now += 20
+  visibility.set(false)
+  await sleep(20)
+  t.is(notes.counts.find, baseline + 1, 'a meaningful sleep gets one safety refetch')
+
+  unsub()
+})
+
+test('reconnect: inactive cached queries become pending for their next subscriber', async t => {
+  const feathers = mockFeathers({
+    notes: { data: { 1: { id: 1, content: 'hello' } } },
+  })
+  const io = new EventEmitter()
+  ;(feathers as unknown as { io: EventEmitter }).io = io
+  const figbird = new Figbird({
+    schema,
+    adapter: new FeathersAdapter(feathers),
+    eventBatchInterval: 0,
+    reconcileCooldown: 0,
+    reconnectJitter: [40, 40],
+  })
+  const notes = feathers.service('notes')
+  const ref = figbird.queryDesc({ serviceName: 'notes', method: 'find' })
+  const unsub = ref.subscribe(() => {})
+  await sleep(20)
+  const baseline = notes.counts.find
+  unsub()
+
+  io.emit('reconnect')
+  t.is(notes.counts.find, baseline, 'reconnect does not fetch an inactive query')
+
+  const resubscribe = ref.subscribe(() => {})
+  await sleep(20)
+  t.is(notes.counts.find, baseline + 1, 'pending overrides the five-minute default')
+
+  await sleep(40)
+  t.is(notes.counts.find, baseline + 1, 'the delayed sweep does not repeat that fetch')
+  resubscribe()
 })
 
 test('reconnect jitter delays and coalesces a visible-tab sweep', async t => {

--- a/test/reconcile.test.tsx
+++ b/test/reconcile.test.tsx
@@ -277,6 +277,12 @@ test('visibility: returning after staleTime reconciles active queries once', asy
     visibility: visibility.source,
   })
   const notes = feathers.service('notes')
+  const reconcileCauses: string[][] = []
+  const unsubscribeEvents = figbird.events.subscribe(event => {
+    if (event.kind === 'fetch:start' && event.reason === 'reconcile') {
+      reconcileCauses.push(event.causes?.map(cause => cause.kind) ?? [])
+    }
+  })
   const ref = figbird.queryDesc({ serviceName: 'notes', method: 'find' })
   const unsub = ref.subscribe(() => {})
   await sleep(20)
@@ -289,12 +295,27 @@ test('visibility: returning after staleTime reconciles active queries once', asy
   t.is(notes.counts.find, baseline, 'a short background visit keeps the live result')
 
   visibility.set(true)
+  now += 15
+  ref.refetch()
+  await sleep(10)
+  now += 5
+  visibility.set(false)
+  await sleep(10)
+  t.is(
+    notes.counts.find,
+    baseline + 1,
+    'a query refreshed while hidden is not immediately fetched again',
+  )
+
+  visibility.set(true)
   now += 20
   visibility.set(false)
   await sleep(20)
-  t.is(notes.counts.find, baseline + 1, 'a meaningful sleep gets one safety refetch')
+  t.is(notes.counts.find, baseline + 2, 'a meaningful sleep gets one safety refetch')
+  t.deepEqual(reconcileCauses, [['visibility']])
 
   unsub()
+  unsubscribeEvents()
 })
 
 test('reconnect: inactive cached queries become pending for their next subscriber', async t => {

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -3245,6 +3245,55 @@ test('staleTime: the five-minute default skips SWR revalidation and explicit zer
   unsub3()
 })
 
+test('staleTime: public entry points reject invalid durations', t => {
+  const { adapter } = createApp()
+  t.throws(() => new Figbird({ schema, adapter, staleTime: Number.NaN }), {
+    instanceOf: RangeError,
+    message: /Figbird\(\): staleTime must be a non-negative number or Infinity/,
+  })
+  t.notThrows(() => new Figbird({ schema, adapter, staleTime: Infinity }))
+
+  const { App, figbird } = createApp()
+  const builder = figbird.q.issues.related('creator')
+
+  function InvalidReader() {
+    useQuery(builder, { staleTime: Number.NaN })
+    return null
+  }
+
+  t.throws(
+    () =>
+      renderToString(
+        <App>
+          <InvalidReader />
+        </App>,
+      ),
+    {
+      instanceOf: RangeError,
+      message: /useQuery\(\): staleTime must be a non-negative number or Infinity/,
+    },
+  )
+
+  t.throws(() => figbird.query(builder).subscribe(() => {}, { staleTime: -1 }), {
+    instanceOf: RangeError,
+    message: /query\(\): staleTime must be a non-negative number or Infinity/,
+  })
+  t.throws(() =>
+    figbird
+      .queryDesc({ serviceName: 'issues', method: 'find' })
+      .subscribe(() => {}, { staleTime: Number.NaN }),
+  )
+  t.throws(() => figbird.prepare(builder, { staleTime: -1 }), {
+    instanceOf: RangeError,
+    message: /prepare\(\): staleTime must be a non-negative number or Infinity/,
+  })
+  t.throws(() => figbird.prefetch(builder, { staleTime: Infinity }), {
+    instanceOf: RangeError,
+    message: /prefetch\(\): staleTime must be between 0 and 2147483647/,
+  })
+  t.throws(() => figbird.prefetch(builder, { staleTime: Number.MAX_SAFE_INTEGER }))
+})
+
 test('prefetch, prepare, and mount share one request while the preparation lease is active', async t => {
   const { figbird, feathers } = createApp()
   const { q } = createHooks(schema)
@@ -3264,6 +3313,22 @@ test('prefetch, prepare, and mount share one request while the preparation lease
   t.is(feathers.service('users').counts.find, 1, 'the relation is fetched once')
   prepared.release()
   mounted()
+})
+
+test('prepare: an abort signal releases the route preparation lease', async t => {
+  const { figbird } = createApp()
+  const request = figbird.q.issues.get(1).related('creator')
+  const controller = new AbortController()
+  const prepared = figbird.prepare(request, { signal: controller.signal })
+  const ref = figbird.query(request)
+
+  t.is(ref.inspect().prepareCount, 1)
+  controller.abort()
+  t.is(ref.inspect().prepareCount, 0)
+  await t.throwsAsync(prepared.promise, { name: 'AbortError' })
+
+  // Explicit cleanup remains safe for routers that release in a finally block.
+  prepared.release()
 })
 
 test('staleTime: stricter subscriber revalidates an already-live relational query', async t => {

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -3205,12 +3205,18 @@ test('snapshot: frozen queries ignore realtime; refetch still works; explain say
   unmount()
 })
 
-test('staleTime: fresh data skips the SWR revalidation on resubscribe', async t => {
+test('staleTime: the five-minute default skips SWR revalidation and explicit zero opts out', async t => {
+  const realNow = Date.now
+  let now = realNow()
+  Date.now = () => now
+  t.teardown(() => {
+    Date.now = realNow
+  })
   const { figbird, feathers } = createApp()
   const builder = figbird.q.issues.related('creator')
 
   // Cold read — fetches.
-  const unsub1 = figbird.query(builder).subscribe(() => {}, { staleTime: 60_000 })
+  const unsub1 = figbird.query(builder).subscribe(() => {})
   await new Promise(resolve => setTimeout(resolve, 10))
   t.is(feathers.service('issues').counts.find, 1)
   unsub1()
@@ -3218,45 +3224,46 @@ test('staleTime: fresh data skips the SWR revalidation on resubscribe', async t 
 
   // Resubscribe within the tolerance — warm store data, no revalidation.
   const ref2 = figbird.query(builder)
-  const unsub2 = ref2.subscribe(() => {}, { staleTime: 60_000 })
+  const unsub2 = ref2.subscribe(() => {})
   await new Promise(resolve => setTimeout(resolve, 10))
   t.is(feathers.service('issues').counts.find, 1, 'fresh data must not refetch')
   t.is(ref2.getSnapshot().status, 'success')
   unsub2()
   await new Promise(resolve => setTimeout(resolve, 10))
 
-  // Default tolerance (0) revalidates on resubscribe.
-  const unsub3 = figbird.query(builder).subscribe(() => {})
+  now += 5 * 60_000
+  const stale = figbird.query(builder).subscribe(() => {})
   await new Promise(resolve => setTimeout(resolve, 10))
-  t.is(feathers.service('issues').counts.find, 2, 'default revalidates on resubscribe')
+  t.is(feathers.service('issues').counts.find, 2, 'the default expires at five minutes')
+  stale()
+  await new Promise(resolve => setTimeout(resolve, 10))
+
+  // A read site can still demand mount-time revalidation.
+  const unsub3 = figbird.query(builder).subscribe(() => {}, { staleTime: 0 })
+  await new Promise(resolve => setTimeout(resolve, 10))
+  t.is(feathers.service('issues').counts.find, 3, 'explicit zero revalidates on resubscribe')
   unsub3()
 })
 
-test('prepare and prefetch install staleTime before materializing a warm query', async t => {
+test('prefetch, prepare, and mount share one request while the preparation lease is active', async t => {
   const { figbird, feathers } = createApp()
   const { q } = createHooks(schema)
   const issueDetail = defineQuery('preparedIssueStaleTime', ({ id }: { id: number }) =>
     q.issues.get(id).related('creator'),
   )
 
-  const first = figbird.prepare(issueDetail({ id: 1 }), { staleTime: 60_000 })
-  await first.promise
-  first.release()
+  figbird.prefetch(issueDetail({ id: 1 }))
   await new Promise(resolve => setTimeout(resolve, 10))
 
-  const second = figbird.prepare(issueDetail({ id: 1 }), { staleTime: 60_000 })
-  await second.promise
+  const prepared = figbird.prepare(issueDetail({ id: 1 }))
+  await prepared.promise
+  const mounted = figbird.query(issueDetail({ id: 1 })).subscribe(() => {}, { staleTime: 0 })
   await new Promise(resolve => setTimeout(resolve, 10))
 
-  t.is(feathers.service('issues').counts.get, 1, 'fresh root must not revalidate')
-  t.is(feathers.service('users').counts.find, 1, 'fresh relation must not revalidate')
-  second.release()
-  await new Promise(resolve => setTimeout(resolve, 10))
-
-  figbird.prefetch(issueDetail({ id: 1 }), { staleTime: 60_000 })
-  await new Promise(resolve => setTimeout(resolve, 10))
-  t.is(feathers.service('issues').counts.get, 1, 'prefetch must respect fresh root data')
-  t.is(feathers.service('users').counts.find, 1, 'prefetch must respect fresh relation data')
+  t.is(feathers.service('issues').counts.get, 1, 'the root is fetched once')
+  t.is(feathers.service('users').counts.find, 1, 'the relation is fetched once')
+  prepared.release()
+  mounted()
 })
 
 test('staleTime: stricter subscriber revalidates an already-live relational query', async t => {
@@ -3271,10 +3278,10 @@ test('staleTime: stricter subscriber revalidates an already-live relational quer
   t.is(feathers.service('issues').counts.get, 1)
   t.is(feathers.service('users').counts.find, 1)
 
-  // A normal subscriber has staleTime 0. Even though it joins the already-live
+  // An explicitly strict subscriber has staleTime 0. Even though it joins the already-live
   // relational ref, its stricter tolerance must propagate to the root and relation refs.
   const ref = figbird.query(issueDetail({ id: 1 }))
-  const unsub = ref.subscribe(() => {})
+  const unsub = ref.subscribe(() => {}, { staleTime: 0 })
   await new Promise(resolve => setTimeout(resolve, 10))
 
   t.is(feathers.service('issues').counts.get, 2, 'root get must revalidate')

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -3294,25 +3294,90 @@ test('staleTime: public entry points reject invalid durations', t => {
   t.throws(() => figbird.prefetch(builder, { staleTime: Number.MAX_SAFE_INTEGER }))
 })
 
-test('prefetch, prepare, and mount share one request while the preparation lease is active', async t => {
+test('prepared result adoption covers one subscriber wave, not the retained pin lifetime', async t => {
   const { figbird, feathers } = createApp()
   const { q } = createHooks(schema)
   const issueDetail = defineQuery('preparedIssueStaleTime', ({ id }: { id: number }) =>
     q.issues.get(id).related('creator'),
   )
+  const request = issueDetail({ id: 1 })
 
-  figbird.prefetch(issueDetail({ id: 1 }))
-  await new Promise(resolve => setTimeout(resolve, 10))
-
-  const prepared = figbird.prepare(issueDetail({ id: 1 }))
+  figbird.prefetch(request)
+  const prepared = figbird.prepare(request)
   await prepared.promise
-  const mounted = figbird.query(issueDetail({ id: 1 })).subscribe(() => {}, { staleTime: 0 })
-  await new Promise(resolve => setTimeout(resolve, 10))
+  const ref = figbird.query(request)
+  const first = ref.subscribe(() => {}, { staleTime: 0 })
+  const sibling = ref.subscribe(() => {}, { staleTime: 0 })
+  first()
+  sibling()
+  const strictModeReplay = ref.subscribe(() => {}, { staleTime: 0 })
+  await new Promise<void>(resolve => queueMicrotask(resolve))
 
-  t.is(feathers.service('issues').counts.get, 1, 'the root is fetched once')
-  t.is(feathers.service('users').counts.find, 1, 'the relation is fetched once')
+  t.is(feathers.service('issues').counts.get, 1, 'the initial subscriber wave adopts the root')
+  t.is(feathers.service('users').counts.find, 1, 'the initial subscriber wave adopts the relation')
+
+  strictModeReplay()
+  let releaseLaterMount = () => {}
+  await new Promise<void>(resolve => {
+    releaseLaterMount = ref.subscribe(
+      state => {
+        if (state.status === 'success' && !state.isFetching) resolve()
+      },
+      { staleTime: 0 },
+    )
+  })
+
+  t.is(feathers.service('issues').counts.get, 2, 'a later mount revalidates the root')
+  t.is(feathers.service('users').counts.find, 2, 'a later mount revalidates the relation')
   prepared.release()
-  mounted()
+  releaseLaterMount()
+})
+
+test('prepared result adoption orders overlapping and cancelled generations', async t => {
+  const { figbird, feathers } = createApp()
+  const { q } = createHooks(schema)
+  const issueDetail = defineQuery('preparedIssueGeneration', ({ id }: { id: number }) =>
+    q.issues.get(id).related('creator'),
+  )
+  const request = issueDetail({ id: 1 })
+
+  const older = figbird.prepare(request)
+  const cancelledBeforeClaim = figbird.prepare(request, { staleTime: Infinity })
+  cancelledBeforeClaim.release()
+  await older.promise
+
+  const ref = figbird.query(request)
+  const firstMount = ref.subscribe(() => {}, { staleTime: 0 })
+  await new Promise<void>(resolve => queueMicrotask(resolve))
+  t.is(feathers.service('issues').counts.get, 1, 'the surviving older generation is adopted')
+  t.is(feathers.service('users').counts.find, 1)
+  firstMount()
+
+  const newer = figbird.prepare(request, { staleTime: Infinity })
+  await newer.promise
+  const secondMount = ref.subscribe(() => {}, { staleTime: 0 })
+  await new Promise<void>(resolve => queueMicrotask(resolve))
+  t.is(feathers.service('issues').counts.get, 1, 'a newer generation gets its own adoption wave')
+  t.is(feathers.service('users').counts.find, 1)
+  secondMount()
+  newer.release()
+
+  const cancelledAfterClaim = figbird.prepare(request, { staleTime: Infinity })
+  cancelledAfterClaim.release()
+  let releaseLaterMount = () => {}
+  await new Promise<void>(resolve => {
+    releaseLaterMount = ref.subscribe(
+      state => {
+        if (state.status === 'success' && !state.isFetching) resolve()
+      },
+      { staleTime: 0 },
+    )
+  })
+
+  t.is(feathers.service('issues').counts.get, 2, 'the consumed older generation stays closed')
+  t.is(feathers.service('users').counts.find, 2)
+  older.release()
+  releaseLaterMount()
 })
 
 test('staleTime: stricter subscriber revalidates an already-live relational query', async t => {

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -3315,22 +3315,6 @@ test('prefetch, prepare, and mount share one request while the preparation lease
   mounted()
 })
 
-test('prepare: an abort signal releases the route preparation lease', async t => {
-  const { figbird } = createApp()
-  const request = figbird.q.issues.get(1).related('creator')
-  const controller = new AbortController()
-  const prepared = figbird.prepare(request, { signal: controller.signal })
-  const ref = figbird.query(request)
-
-  t.is(ref.inspect().prepareCount, 1)
-  controller.abort()
-  t.is(ref.inspect().prepareCount, 0)
-  await t.throwsAsync(prepared.promise, { name: 'AbortError' })
-
-  // Explicit cleanup remains safe for routers that release in a finally block.
-  prepared.release()
-})
-
 test('staleTime: stricter subscriber revalidates an already-live relational query', async t => {
   const { figbird, feathers } = createApp()
   const issueDetail = defineQuery('issueDetailStaleTime', ({ id }: { id: number }) =>

--- a/test/window-query.test.tsx
+++ b/test/window-query.test.tsx
@@ -249,7 +249,7 @@ test('window query: retained pages follow the strictest active reader', async t 
     preloadPages: 0,
     maxPages: 2,
   })
-  const lenient = readSettledWindow(ref, range, Infinity)
+  const lenient = readSettledWindow(ref, range)
   await lenient.promise
   const service = feathers.service('items')
   const initialFetches = service.counts.find


### PR DESCRIPTION
## Summary

- default successful query results to a five-minute stale window, configurable per Figbird instance and overridable per reader
- let mounted subscribers adopt an active prepared query without a second freshness check while keeping prefetch retention at 30 seconds
- reconcile active queries after meaningful background sleep and mark inactive cache entries pending on reconnect or long visibility gaps
- document the freshness contract and update legacy SWR tests to opt into staleTime 0 explicitly

## Verification

- npm run test (361 tests passed)
- npm run build

## Release

No version bump is included. This is ready for the next prerelease cut, expected to be 0.24.0-pre.13.