### PR TITLE
Fix duplicate fetch between prefetch and prepare

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -949,6 +949,12 @@ result without another freshness check, even when other queries or code took lon
 The adoption window then closes: retaining the handle longer only keeps the query pinned,
 and later mounts use the ordinary `staleTime` policy again.
 
+If an active `prefetch(request)` already warmed the query, the first `prepare(request)`
+adopts that read without fetching again, even with global `staleTime: 0`. This handover
+expires with the speculative pin and can be used only once. Later preparations use the
+ordinary freshness policy. An explicit `prepare(request, { staleTime })` overrides the
+handover, and errors and explicit refetches are still handled normally.
+
 ### prefetch
 
 `prefetch()` is the idempotent, fire-and-forget sibling of `prepare()`, built for "the user will probably need this" moments like hover or viewport entry:

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -512,6 +512,8 @@ export class Figbird<
    * preparation is an earlier read, not a different read. Keep the handle active through
    * the destination's first subscriber commit. That subscriber wave adopts the prepared
    * result without revalidation; retaining the handle longer only keeps the query pinned.
+   * An active prefetch can be adopted by one preparation, even with a zero instance
+   * staleTime. An explicit preparation staleTime overrides this handover.
    *
    * @example
    * ```ts

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -165,7 +165,8 @@ type GatherResult = {
 }
 
 type RelationalListener =
-  | { source: 'subscriber' | 'prefetch'; staleTime: number }
+  | { source: 'subscriber'; staleTime: number }
+  | { source: 'prefetch'; staleTime: number; adoptableUntil: number | null }
   | { source: 'prepare'; staleTime: number; preparationGeneration: number }
 
 type PreparedAdoption =
@@ -423,11 +424,14 @@ export class RelationalQueryRef<
             staleTime,
             preparationGeneration: ++this.#nextPreparationGeneration,
           }
-        : { source, staleTime }
+        : source === 'prefetch'
+          ? { source, staleTime, adoptableUntil: Date.now() + staleTime }
+          : { source, staleTime }
     // Preparation makes one freshness decision for the destination's initial React
     // commit. Every subscriber in that synchronous wave adopts it; later mounts use
     // their own staleTime even if the router keeps the preparation pinned.
     const adoptsPreparation = source === 'subscriber' && this.#claimPreparedAdoption()
+    const adoptsPrefetch = source === 'prepare' && this.#claimPrefetch()
     const claimsColdStart = this.#coldStartAwaitingSubscriber
     this.#listeners.set(fn, listener)
     this.#staleTime = this.#currentStaleTime()
@@ -444,7 +448,9 @@ export class RelationalQueryRef<
           this.#coldStartAwaitingSubscriber = false
         })
       } else if (!adoptsPreparation) {
-        this.#ensureFresh(staleTime)
+        // Adopt the speculative read once, but still retry errors and pending
+        // invalidations. An explicit preparation staleTime takes precedence.
+        this.#ensureFresh(adoptsPrefetch && options?.staleTime === undefined ? Infinity : staleTime)
       }
     }
 
@@ -496,6 +502,18 @@ export class RelationalQueryRef<
     }
 
     return this.#preparedAdoption.kind === 'wave'
+  }
+
+  #claimPrefetch(): boolean {
+    const now = Date.now()
+    let claimed = false
+    for (const listener of this.#listeners.values()) {
+      if (listener.source === 'prefetch' && listener.adoptableUntil !== null) {
+        claimed ||= now < listener.adoptableUntil
+        listener.adoptableUntil = null
+      }
+    }
+    return claimed
   }
 
   #beginGraphRun(): string | null {

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -3294,43 +3294,62 @@ test('staleTime: public entry points reject invalid durations', t => {
   t.throws(() => figbird.prefetch(builder, { staleTime: Number.MAX_SAFE_INTEGER }))
 })
 
-test('prepared result adoption covers one subscriber wave, not the retained pin lifetime', async t => {
-  const { figbird, feathers } = createApp()
-  const { q } = createHooks(schema)
-  const issueDetail = defineQuery('preparedIssueStaleTime', ({ id }: { id: number }) =>
-    q.issues.get(id).related('creator'),
-  )
-  const request = issueDetail({ id: 1 })
-
-  figbird.prefetch(request)
-  const prepared = figbird.prepare(request)
-  await prepared.promise
-  const ref = figbird.query(request)
-  const first = ref.subscribe(() => {}, { staleTime: 0 })
-  const sibling = ref.subscribe(() => {}, { staleTime: 0 })
-  first()
-  sibling()
-  const strictModeReplay = ref.subscribe(() => {}, { staleTime: 0 })
-  await new Promise<void>(resolve => queueMicrotask(resolve))
-
-  t.is(feathers.service('issues').counts.get, 1, 'the initial subscriber wave adopts the root')
-  t.is(feathers.service('users').counts.find, 1, 'the initial subscriber wave adopts the relation')
-
-  strictModeReplay()
-  let releaseLaterMount = () => {}
-  await new Promise<void>(resolve => {
-    releaseLaterMount = ref.subscribe(
-      state => {
-        if (state.status === 'success' && !state.isFetching) resolve()
-      },
-      { staleTime: 0 },
+test('prefetched result adoption covers one preparation and subscriber wave', async t => {
+  for (const completePrefetch of [false, true]) {
+    const { adapter, feathers } = createApp()
+    const figbird = new Figbird({ schema, adapter, staleTime: 0 })
+    const { q } = createHooks(schema)
+    const issueDetail = defineQuery('preparedIssueStaleTime', ({ id }: { id: number }) =>
+      q.issues.get(id).related('creator'),
     )
-  })
+    const request = issueDetail({ id: 1 })
 
-  t.is(feathers.service('issues').counts.get, 2, 'a later mount revalidates the root')
-  t.is(feathers.service('users').counts.find, 2, 'a later mount revalidates the relation')
-  prepared.release()
-  releaseLaterMount()
+    figbird.prefetch(request)
+    if (completePrefetch) {
+      await figbird.query(request).suspensePromise()
+      await new Promise(resolve => setTimeout(resolve, 10))
+    }
+    const prepared = figbird.prepare(request)
+    await prepared.promise
+    await new Promise(resolve => setTimeout(resolve, 10))
+    const ref = figbird.query(request)
+    const first = ref.subscribe(() => {}, { staleTime: 0 })
+    const sibling = ref.subscribe(() => {}, { staleTime: 0 })
+    first()
+    sibling()
+    const strictModeReplay = ref.subscribe(() => {}, { staleTime: 0 })
+    await new Promise<void>(resolve => queueMicrotask(resolve))
+
+    t.is(feathers.service('issues').counts.get, 1, 'the initial subscriber wave adopts the root')
+    t.is(
+      feathers.service('users').counts.find,
+      1,
+      'the initial subscriber wave adopts the relation',
+    )
+
+    strictModeReplay()
+    let releaseLaterMount = () => {}
+    await new Promise<void>(resolve => {
+      releaseLaterMount = ref.subscribe(
+        state => {
+          if (state.status === 'success' && !state.isFetching) resolve()
+        },
+        { staleTime: 0 },
+      )
+    })
+
+    t.is(feathers.service('issues').counts.get, 2, 'a later mount revalidates the root')
+    t.is(feathers.service('users').counts.find, 2, 'a later mount revalidates the relation')
+    prepared.release()
+    releaseLaterMount()
+
+    const laterPreparation = figbird.prepare(request)
+    await laterPreparation.promise
+    await new Promise(resolve => setTimeout(resolve, 10))
+    t.is(feathers.service('issues').counts.get, 3, 'a later preparation revalidates the root')
+    t.is(feathers.service('users').counts.find, 3, 'a later preparation revalidates the relation')
+    laterPreparation.release()
+  }
 })
 
 test('prepared result adoption orders overlapping and cancelled generations', async t => {


### PR DESCRIPTION
With global `staleTime: 0`, a completed hover prefetch was fetched again when the route called `prepare()`. Preparation now consumes an unexpired prefetch handover once, then the component adopts the preparation as before. Hover → prepare → component makes one request; later mounts and preparations revalidate normally.

The handover checks the pin's deadline even if its cleanup timer has not fired. Explicit preparation stale-time overrides still take precedence, and freshness checks still handle errors and pending invalidation. The existing adoption test now exercises both in-flight and completed prefetches, the initial subscriber wave, later remounts, and later preparations. The public documentation describes the handover.

Validation:
- `npm run tsc` and `npm run lint` passed.
- `npm run ava` passed all 363 tests.
- `npm run build` passed. The supplied reproduction against the build now reports request counts of 1 → 1 → 1 → 2 for hover, preparation, component subscription, and ordinary remount.
- Additional manual checks passed for expired pins, delayed cleanup timers, explicit `staleTime: 0`, manual refetch, and recovery from a failed prefetch.
- `npm run test` passed on rerun, including formatting and all 363 tests under coverage. The first coverage run hit an intermittent failure in `collector marks optimistic mutation failures as rolled back writes`; its focused check on unchanged master passed, as did the full rerun with this fix.
