### PR TITLE
Widen timeline activity and add Firefox upload command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: release-extensions
+.PHONY: release-extensions upload-firefox-extension
 
 release-extensions:
 	@node tasks/release-devtools.js
+
+upload-firefox-extension:
+	@node tasks/upload-firefox-devtools.js

--- a/extensions/RELEASING.md
+++ b/extensions/RELEASING.md
@@ -63,6 +63,19 @@ npm run devtools:sign:firefox:local
 
 The signed XPI is written to `extensions/build/firefox-signed`.
 
+After the version-bump PR has merged, update your local `master` checkout and run the complete
+local Firefox fallback:
+
+```sh
+git pull --ff-only origin master
+make upload-firefox-extension
+```
+
+The command builds fresh release inputs, signs the Firefox extension with the Keychain-backed
+Mozilla credentials, and uploads `figbird-devtools-firefox-signed.xpi` to the matching
+`devtools-v<version>` GitHub release. It exits successfully without signing again if that asset is
+already present, so it is safe to run after checking an uncertain workflow result.
+
 ## Release both extensions
 
 After merging the extension changes, run:

--- a/lib/devtools/TimelineActivityTable.tsx
+++ b/lib/devtools/TimelineActivityTable.tsx
@@ -37,7 +37,7 @@ export type TimelineVisibility = 'all' | 'fetch' | 'realtime' | 'write' | 'conne
 
 const COLUMNS = [
   { label: 'time', width: 96, minWidth: 78 },
-  { label: 'activity', width: 145, minWidth: 100 },
+  { label: 'activity', width: 435, minWidth: 100 },
   { label: 'operation', width: 85, minWidth: 70 },
   { label: 'context', width: 120, minWidth: 80 },
   { label: 'status', width: 84, minWidth: 70 },

--- a/lib/devtools/TimelineActivityTable.tsx
+++ b/lib/devtools/TimelineActivityTable.tsx
@@ -37,7 +37,7 @@ export type TimelineVisibility = 'all' | 'fetch' | 'realtime' | 'write' | 'conne
 
 const COLUMNS = [
   { label: 'time', width: 96, minWidth: 78 },
-  { label: 'activity', width: 435, minWidth: 100 },
+  { label: 'activity', width: 330, minWidth: 100 },
   { label: 'operation', width: 85, minWidth: 70 },
   { label: 'context', width: 120, minWidth: 80 },
   { label: 'status', width: 84, minWidth: 70 },

--- a/tasks/upload-firefox-devtools.js
+++ b/tasks/upload-firefox-devtools.js
@@ -1,0 +1,89 @@
+import { copyFile, readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const assetName = 'figbird-devtools-firefox-signed.xpi'
+
+try {
+  await uploadFirefoxExtension()
+} catch (error) {
+  console.error(`\n${error instanceof Error ? error.message : String(error)}`)
+  process.exitCode = 1
+}
+
+async function uploadFirefoxExtension() {
+  const { version } = JSON.parse(
+    await readFile(path.join(root, 'extensions', 'version.json'), 'utf8'),
+  )
+  if (!isExtensionVersion(version)) {
+    throw new Error(`Invalid extension version: ${String(version)}`)
+  }
+
+  const tag = `devtools-v${version}`
+  run('gh', ['auth', 'status', '--hostname', 'github.com'])
+  const existingAssets = new Set(
+    capture('gh', ['release', 'view', tag, '--json', 'assets', '--jq', '.assets[].name'])
+      .split('\n')
+      .filter(Boolean),
+  )
+  if (existingAssets.has(assetName)) {
+    console.log(`Firefox extension ${version} is already published in GitHub release ${tag}`)
+    return
+  }
+
+  run(process.execPath, ['tasks/sign-firefox-devtools-local.js', '--check'])
+  run('npm', ['run', 'devtools:package'])
+  run('npm', ['run', 'devtools:sign:firefox:local'])
+
+  const signedDirectory = path.join(root, 'extensions', 'build', 'firefox-signed')
+  const signedPackages = (await readdir(signedDirectory, { withFileTypes: true }))
+    .filter(entry => entry.isFile() && entry.name.endsWith('.xpi'))
+    .map(entry => path.join(signedDirectory, entry.name))
+  if (signedPackages.length !== 1) {
+    throw new Error(
+      `Expected one signed Firefox package in ${path.relative(root, signedDirectory)}, found ${signedPackages.length}`,
+    )
+  }
+
+  const asset = path.join(root, 'extensions', 'build', assetName)
+  await copyFile(signedPackages[0], asset)
+  run('gh', ['release', 'upload', tag, asset, '--clobber'])
+
+  const releaseUrl = capture('gh', ['release', 'view', tag, '--json', 'url', '--jq', '.url'])
+  console.log(`Published Firefox extension ${version}: ${releaseUrl}`)
+}
+
+function isExtensionVersion(value) {
+  if (typeof value !== 'string') return false
+  const components = value.split('.')
+  return (
+    components.length >= 1 &&
+    components.length <= 4 &&
+    components.some(component => component !== '0') &&
+    components.every(component => /^(?:0|[1-9]\d*)$/.test(component) && Number(component) <= 65_535)
+  )
+}
+
+function capture(command, args) {
+  const result = spawnSync(command, args, { cwd: root, encoding: 'utf8' })
+  checkResult(command, args, result)
+  return result.stdout.trim()
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, { cwd: root, stdio: 'inherit' })
+  checkResult(command, args, result)
+}
+
+function checkResult(command, args, result) {
+  if (result.error) {
+    if (result.error.code === 'ENOENT') throw new Error(`Required command not found: ${command}`)
+    throw result.error
+  }
+  if (result.status !== 0) {
+    const detail = result.stderr?.trim() || result.stdout?.trim()
+    throw new Error(`${command} ${args.join(' ')} failed${detail ? `:\n${detail}` : ''}`)
+  }
+}


### PR DESCRIPTION
## Summary

- widen the timeline Activity column from 145px to 330px
- add `make upload-firefox-extension` to build, sign, and publish the current Firefox extension
- skip signing when the release already has the normalized XPI asset, and document the post-merge fallback flow

## Verification

- `npm test`
- `npm run devtools:check`
- `make upload-firefox-extension` against 0.3.1, confirming the existing-asset no-op path