### PR TITLE
Migrate Hugo tooling to mise

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,0 @@
-hugo extended_0.143.0

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,5 +1,5 @@
 baseURL = "https://humaans.github.io/figbird"
-languageCode = "en-us"
+locale = "en-us"
 title = "Figbird"
 description = "Effortless realtime data management for React + Feathers applications."
 

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
 <head>
   {{ hugo.Generator }}

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+hugo-extended = "0.165.0"


### PR DESCRIPTION
## Summary

- replace the asdf .tool-versions file with mise.toml
- pin Hugo Extended 0.165.0
- update the deprecated Hugo locale settings

## Testing

- npm run test (363 tests)
- mise exec -- npm run docs:build