### PR TITLE
Preserve unchanged relational results and share join indexes

### DIFF
--- a/lib/core/relationalAssembly.ts
+++ b/lib/core/relationalAssembly.ts
@@ -146,18 +146,38 @@ function firstMatchIndex(items: unknown[], destField: string): Map<string | numb
  * fields on the parent — this is load-bearing for `embed`, where the parent's id-list
  * field expands into the materialized entities under the same key.
  */
-export function assembleRelations(
+interface AssemblyContext {
+  schema: Schema
+  relationData: Map<string, AssembledRelationData>
+  indexesByPath: Map<string | null, Map<string, RelationIndex>>
+  previousByPath: Map<string | null, WeakMap<object, Record<string, unknown>>>
+}
+
+function assembleRelations(
   items: unknown[],
   ast: QueryAST,
-  schema: Schema,
-  relationData: Map<string, AssembledRelationData>,
-  parentKey: string | null = null,
+  parentKey: string | null,
+  context: AssemblyContext,
 ): unknown[] {
+  const { schema, relationData, indexesByPath, previousByPath } = context
   const relationships = schema.relationships?.[ast.service] ?? {}
-  const indexes = buildIndexes(ast, parentKey, relationships, relationData)
+  if (Object.keys(ast.related).length === 0) return items
+  let indexes = indexesByPath.get(parentKey)
+  if (!indexes) {
+    indexes = buildIndexes(ast, parentKey, relationships, relationData)
+    indexesByPath.set(parentKey, indexes)
+  }
+  let previousRows = previousByPath.get(parentKey)
+  if (!previousRows) {
+    previousRows = new WeakMap()
+    previousByPath.set(parentKey, previousRows)
+  }
+  const cache = previousRows
 
   return items.map(item => {
-    const result = { ...(item as object) } as Record<string, unknown>
+    if (!item || typeof item !== 'object') return item
+    const previous = cache.get(item)
+    const result = { ...item } as Record<string, unknown>
 
     for (const [relName, relAST] of Object.entries(ast.related)) {
       const key = relationKey(parentKey, relName)
@@ -204,7 +224,7 @@ export function assembleRelations(
         if (relDef.cardinality === 'one') {
           let found: unknown = matchedItems[0] ?? null
           if (hasNested && found) {
-            found = assembleRelations([found], relAST, schema, relationData, key)[0] ?? null
+            found = assembleRelations([found], relAST, key, context)[0] ?? null
           }
           result[relName] = found
           continue
@@ -214,7 +234,7 @@ export function assembleRelations(
         const found = sourceValue === undefined ? null : (index?.byKey?.get(sourceValue) ?? null)
         result[relName] = found
         if (hasNested && found) {
-          const assembled = assembleRelations([found], relAST, schema, relationData, key)
+          const assembled = assembleRelations([found], relAST, key, context)
           result[relName] = assembled[0] ?? null
         }
         continue
@@ -225,11 +245,45 @@ export function assembleRelations(
       }
 
       if (hasNested && matchedItems.length > 0) {
-        matchedItems = assembleRelations(matchedItems, relAST, schema, relationData, key)
+        matchedItems = assembleRelations(matchedItems, relAST, key, context)
       }
-      result[relName] = matchedItems
+      result[relName] = reuseArray(previous?.[relName], matchedItems)
     }
 
+    if (
+      previous &&
+      Object.keys(previous).length === Object.keys(result).length &&
+      Object.keys(result).every(key => previous[key] === result[key])
+    ) {
+      return previous
+    }
+    cache.set(item, result)
     return result
   })
+}
+
+function reuseArray(previous: unknown, next: unknown[]): unknown[] {
+  return Array.isArray(previous) &&
+    previous.length === next.length &&
+    next.every((item, index) => item === previous[index])
+    ? previous
+    : next
+}
+
+/** Each query owns weak row caches; each assembly builds an index once per relation path. */
+export function createRelationAssembler(ast: QueryAST, schema: Schema) {
+  const previousByPath = new Map<string | null, WeakMap<object, Record<string, unknown>>>()
+  let previous: unknown[] = []
+  return (items: unknown[], relationData: Map<string, AssembledRelationData>): unknown[] => {
+    previous = reuseArray(
+      previous,
+      assembleRelations(items, ast, null, {
+        schema,
+        relationData,
+        indexesByPath: new Map(),
+        previousByPath,
+      }),
+    )
+    return previous
+  }
 }

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -24,7 +24,7 @@ import {
   type RootSource,
 } from './queryRoots.js'
 import {
-  assembleRelations,
+  createRelationAssembler,
   getFieldValueAsList,
   relationKey,
   sourceSet,
@@ -265,6 +265,7 @@ export class RelationalQueryRef<
   // keeps an unresolved leaf stale without rolling back unrelated optimistic edges.
   #lastRelationAssembly: Map<string, AssembledRelationData> | null = null
   #lastGatherWasPartial = false
+  #assembleRelations: ReturnType<typeof createRelationAssembler> | null = null
 
   // Suspense-support state. The promise is created lazily when suspensePromise() is
   // first called and resolves/rejects on the first transition to success/error. Once
@@ -690,7 +691,8 @@ export class RelationalQueryRef<
   }
 
   #assemble(rootRows: unknown[], assembly: Map<string, AssembledRelationData>): T {
-    const assembled = assembleRelations(rootRows, this.#ast, this.#schema, assembly)
+    this.#assembleRelations ??= createRelationAssembler(this.#ast, this.#schema)
+    const assembled = this.#assembleRelations(rootRows, assembly)
     return this.#ast.kind !== 'paginate' && this.#ast.cardinality === 'one'
       ? ((assembled[0] ?? null) as T)
       : (assembled as unknown as T)
@@ -1696,6 +1698,7 @@ export class RelationalQueryRef<
     this.#lastRelationData.clear()
     this.#lastRelationAssembly = null
     this.#lastGatherWasPartial = false
+    this.#assembleRelations = null
     this.#staleTime = 0
     if (this.#preparedAdoption.kind === 'wave') {
       this.#preparedAdoption = {

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -1979,6 +1979,11 @@ it('realtime: child entity arrival on nested relation updates the assembled view
   t.is($('.comment[data-id="1"]')!.innerHTML, 'r=2')
   t.is($('.comment[data-id="2"]')!.innerHTML, 'r=1')
 
+  const ref = figbird.query(
+    figbird.q.issues.get(1).related('comments', c => c.related('reactions')),
+  )
+  const before = ref.getSnapshot().data
+
   // New reaction on comment 2 should propagate into the nested view.
   await feathers.service('reactions').create({
     id: 99,
@@ -1990,6 +1995,11 @@ it('realtime: child entity arrival on nested relation updates the assembled view
 
   t.is($('.comment[data-id="2"]')!.innerHTML, 'r=2')
 
+  const after = ref.getSnapshot().data
+  t.not(after, before, 'the changed parent receives a new identity')
+  t.is(after?.comments[0], before?.comments[0], 'the untouched sibling retains its identity')
+  t.is(after?.comments[0]?.reactions, before?.comments[0]?.reactions)
+  t.not(after?.comments[1], before?.comments[1], 'the changed nested child receives a new identity')
   unmount()
 })
 


### PR DESCRIPTION
Relational updates now preserve unchanged parent objects and relation arrays, allowing memoized rows to skip rendering when a sibling changes. Nested assembly builds join indexes once per relation path rather than once per parent. Weak caches belong to each query and are released with its lifecycle.

Existing nested-relation coverage now checks that changed branches receive new identities and untouched siblings retain theirs. In a synthetic graph with 200 parents, 600 children, and 1,800 leaves, leaf join-key reads fall from 360,000 to 1,800; changing one leaf preserves 199 of 200 root identities.

Validation: `npm run tsc`, `npm run lint`, `npm run ava`, and `npm run test` pass, including all 365 tests.

Stacked on #119. Merge that PR first, then retarget this PR to master if GitHub does not do so automatically.
