### PR TITLE
Fix exhaustive query ordering and fetched cache consistency

### DIFF
--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -157,7 +157,6 @@ interface AppliedEventEffect {
   event: ProcessedCacheEvent
   reconcileQueryIds: Set<string>
   queryEffects?: Map<string, 'merged' | 'reconcile'>
-  observabilityOnly?: boolean
 }
 
 interface PublishedEventEffects {
@@ -1866,19 +1865,12 @@ export class QueryStore<
       }
       for (const event of activeOverlayEvents) journaledItemIds.add(event.itemId)
 
-      // A complete-set fetch (unfiltered allPages — the materialization condition)
-      // is authoritative for the whole service: snapshot the entity cache before
-      // applying the result so it can be diffed below and the changes propagated
-      // to every other query the same way realtime events are. `.server()` fetches
-      // don't diff — a server-authoritative query refetching in response to diff
-      // events must not itself produce diff events, or two of them could cycle.
       const findConfig = query.config as FindQueryConfig<unknown, unknown>
       const isCompleteSet =
         query.desc.method === 'find' &&
         Boolean(findConfig.allPages) &&
         isUnfilteredFindQuery(query.desc.params)
-      const previousEntities =
-        isCompleteSet && !findConfig.server ? new Map(service.entities) : null
+      const previousEntities = isCompleteSet ? new Map(service.entities) : null
       const meta = (result as { meta?: TMeta }).meta
       const pageInfo = 'pageInfo' in result ? result.pageInfo : undefined
       const rebasedResponse = rebaseResponseData({
@@ -1906,6 +1898,7 @@ export class QueryStore<
       // not full entities — never write them to the entity cache, which must hold
       // only complete rows for the materialized local-answer paths to be sound
       // (isItemStale can't catch a projection: same updatedAt as the row it shadows).
+      const fetchedEvents: ProcessedCacheEvent[] = []
       for (const item of rebasedResponse.items) {
         const itemId = getId(item)
         if (itemId !== undefined) {
@@ -1914,21 +1907,16 @@ export class QueryStore<
             const currentItem = service.entities.get(key)
             if (!currentItem || !this.#adapter.isItemStale(currentItem, item)) {
               service.entities.set(key, item)
-              if (!isCompleteSet && currentItem !== item && this.#telemetry.active) {
-                eventEffects.push({
-                  event: {
-                    mode: 'server',
-                    source: 'fetch',
-                    serviceName: query.desc.serviceName,
-                    type: currentItem === undefined ? 'created' : 'updated',
-                    item,
-                    previousItem: currentItem ?? null,
-                    itemId: key,
-                    ...(cause === undefined ? {} : { cause }),
-                  },
-                  reconcileQueryIds: new Set(),
-                  queryEffects: new Map([[queryId, 'merged']]),
-                  observabilityOnly: true,
+              if (!isCompleteSet && currentItem !== item) {
+                fetchedEvents.push({
+                  mode: 'server',
+                  source: 'fetch',
+                  serviceName: query.desc.serviceName,
+                  type: currentItem === undefined ? 'created' : 'updated',
+                  item,
+                  previousItem: currentItem ?? null,
+                  itemId: key,
+                  ...(cause === undefined ? {} : { cause }),
                 })
               }
             }
@@ -1972,31 +1960,26 @@ export class QueryStore<
         },
       })
 
-      // Diff the complete set against the pre-fetch cache and apply the changes as
-      // synthetic events. Without this, queries answered locally from the cache
-      // (see #tryLocalFind) would never observe changes a root refetch brought in —
-      // rows created or removed out-of-band would be invisible to them forever.
-      // The fetched query itself is excluded: its state was just set from the result.
-      if (previousEntities) {
-        const diffEvents = diffCompleteSet({
-          service,
-          serviceName: query.desc.serviceName,
-          previousEntities,
-          nextItemIds,
-          ignoredItemIds: journaledItemIds,
-        })
-        eventEffects.push(
-          ...this.#updateQueriesForEvents({
+      const changes = previousEntities
+        ? diffCompleteSet({
             service,
             serviceName: query.desc.serviceName,
-            processedEvents: diffEvents.map(event =>
-              cause === undefined ? event : { ...event, cause },
-            ),
-            touch,
-            excludeQueryId: queryId,
-          }),
-        )
-      }
+            previousEntities,
+            nextItemIds,
+            ignoredItemIds: journaledItemIds,
+          })
+        : fetchedEvents
+      eventEffects.push(
+        ...this.#updateQueriesForEvents({
+          service,
+          serviceName: query.desc.serviceName,
+          processedEvents: changes.map(event =>
+            cause === undefined ? event : { ...event, cause },
+          ),
+          touch,
+          excludeQueryId: queryId,
+        }),
+      )
 
       if (effectiveJournalEvents.length > 0 && responseMode === 'entity') {
         replayFetchedQueryFromEvents({
@@ -2378,8 +2361,7 @@ export class QueryStore<
       if (merged) reconcileCauses.set(queryId, merged)
     }
 
-    for (const { event, reconcileQueryIds, queryEffects, observabilityOnly } of effects) {
-      if (observabilityOnly) continue
+    for (const { event, reconcileQueryIds, queryEffects } of effects) {
       const cause = causeFor(event)
       const deferred =
         event.mode === 'optimistic' &&

--- a/lib/core/windowMaintenance.ts
+++ b/lib/core/windowMaintenance.ts
@@ -549,6 +549,15 @@ export function updateQueriesFromEvents<TMeta>({
         event.mode === 'server' &&
         event.source === 'fetch'
       ) {
+        if (
+          query.classification === 'server-window' &&
+          service.materialized &&
+          service.materialized?.queryId === excludeQueryId
+        ) {
+          serverMaintainedQueriesToRefetch.add(queryId)
+          onEffect?.(queryId, 'reconcile')
+          continue
+        }
         // A fetched row supplies values, not another server query's membership.
         // Preserve projections and avoid fetch-to-fetch reconciliation cycles.
         if (

--- a/lib/core/windowMaintenance.ts
+++ b/lib/core/windowMaintenance.ts
@@ -9,7 +9,7 @@
  * "refetch" when it is not. The soundness argument lives on the function.
  */
 
-import { isServerMaintained } from './queryClassification.js'
+import { isProjectionQuery, isServerMaintained } from './queryClassification.js'
 import { ItemRemovedError } from './errors.js'
 import { buildComparator } from './sort.js'
 import {
@@ -363,14 +363,15 @@ function applyVisibleEventEffect<TMeta>(
   }
 
   if (!hasItem || query.state.status !== 'success') return false
+  const data = (query.state.data as unknown[]).map(current =>
+    itemHasKey(current, itemId, getId) ? item : current,
+  )
+  if (query.classification === 'local-exact') {
+    sortQueryRows(data, query, context.defaultSort)
+  }
   service.queries.set(queryId, {
     ...query,
-    state: {
-      ...query.state,
-      data: (query.state.data as unknown[]).map(current =>
-        itemHasKey(current, itemId, getId) ? item : current,
-      ),
-    },
+    state: { ...query.state, data },
   })
   touch(queryId)
   return true
@@ -409,6 +410,15 @@ export function applyVisibleEventToQuery<TMeta>({
     event,
     event.type === 'removed' ? 'remove' : 'replace',
   )
+}
+
+function sortQueryRows<TMeta>(
+  rows: unknown[],
+  query: Query<unknown, TMeta, unknown>,
+  defaultSort: Record<string, number> | undefined,
+): unknown[] {
+  const sort = splitWindow(queryOfParams(query.desc.params)).sort ?? defaultSort
+  return sort ? rows.sort(buildComparator(sort)) : rows
 }
 
 function applyMergeEventToQuery<TMeta>(
@@ -476,7 +486,7 @@ function applyMergeEventToQuery<TMeta>(
       state: {
         ...query.state,
         meta: itemAdded(query.state.meta),
-        data: (query.state.data as unknown[]).concat(item),
+        data: sortQueryRows((query.state.data as unknown[]).concat(item), query, defaultSort),
       },
     })
     addQueryToItemIndex(service, itemId, queryId)
@@ -534,6 +544,26 @@ export function updateQueriesFromEvents<TMeta>({
     for (const [queryId, query] of service.queries) {
       if (queryId === excludeQueryId || query.config.realtime !== 'merge') continue
       if (query.desc.method === 'find' && query.config.fetchPolicy === 'network-only') continue
+      if (
+        isServerMaintained(query.classification) &&
+        event.mode === 'server' &&
+        event.source === 'fetch'
+      ) {
+        // A fetched row supplies values, not another server query's membership.
+        // Preserve projections and avoid fetch-to-fetch reconciliation cycles.
+        if (
+          !isProjectionQuery(queryOfParams(query.desc.params)) &&
+          applyVisibleEventEffect(
+            context,
+            queryId,
+            event,
+            event.type === 'removed' ? 'remove' : 'replace',
+          )
+        ) {
+          onEffect?.(queryId, 'merged')
+        }
+        continue
+      }
       const result = applyMergeEventToQuery(context, queryId, event)
       if (result === 'reconcile') {
         serverMaintainedQueriesToRefetch.add(queryId)

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -3031,7 +3031,8 @@ test('.all(): materialized reads stay local only when their ordering is knowable
   const { figbird, feathers } = createApp()
 
   // Preload the complete set ($sort doesn't affect completeness, so it still materializes).
-  const unsubAll = figbird.query(figbird.q.issues.orderBy('id').all()).subscribe(() => {})
+  const allRef = figbird.query(figbird.q.issues.orderBy('title').all())
+  const unsubAll = allRef.subscribe(() => {})
   await new Promise(resolve => setTimeout(resolve, 10))
   const findsAfterAll = feathers.service('issues').counts.find
   t.true(findsAfterAll >= 1)
@@ -3074,6 +3075,33 @@ test('.all(): materialized reads stay local only when their ordering is knowable
     findsAfterUnsorted,
     'realtime maintenance stays local',
   )
+
+  await figbird.m.issues.patch(1, { title: 'ZZZ' })
+  await new Promise(resolve => setTimeout(resolve, 10))
+  t.is(allRef.getSnapshot().data?.at(-1)?.id, 1, 'patches restore exhaustive query order')
+
+  feathers.service('issues').data[1] = { id: 1, title: 'AAA', status: 'open', creatorId: 1 }
+  const detail = figbird.query(figbird.q.issues.get(1).server())
+  const unsubDetail = detail.subscribe(() => {})
+  await new Promise(resolve => setTimeout(resolve, 10))
+  t.is(allRef.getSnapshot().data?.[0]?.title, 'AAA', 'a get updates existing live lists')
+
+  const serverAll = figbird.query(figbird.q.issues.all().server())
+  const unsubServerAll = serverAll.subscribe(() => {})
+  await new Promise(resolve => setTimeout(resolve, 10))
+  delete feathers.service('issues').data[9]
+  serverAll.refetch()
+  await new Promise(resolve => setTimeout(resolve, 10))
+  const local = figbird.query(figbird.q.issues.orderBy('id'))
+  const unsubLocal = local.subscribe(() => {})
+  await new Promise(resolve => setTimeout(resolve, 10))
+  t.deepEqual(
+    local.getSnapshot().data?.map(issue => issue.id),
+    [1, 2, 3],
+  )
+  unsubLocal()
+  unsubServerAll()
+  unsubDetail()
 
   unsubUnsorted()
   unsubOpen()

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -3092,12 +3092,25 @@ test('.all(): materialized reads stay local only when their ordering is knowable
   delete feathers.service('issues').data[9]
   serverAll.refetch()
   await new Promise(resolve => setTimeout(resolve, 10))
+  t.deepEqual(
+    winRef.getSnapshot().data?.map(issue => issue.id),
+    [3, 2],
+  )
+  const findsAfterRemoval = feathers.service('issues').counts.find
+  feathers.service('issues').data[10] = { id: 10, title: 'Ten', status: 'open', creatorId: 1 }
+  serverAll.refetch()
+  await new Promise(resolve => setTimeout(resolve, 10))
+  t.deepEqual(
+    winRef.getSnapshot().data?.map(issue => issue.id),
+    [10, 3],
+  )
+  t.is(feathers.service('issues').counts.find, findsAfterRemoval + 1, 'window refill stays local')
   const local = figbird.query(figbird.q.issues.orderBy('id'))
   const unsubLocal = local.subscribe(() => {})
   await new Promise(resolve => setTimeout(resolve, 10))
   t.deepEqual(
     local.getSnapshot().data?.map(issue => issue.id),
-    [1, 2, 3],
+    [1, 2, 3, 10],
   )
   unsubLocal()
   unsubServerAll()


### PR DESCRIPTION
Fix three cases where live queries disagree with server data: sorted `.all()` results now reorder after writes, fetching a newer entity updates existing live query values, and `.all().server()` refetches remove deleted records from the materialized cache.

Fetch propagation preserves server-controlled page membership and projected rows, avoiding page duplication and fetch-to-fetch reconciliation loops. Snapshots remain frozen. Existing materialization coverage now exercises the reported cases.

Validation: `npm run tsc`, `npm run lint`, `npm run ava`, and `npm run test` pass, including all 365 tests. The standalone review reproductions pass.

First PR in the cache improvement stack. Relational identity, lifecycle, and internal storage changes follow separately.
