### PR TITLE
Remember the active devtools tab

### DIFF
--- a/lib/devtools/CacheTab.tsx
+++ b/lib/devtools/CacheTab.tsx
@@ -35,7 +35,7 @@ import {
 } from './ui.js'
 
 const CACHE_COLUMNS = [
-  { label: 'service', width: 140, minWidth: 95 },
+  { label: 'service', width: 280, minWidth: 95 },
   { label: 'entity', width: 150, minWidth: 90 },
   { label: 'value', width: 310, minWidth: 160 },
   { label: 'est. size', width: 90, minWidth: 72 },

--- a/lib/devtools/Devtools.tsx
+++ b/lib/devtools/Devtools.tsx
@@ -68,11 +68,7 @@ export function FigbirdDevtoolsPanel({
   const colors = colorScheme === 'dark' ? darkColors : lightColors
   const styles = useMemo(() => makeStyles(colors), [colors])
   const themeValue = useMemo(() => ({ colors, styles }), [colors, styles])
-  const [tab, setTabState] = useState<Tab>(readStoredTab)
-  const setTab = useCallback((nextTab: Tab) => {
-    setTabState(nextTab)
-    storeTab(nextTab)
-  }, [])
+  const [tab, setTab] = useState<Tab>(readStoredTab)
   const [queryFilter, setQueryFilter] = useState('')
   const [queryVisibility, setQueryVisibility] = useState<QueryVisibility>('active')
   const [eventFilter, setEventFilter] = useState('')
@@ -92,25 +88,24 @@ export function FigbirdDevtoolsPanel({
   const [timelineFollow, setTimelineFollow] = useState(true)
   const panelRef = useRef<HTMLElement>(null)
 
-  const inspectFetch = useCallback(
-    (span: QuerySpan) => {
-      if (span.fetchId !== undefined) {
-        setTimelineFilter('')
-        setTimelineVisibility('all')
-        setTimelineFollow(false)
-        setRequestedTimelineActivityId(`fetch:${span.fetchId}`)
-        setTab('timeline')
-        return
-      }
+  useEffect(() => storeTab(tab), [tab])
 
-      const traceId = span.traceIds?.[0]
-      if (traceId !== undefined) {
-        setSelectedTraceId(traceId)
-        setTab('events')
-      }
-    },
-    [setTab],
-  )
+  const inspectFetch = useCallback((span: QuerySpan) => {
+    if (span.fetchId !== undefined) {
+      setTimelineFilter('')
+      setTimelineVisibility('all')
+      setTimelineFollow(false)
+      setRequestedTimelineActivityId(`fetch:${span.fetchId}`)
+      setTab('timeline')
+      return
+    }
+
+    const traceId = span.traceIds?.[0]
+    if (traceId !== undefined) {
+      setSelectedTraceId(traceId)
+      setTab('events')
+    }
+  }, [])
 
   const openQuery = useCallback(
     (queryId: string) => {
@@ -120,17 +115,14 @@ export function FigbirdDevtoolsPanel({
       setSelectedQueryId(queryId)
       setTab('queries')
     },
-    [inspection, setTab],
+    [inspection],
   )
 
-  const openCacheEntity = useCallback(
-    (serviceName: string, itemId: string | number) => {
-      setCacheFilter('')
-      setRequestedCacheEntity({ serviceName, itemId })
-      setTab('cache')
-    },
-    [setTab],
-  )
+  const openCacheEntity = useCallback((serviceName: string, itemId: string | number) => {
+    setCacheFilter('')
+    setRequestedCacheEntity({ serviceName, itemId })
+    setTab('cache')
+  }, [])
 
   useEffect(() => {
     collector.start()

--- a/lib/devtools/Devtools.tsx
+++ b/lib/devtools/Devtools.tsx
@@ -18,7 +18,10 @@ import {
   type DevtoolsThemeMode,
 } from './ui.js'
 
-type Tab = 'queries' | 'timeline' | 'events' | 'cache'
+const TABS = ['queries', 'timeline', 'events', 'cache'] as const
+const DEVTOOLS_TAB_STORAGE_KEY = 'figbird.devtools.tab'
+
+type Tab = (typeof TABS)[number]
 export type QueryVisibility = 'active' | 'inactive' | 'retained' | 'all' | 'skipped'
 export type EventVisibility = 'groups' | 'raw'
 
@@ -65,7 +68,11 @@ export function FigbirdDevtoolsPanel({
   const colors = colorScheme === 'dark' ? darkColors : lightColors
   const styles = useMemo(() => makeStyles(colors), [colors])
   const themeValue = useMemo(() => ({ colors, styles }), [colors, styles])
-  const [tab, setTab] = useState<Tab>('queries')
+  const [tab, setTabState] = useState<Tab>(readStoredTab)
+  const setTab = useCallback((nextTab: Tab) => {
+    setTabState(nextTab)
+    storeTab(nextTab)
+  }, [])
   const [queryFilter, setQueryFilter] = useState('')
   const [queryVisibility, setQueryVisibility] = useState<QueryVisibility>('active')
   const [eventFilter, setEventFilter] = useState('')
@@ -85,22 +92,25 @@ export function FigbirdDevtoolsPanel({
   const [timelineFollow, setTimelineFollow] = useState(true)
   const panelRef = useRef<HTMLElement>(null)
 
-  const inspectFetch = useCallback((span: QuerySpan) => {
-    if (span.fetchId !== undefined) {
-      setTimelineFilter('')
-      setTimelineVisibility('all')
-      setTimelineFollow(false)
-      setRequestedTimelineActivityId(`fetch:${span.fetchId}`)
-      setTab('timeline')
-      return
-    }
+  const inspectFetch = useCallback(
+    (span: QuerySpan) => {
+      if (span.fetchId !== undefined) {
+        setTimelineFilter('')
+        setTimelineVisibility('all')
+        setTimelineFollow(false)
+        setRequestedTimelineActivityId(`fetch:${span.fetchId}`)
+        setTab('timeline')
+        return
+      }
 
-    const traceId = span.traceIds?.[0]
-    if (traceId !== undefined) {
-      setSelectedTraceId(traceId)
-      setTab('events')
-    }
-  }, [])
+      const traceId = span.traceIds?.[0]
+      if (traceId !== undefined) {
+        setSelectedTraceId(traceId)
+        setTab('events')
+      }
+    },
+    [setTab],
+  )
 
   const openQuery = useCallback(
     (queryId: string) => {
@@ -110,14 +120,17 @@ export function FigbirdDevtoolsPanel({
       setSelectedQueryId(queryId)
       setTab('queries')
     },
-    [inspection],
+    [inspection, setTab],
   )
 
-  const openCacheEntity = useCallback((serviceName: string, itemId: string | number) => {
-    setCacheFilter('')
-    setRequestedCacheEntity({ serviceName, itemId })
-    setTab('cache')
-  }, [])
+  const openCacheEntity = useCallback(
+    (serviceName: string, itemId: string | number) => {
+      setCacheFilter('')
+      setRequestedCacheEntity({ serviceName, itemId })
+      setTab('cache')
+    },
+    [setTab],
+  )
 
   useEffect(() => {
     collector.start()
@@ -176,7 +189,7 @@ export function FigbirdDevtoolsPanel({
         <TooltipLayer rootRef={panelRef} />
         <header style={styles.header}>
           <span style={styles.brand}>figbird</span>
-          {(['queries', 'timeline', 'events', 'cache'] as const).map(item => (
+          {TABS.map(item => (
             <TabButton key={item} active={tab === item} onClick={() => setTab(item)} label={item} />
           ))}
           {tab === 'queries' ? (
@@ -388,6 +401,27 @@ export function FigbirdDevtoolsPanel({
       </section>
     </ThemeContext.Provider>
   )
+}
+
+function readStoredTab(): Tab {
+  if (typeof window === 'undefined') return 'timeline'
+
+  try {
+    const storedTab = window.localStorage.getItem(DEVTOOLS_TAB_STORAGE_KEY)
+    return TABS.find(tab => tab === storedTab) ?? 'timeline'
+  } catch {
+    return 'timeline'
+  }
+}
+
+function storeTab(tab: Tab): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    window.localStorage.setItem(DEVTOOLS_TAB_STORAGE_KEY, tab)
+  } catch {
+    // Devtools still work when storage is unavailable.
+  }
 }
 
 function inspectionTitle({

--- a/lib/devtools/EventsTab.tsx
+++ b/lib/devtools/EventsTab.tsx
@@ -36,7 +36,7 @@ import {
 const EVENT_COLUMNS = [
   { label: 'time', width: 108, minWidth: 84 },
   { label: 'group', width: 112, minWidth: 84 },
-  { label: 'service', width: 130, minWidth: 92 },
+  { label: 'service', width: 260, minWidth: 92 },
   { label: 'operation', width: 92, minWidth: 72 },
   { label: 'scope', width: 135, minWidth: 92 },
   { label: 'status', width: 94, minWidth: 74 },

--- a/lib/devtools/QueriesTab.tsx
+++ b/lib/devtools/QueriesTab.tsx
@@ -36,7 +36,7 @@ export function operationIsRetained(operation: DevtoolsOperation): boolean {
 const QUERY_COLUMNS = [
   {
     label: 'service',
-    width: 185,
+    width: 370,
     minWidth: 120,
     description:
       'Query service. The dot shows its state: green active, amber inactive cached, blue pending, red error, or gray skipped/retained history.',

--- a/test/devtools.test.tsx
+++ b/test/devtools.test.tsx
@@ -933,6 +933,8 @@ test('query details show a cursor operation as one inspectable page chain', t =>
   }
 
   render(<FigbirdDevtoolsPanel collector={collector} theme='light' />)
+  t.truthy($('[aria-label="Timeline visibility"]'))
+  click($all('button').find(button => button.textContent === 'queries')!)
   const row = $all('tbody tr')[0]
   t.truthy(row)
   t.is(row?.querySelectorAll('td')[1]?.textContent, 'paginate')
@@ -951,6 +953,10 @@ test('query details show a cursor operation as one inspectable page chain', t =>
   t.true(details.includes('after start · next "cursor:25"'))
   t.true(details.includes('after "cursor:25" · end'))
   t.false(details.includes('merges stable updates'))
+
+  render(<></>)
+  render(<FigbirdDevtoolsPanel collector={collector} theme='light' />)
+  t.is($all('th')[0]?.textContent, 'service')
   unmount()
 })
 
@@ -1346,6 +1352,7 @@ test('panel shows root queries and nests relation fetches in details', async t =
   }
 
   render(<FigbirdDevtoolsPanel collector={collector} inspection={inspection} />)
+  click($all('button').find(button => button.textContent === 'queries')!)
   await act(async () => {
     const graph = {
       operationId: inspectedRef.hash(),

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -31,7 +31,7 @@ interface DomHelpers {
 }
 
 export function dom(options?: RootOptions): DomHelpers {
-  const dom = new JSDOM('<!doctype html><div id="root"></div>')
+  const dom = new JSDOM('<!doctype html><div id="root"></div>', { url: 'https://figbird.test' })
   // JSDOM's DOMWindow interface doesn't perfectly match TypeScript's Window & typeof globalThis.
   // The double assertion pattern (as unknown as T) is the recommended approach when we need
   // to bridge incompatible types that we know are safe to use in our context.


### PR DESCRIPTION
## Summary

- default new devtools sessions to the Timeline tab
- persist the last selected tab and restore it when devtools reopen
- double the default service column width in Queries, Events, and Cache

## Verification

- npm run tsc
- npm run lint
- npm run ava (359 tests)
- npm run test
- npm run devtools:build