### PR TITLE
Bound idle query retention and release disposed instance resources

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1262,6 +1262,24 @@ figbird.queryDesc(desc, { retry: 1, retryDelay: 250 })
 Each network attempt emits its own fetch lifecycle events and contributes to the query's
 fetch and error counts in `inspect()`.
 
+### Cache retention and instance disposal
+
+`new Figbird({ adapter, schema, gcTime: 300_000 })` retains idle query results for five
+minutes after their last reader releases them. A returning reader cancels eviction.
+`gcTime` controls memory retention independently of `staleTime`, which controls freshness.
+Set `gcTime: Infinity` to keep idle results for the instance's lifetime, or `0` to evict
+on the next timer turn. Unreferenced entities and unused service subscriptions are
+released when queries expire. Complete unfiltered `.all()` materializations remain
+retained because other queries use them for local reads.
+
+After unmounting an instance's readers, call `figbird.dispose()` to release its cache,
+realtime and connection subscriptions, visibility listener, speculative reads, and
+devtools sessions. Calling it twice is harmless. New queries and mutations are rejected.
+Already registered writes finish in order; owned mutation queues flush their pending work
+and discard after a terminal failure instead of waiting for an owner to retry. Late fetch
+and mutation responses cannot repopulate the disposed cache. Disposal does not disconnect
+the adapter's shared transport.
+
 ### Freezing a query: .snapshot()
 
 `.snapshot()` fetches once and then ignores realtime entirely, for the root and every

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1264,8 +1264,9 @@ fetch and error counts in `inspect()`.
 
 ### Cache retention and instance disposal
 
-`new Figbird({ adapter, schema, gcTime: 300_000 })` retains idle query results for five
-minutes after their last reader releases them. A returning reader cancels eviction.
+By default, idle query results are retained for thirty minutes after their last reader
+releases them. Configure this with `new Figbird({ adapter, schema, gcTime: 30 * 60_000 })`.
+A returning reader cancels eviction.
 `gcTime` controls memory retention independently of `staleTime`, which controls freshness.
 Set `gcTime: Infinity` to keep idle results for the instance's lifetime, or `0` to evict
 on the next timer turn. Unreferenced entities and unused service subscriptions are

--- a/lib/core/devtoolsBridge.ts
+++ b/lib/core/devtoolsBridge.ts
@@ -101,15 +101,15 @@ interface DevtoolsPageBridge {
     itemJson: string,
   ): string
   readJson(sessionId: string, version: number | null): string | null
-  register(source: DevtoolsSource): void
+  register(source: DevtoolsSource): (() => void) | void
 }
 
 let fallbackBridge: DevtoolsPageBridge | undefined
 
 /** Register a Figbird instance for browser extensions without starting collection. */
-export function registerDevtoolsInstance(source: DevtoolsSource): void {
-  if (typeof window === 'undefined' || typeof WeakRef === 'undefined') return
-  getPageBridge().register(source)
+export function registerDevtoolsInstance(source: DevtoolsSource): () => void {
+  if (typeof window === 'undefined' || typeof WeakRef === 'undefined') return () => {}
+  return getPageBridge().register(source) ?? (() => {})
 }
 
 function getPageBridge(): DevtoolsPageBridge {
@@ -184,14 +184,22 @@ function createPageBridge(): DevtoolsPageBridge {
       const instanceId = nextInstanceId++
       instances.set(instanceId, new WeakRef(source))
       const captureUntil = startupCaptureUntil()
-      if (captureUntil <= Date.now()) return
-      const events = new CappedBuffer<FigbirdEvent>(EVENT_LIMIT)
-      const unsubscribe = source.events.subscribe(event => events.push(event))
-      const expires = setTimeout(
-        () => closeStartupCapture(instanceId),
-        Math.max(0, captureUntil - Date.now()),
-      )
-      startupCaptures.set(instanceId, { events, expires, unsubscribe })
+      if (captureUntil > Date.now()) {
+        const events = new CappedBuffer<FigbirdEvent>(EVENT_LIMIT)
+        const unsubscribe = source.events.subscribe(event => events.push(event))
+        const expires = setTimeout(
+          () => closeStartupCapture(instanceId),
+          Math.max(0, captureUntil - Date.now()),
+        )
+        startupCaptures.set(instanceId, { events, expires, unsubscribe })
+      }
+      return () => {
+        instances.delete(instanceId)
+        closeStartupCapture(instanceId)
+        for (const [sessionId, session] of sessions) {
+          if (session.source === source) closeSession(sessionId)
+        }
+      }
     },
 
     connect(instanceId) {

--- a/lib/core/events.ts
+++ b/lib/core/events.ts
@@ -225,6 +225,11 @@ export class FigbirdEventEmitter implements FigbirdEvents {
   }> = []
   #flushScheduled = false
 
+  dispose(): void {
+    this.#listeners.clear()
+    this.#queue = []
+  }
+
   get hasListeners(): boolean {
     return this.#listeners.size > 0
   }

--- a/lib/core/fetchRebase.ts
+++ b/lib/core/fetchRebase.ts
@@ -43,6 +43,10 @@ export class FetchEventJournal {
     this.#maxEvents = maxEvents
   }
 
+  clear(): void {
+    this.#services.clear()
+  }
+
   begin(serviceName: string): FetchJournalCursor {
     let journal = this.#services.get(serviceName)
     if (!journal) {

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -40,6 +40,7 @@ import {
 export type { ExplainNode, ExplainReport } from './queryClassification.js'
 import { QueryRef } from './queryRef.js'
 import {
+  DEFAULT_GC_TIME,
   DEFAULT_STALE_TIME,
   QueryStore,
   type DevtoolsCacheEditResult,
@@ -264,7 +265,7 @@ export class Figbird<
     eventBatchInterval,
     schema,
     staleTime = DEFAULT_STALE_TIME,
-    gcTime = DEFAULT_STALE_TIME,
+    gcTime = DEFAULT_GC_TIME,
     reconcileCooldown,
     retry,
     retryDelay,
@@ -276,7 +277,7 @@ export class Figbird<
     eventBatchInterval?: number
     schema?: S
     staleTime?: number
-    /** Idle cache retention in ms. Defaults to five minutes; Infinity disables eviction. */
+    /** Idle cache retention in ms. Defaults to thirty minutes; Infinity disables eviction. */
     gcTime?: number
     reconcileCooldown?: number
     retry?: number | false

--- a/lib/core/figbird.ts
+++ b/lib/core/figbird.ts
@@ -208,6 +208,9 @@ export class Figbird<
   queryStore: QueryStore<S, AdapterParams<A>, AdapterFindMeta<A>, AdapterQuery<A>>
   schema: S | undefined
   #staleTime: number
+  #disposed = false
+  #mutationQueues = new Set<MutationQueue<S>>()
+  #unregisterDevtools: () => void
 
   // Cache of active RelationalQueryRef instances, keyed by AST hash. This is critical for
   // React 18 Suspense interop: on suspense retries React discards render-state (including
@@ -261,6 +264,7 @@ export class Figbird<
     eventBatchInterval,
     schema,
     staleTime = DEFAULT_STALE_TIME,
+    gcTime = DEFAULT_STALE_TIME,
     reconcileCooldown,
     retry,
     retryDelay,
@@ -272,6 +276,8 @@ export class Figbird<
     eventBatchInterval?: number
     schema?: S
     staleTime?: number
+    /** Idle cache retention in ms. Defaults to five minutes; Infinity disables eviction. */
+    gcTime?: number
     reconcileCooldown?: number
     retry?: number | false
     retryDelay?: RetryDelay
@@ -287,6 +293,7 @@ export class Figbird<
       adapter,
       eventBatchInterval,
       staleTime,
+      gcTime,
       ...(reconcileCooldown !== undefined ? { reconcileCooldown } : {}),
       ...(retry !== undefined ? { retry } : {}),
       ...(retryDelay !== undefined ? { retryDelay } : {}),
@@ -294,7 +301,33 @@ export class Figbird<
       ...(visibility !== undefined ? { visibility } : {}),
       ...(defaultSort !== undefined ? { defaultSort } : {}),
     })
-    registerDevtoolsInstance(this)
+    this.#unregisterDevtools = registerDevtoolsInstance(this)
+  }
+
+  /** Release this instance after unmounting its readers. Registered writes finish normally. */
+  dispose(): void {
+    if (this.#disposed) return
+    this.#disposed = true
+    for (const prefetch of this.#prefetches.values()) {
+      clearTimeout(prefetch.timer)
+      prefetch.release()
+    }
+    this.#prefetches.clear()
+    for (const ref of this.#windowQueryCache.values()) ref.dispose()
+    for (const ref of this.#relationalQueryCache.values()) ref.dispose()
+    this.#windowQueryCache.clear()
+    this.#relationalQueryCache.clear()
+    for (const queues of this.#keyedMutationQueues.values()) {
+      for (const entry of queues.values()) {
+        if (entry.evictionTimer) clearTimeout(entry.evictionTimer)
+        entry.unsubscribe()
+      }
+    }
+    this.#keyedMutationQueues.clear()
+    for (const queue of this.#mutationQueues) queue.detach()
+    this.#mutationQueues.clear()
+    this.#unregisterDevtools()
+    this.queryStore.dispose()
   }
 
   /**
@@ -390,6 +423,7 @@ export class Figbird<
     AdapterFindMeta<A>,
     AdapterQuery<A>
   > {
+    this.queryStore.assertActive()
     type T = QueryBuilderResult<B>
     if (!this.schema) {
       throw new Error(
@@ -442,6 +476,7 @@ export class Figbird<
     queryOrBuilder: QueryInput<B, Args>,
     config: WindowQueryConfig,
   ): WindowQueryRef<QueryBuilderItem<B>, S, AdapterParams<A>, AdapterFindMeta<A>, AdapterQuery<A>> {
+    this.queryStore.assertActive()
     type T = QueryBuilderItem<B>
     if (!this.schema) {
       throw new Error(
@@ -842,6 +877,7 @@ export class Figbird<
   }
 
   #createMutationQueue(config: MutationQueueConfig): MutationQueue<S> {
+    this.queryStore.assertActive()
     const host: MutationQueueHost = {
       registerMutation: (desc, control) => {
         const resolve = (value: MutationDescriptor): MutationDescriptor => ({
@@ -863,11 +899,17 @@ export class Figbird<
           control,
         ),
     }
-    return new MutationQueue<S>(host, config)
+    const queue = new MutationQueue<S>(host, config)
+    queue.subscribe(() => {
+      if (queue.pending > 0 && !this.#disposed) this.#mutationQueues.add(queue)
+      else this.#mutationQueues.delete(queue)
+    })
+    return queue
   }
 
   /** Return one reconnectable instance of an immutable queue definition. @internal */
   getMutationQueue(definition: MutationQueueDefinition, key: string): MutationQueue<S> {
+    this.queryStore.assertActive()
     if (key.length === 0) throw new Error('figbird: mutation queue key must not be empty')
     let queues = this.#keyedMutationQueues.get(definition)
     const existing = queues?.get(key)

--- a/lib/core/mutationTracker.ts
+++ b/lib/core/mutationTracker.ts
@@ -41,6 +41,11 @@ export class MutationTracker implements MutationActivity {
   #nextId = 1
   #snapshot: readonly InFlightMutation[] = []
 
+  /** Pending writes can still settle; external owners no longer receive updates. */
+  dispose(): void {
+    this.#listeners.clear()
+  }
+
   start(entry: { serviceName: string; method: string; id?: string | number }): number {
     const mutationId = this.#nextId++
     this.#inFlight.set(mutationId, { mutationId, ...entry })

--- a/lib/core/queryRetention.ts
+++ b/lib/core/queryRetention.ts
@@ -1,0 +1,55 @@
+/** One timer bounds idle query retention without one timeout per cache entry. */
+export class QueryRetention {
+  readonly #duration: number
+  readonly #expire: (queryId: string) => void
+  readonly #deadlines = new Map<string, number>()
+  #timer: ReturnType<typeof setTimeout> | null = null
+  #disposed = false
+
+  constructor(duration: number, expire: (queryId: string) => void) {
+    if (
+      duration !== Infinity &&
+      (!Number.isFinite(duration) || duration < 0 || duration > 2_147_483_647)
+    ) {
+      throw new RangeError('Figbird(): gcTime must be between 0 and 2147483647, or Infinity')
+    }
+    this.#duration = duration
+    this.#expire = expire
+  }
+
+  retain(queryId: string): void {
+    if (this.#disposed || this.#duration === Infinity) return
+    this.#deadlines.set(queryId, Date.now() + this.#duration)
+    if (this.#timer === null) this.#arm(this.#duration)
+  }
+
+  cancel(queryId: string): void {
+    this.#deadlines.delete(queryId)
+  }
+
+  dispose(): void {
+    this.#disposed = true
+    if (this.#timer !== null) clearTimeout(this.#timer)
+    this.#timer = null
+    this.#deadlines.clear()
+  }
+
+  #arm(delay: number): void {
+    this.#timer = setTimeout(() => {
+      this.#timer = null
+      const now = Date.now()
+      let next = Infinity
+      for (const [queryId, deadline] of this.#deadlines) {
+        if (deadline <= now) {
+          this.#deadlines.delete(queryId)
+          this.#expire(queryId)
+        } else {
+          next = Math.min(next, deadline)
+        }
+      }
+      if (!this.#disposed && next !== Infinity) this.#arm(Math.max(0, next - Date.now()))
+    }, delay)
+    const timer = this.#timer as ReturnType<typeof setTimeout> & { unref?: () => void }
+    timer.unref?.()
+  }
+}

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -1470,6 +1470,7 @@ export class QueryStore<
     const promise = run(context).then(
       result => {
         hooks?.onSuccess?.(result, context)
+        this.#pruneService(serviceName)
         this.#mutations.end(mutationId)
         this.#telemetry.emit({
           kind: 'mutate:end',
@@ -1486,6 +1487,7 @@ export class QueryStore<
       (err: unknown) => {
         const error = normalizeError(err)
         hooks?.onError?.(error, context)
+        this.#pruneService(serviceName)
         this.#mutations.end(mutationId)
         this.#telemetry.emit({
           kind: 'mutate:error',

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -193,6 +193,7 @@ export interface QueryFetchHistoryEntry {
 
 export const QUERY_FETCH_HISTORY_LIMIT = 50
 export const DEFAULT_STALE_TIME = 5 * 60_000
+export const DEFAULT_GC_TIME = 30 * 60_000
 
 export interface DevtoolsCacheEditResult {
   ok: boolean
@@ -280,7 +281,7 @@ export class QueryStore<
     adapter,
     eventBatchInterval = 100,
     staleTime = DEFAULT_STALE_TIME,
-    gcTime = DEFAULT_STALE_TIME,
+    gcTime = DEFAULT_GC_TIME,
     reconcileCooldown = 2000,
     retry = DEFAULT_RETRIES,
     retryDelay = defaultRetryDelay,

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -1,3 +1,4 @@
+import { QueryRetention } from './queryRetention.js'
 import {
   locallySupportedOperators,
   type Adapter,
@@ -223,7 +224,13 @@ export class QueryStore<
   #telemetry: QueryTelemetry
   #mutations: MutationTracker
 
-  #realtime: Set<string> = new Set()
+  #realtime = new Map<string, () => void>()
+  #connectionUnsub: (() => void) | undefined
+  #visibilityUnsub: () => void
+  #retention: QueryRetention
+  #disposed = false
+  #retryWaits = new Set<() => void>()
+  #dependencyOwners = new Map<string, number>()
   #listeners: Map<string, Set<(state: QueryState<unknown, TMeta>) => void>> = new Map()
   #globalListeners: Set<(state: Map<string, ServiceState<TMeta>>) => void> = new Set()
   #processedEventListeners: Set<(event: ProcessedCacheEvent) => void> = new Set()
@@ -273,6 +280,7 @@ export class QueryStore<
     adapter,
     eventBatchInterval = 100,
     staleTime = DEFAULT_STALE_TIME,
+    gcTime = DEFAULT_STALE_TIME,
     reconcileCooldown = 2000,
     retry = DEFAULT_RETRIES,
     retryDelay = defaultRetryDelay,
@@ -284,6 +292,7 @@ export class QueryStore<
     eventBatchInterval?: number | undefined
     /** Default age (ms) for skipping mount-time revalidation. */
     staleTime?: number
+    gcTime?: number
     /**
      * Minimum interval (ms) between event-driven refetches of one query — burst
      * safety for server-window/server-authoritative reconciliation. The first
@@ -308,6 +317,16 @@ export class QueryStore<
      */
     defaultSort?: Record<string, number>
   }) {
+    this.#retention = new QueryRetention(gcTime, queryId => {
+      const serviceName = this.#serviceNamesByQueryId.get(queryId)
+      if (
+        this.#listenerCount(queryId) > 0 ||
+        (serviceName !== undefined &&
+          this.#state.get(serviceName)?.materialized?.queryId === queryId)
+      )
+        return
+      this.#vacuum({ queryId })
+    })
     this.#adapter = adapter
     this.#mutationLanes = new MutationLanes(item => this.#peekId(item))
     this.#defaultSort = defaultSort
@@ -321,9 +340,9 @@ export class QueryStore<
     this.#reconnectJitter = this.#normalizeReconnectJitter(reconnectJitter)
     this.#visibility = visibility ?? documentVisibility()
     this.#hiddenAt = this.#visibility.isHidden() ? Date.now() : null
-    this.#visibility.onChange(() => this.#visibilityChanged())
+    this.#visibilityUnsub = this.#visibility.onChange(() => this.#visibilityChanged())
     if (this.#adapter.subscribeToConnectionEvents) {
-      this.#adapter.subscribeToConnectionEvents(event => {
+      this.#connectionUnsub = this.#adapter.subscribeToConnectionEvents(event => {
         const traceId = this.#telemetry.nextTraceId()
         switch (event.type) {
           case 'connected':
@@ -370,10 +389,45 @@ export class QueryStore<
         }
       })
     } else {
-      this.#adapter.subscribeToReconnect?.(() =>
+      this.#connectionUnsub = this.#adapter.subscribeToReconnect?.(() =>
         this.#scheduleReconnectSweep(this.#telemetry.nextTraceId()),
       )
     }
+  }
+
+  assertActive(): void {
+    if (this.#disposed) throw new Error('figbird: instance has been disposed')
+  }
+
+  dispose(): void {
+    if (this.#disposed) return
+    this.#disposed = true
+    this.#retention.dispose()
+    this.#visibilityUnsub()
+    this.#connectionUnsub?.()
+    for (const unsubscribe of this.#realtime.values()) unsubscribe()
+    this.#realtime.clear()
+    for (const queryId of this.#reconcileWindows.keys()) this.#clearReconcileState(queryId)
+    if (this.#reconnectSweepTimer) clearTimeout(this.#reconnectSweepTimer)
+    if (this.#eventBatchProcessingTimer) clearTimeout(this.#eventBatchProcessingTimer)
+    for (const cancel of this.#retryWaits) cancel()
+    this.#state.clear()
+    this.#serviceNamesByQueryId.clear()
+    this.#queryGenerations.clear()
+    this.#queryStats.clear()
+    this.#followupFetchContexts.clear()
+    this.#deferredWhileHidden.clear()
+    this.#reconnectQueryIds.clear()
+    this.#dependencyOwners.clear()
+    this.#eventQueue = []
+    this.#appliedEventQueue = []
+    this.#listeners.clear()
+    this.#globalListeners.clear()
+    this.#processedEventListeners.clear()
+    this.#projectionSettlementListeners.clear()
+    this.#fetchEventJournal.clear()
+    this.#telemetry.dispose()
+    this.#mutations.dispose()
   }
 
   // Public store API
@@ -500,9 +554,11 @@ export class QueryStore<
    * service/query structures on first use.
    */
   materialize<T, TQueryType>(queryRef: QueryRef<T, TQueryType, S, TParams, TMeta, TQuery>): void {
+    this.assertActive()
     const { queryId, desc, config } = queryRef.details()
 
     if (!this.#getQuery(queryId)) {
+      this.#retention.retain(queryId)
       this.#serviceNamesByQueryId.set(queryId, desc.serviceName)
       this.#queryGenerations.set(queryId, this.#nextQueryGeneration++)
 
@@ -549,6 +605,7 @@ export class QueryStore<
     const q = this.#getQuery(queryId)
     if (!q) return () => {}
 
+    this.#retention.cancel(queryId)
     this.ensureFresh(queryId, options)
 
     const removeListener = this.#addListener(queryId, fn)
@@ -558,8 +615,9 @@ export class QueryStore<
     const shouldVacuum = isEphemeralQuery(q.config)
     return () => {
       removeListener()
-      if (shouldVacuum && this.#listenerCount(queryId) === 0) {
-        this.#vacuum({ queryId })
+      if (this.#listenerCount(queryId) === 0) {
+        if (shouldVacuum) this.#vacuum({ queryId })
+        else this.#retention.retain(queryId)
       }
     }
   }
@@ -621,8 +679,19 @@ export class QueryStore<
    * against it is subscribed. Used by relational-filter invalidation, which needs
    * events from dependency services the consumer never queries directly.
    */
-  ensureRealtimeSubscription(serviceName: string): void {
+  ensureRealtimeSubscription(serviceName: string): () => void {
+    this.assertActive()
+    this.#dependencyOwners.set(serviceName, (this.#dependencyOwners.get(serviceName) ?? 0) + 1)
     this.#subscribeToRealtimeService(serviceName)
+    let released = false
+    return () => {
+      if (released) return
+      released = true
+      const count = (this.#dependencyOwners.get(serviceName) ?? 1) - 1
+      if (count > 0) this.#dependencyOwners.set(serviceName, count)
+      else this.#dependencyOwners.delete(serviceName)
+      this.#pruneService(serviceName)
+    }
   }
 
   /** Number of active subscribers for a query — powers figbird.inspect(). */
@@ -730,6 +799,7 @@ export class QueryStore<
 
   /** Commit several keyed CRUD mutations through the adapter's atomic capability. */
   transaction(descs: readonly MutationDescriptor[]): Promise<void> {
+    this.assertActive()
     if (!this.#adapter.transaction) {
       throw new Error('figbird: the configured adapter does not support transactions')
     }
@@ -833,6 +903,7 @@ export class QueryStore<
    * request and start another request for the same record. @internal
    */
   mutateConfirmedDirect<D extends MutationDescriptor>(desc: D): Promise<InferMutationData<S, D>> {
+    this.assertActive()
     const { serviceName, method } = desc
     const id = method === 'create' ? this.#peekId(desc.data) : desc.id
     const args = this.#buildMutationArgs(desc)
@@ -859,6 +930,7 @@ export class QueryStore<
     desc: MutationDescriptor,
     control?: ScheduledMutationControl,
   ): RegisteredMutation {
+    this.assertActive()
     const { serviceName, method, optimistic } = desc
     const optimisticItem = method === 'create' ? resolveCreateOptimisticItem(desc) : undefined
     // For creates, track by the client-generated id — this is what lets
@@ -1270,6 +1342,7 @@ export class QueryStore<
   }
 
   #applyProjection(change: ProjectionChange, immediate: boolean, cause?: TraceCause): boolean {
+    if (this.#disposed) return false
     const event = this.#queuedProjectionEvent(change, cause)
     if (!event) return false
     this.#eventQueue.push(event)
@@ -1377,6 +1450,7 @@ export class QueryStore<
     run: (context: MutationTrackingContext) => Promise<T>,
     hooks?: MutationTrackingHooks<T>,
   ): TrackedMutation<T> {
+    this.assertActive()
     const { serviceName, method, id, optimistic, args } = entry
     const idField = id !== undefined ? { id } : {}
     const startedAt = Date.now()
@@ -1475,7 +1549,15 @@ export class QueryStore<
         retryAttempt++
         const configuredDelay = query.config.retryDelay ?? this.#retryDelay
         const delay = this.#resolveRetryDelay(configuredDelay, retryAttempt, outcome.error)
-        await new Promise<void>(resolve => setTimeout(resolve, delay))
+        await new Promise<void>(resolve => {
+          const cancel = () => {
+            clearTimeout(timer)
+            this.#retryWaits.delete(cancel)
+            resolve()
+          }
+          const timer = setTimeout(cancel, delay)
+          this.#retryWaits.add(cancel)
+        })
 
         if (this.#queryGenerations.get(queryId) !== generation) return
         if (!this.#hasRetryOwner(queryId)) {
@@ -1944,6 +2026,10 @@ export class QueryStore<
       // allPages fetch is complete only for its own filter — it must not materialize
       // the service.
       if (isCompleteSet) {
+        const previousRoot = service.materialized?.queryId
+        if (previousRoot && previousRoot !== queryId && this.#listenerCount(previousRoot) === 0) {
+          this.#retention.retain(previousRoot)
+        }
         service.materialized = { queryId, fetchedAt: Date.now() }
       }
 
@@ -2107,7 +2193,7 @@ export class QueryStore<
 
   #subscribeToRealtimeService(serviceName: string): void {
     // check if already subscribed to the events of this service
-    if (this.#realtime.has(serviceName)) return
+    if (this.#disposed || this.#realtime.has(serviceName)) return
     if (!this.#adapter.subscribe) return // Real-time not supported by this adapter
 
     const created = (item: unknown) => this.#queueEvent(serviceName, { type: 'created', item })
@@ -2115,13 +2201,13 @@ export class QueryStore<
     const patched = (item: unknown) => this.#queueEvent(serviceName, { type: 'patched', item })
     const removed = (item: unknown) => this.#queueEvent(serviceName, { type: 'removed', item })
 
-    this.#adapter.subscribe(serviceName, {
+    const unsubscribe = this.#adapter.subscribe(serviceName, {
       created,
       updated,
       patched,
       removed,
     })
-    this.#realtime.add(serviceName)
+    this.#realtime.set(serviceName, unsubscribe)
   }
 
   #emitRealtime(serviceName: string, type: Event['type'], item: unknown): TraceCause | undefined {
@@ -2192,6 +2278,7 @@ export class QueryStore<
       | { immediate: false; source: 'realtime' }
       | { immediate: true; source: 'mutation'; cause?: TraceCause },
   ): void {
+    if (this.#disposed) return
     const items = Array.isArray(event.item) ? event.item : [event.item]
     for (const item of items) {
       const cause =
@@ -2986,7 +3073,7 @@ export class QueryStore<
     serviceName: string,
     fn: (service: ServiceState<TMeta>, touch: (queryId: string) => void) => void,
   ): Set<string> {
-    if (!serviceName) return new Set()
+    if (this.#disposed || !serviceName) return new Set()
 
     // initialise the service structure if needed
     if (!this.getState().get(serviceName)) {
@@ -3003,6 +3090,9 @@ export class QueryStore<
   }
 
   #vacuum({ queryId }: { queryId: string }): void {
+    const serviceName = this.#serviceNamesByQueryId.get(queryId)
+    this.#retention.cancel(queryId)
+    this.#followupFetchContexts.delete(queryId)
     this.#clearReconcileState(queryId)
     this.#transactOverService(queryId, (service, query) => {
       if (query) {
@@ -3019,6 +3109,22 @@ export class QueryStore<
         }
       }
     })
+    if (serviceName) this.#pruneService(serviceName)
+  }
+
+  #pruneService(serviceName: string): void {
+    const service = this.#state.get(serviceName)
+    if (!service || service.materialized || this.#dependencyOwners.has(serviceName)) return
+    for (const key of service.entities.keys()) {
+      if (!service.itemQueryIndex.has(key) && !this.#mutationLanes.get(serviceName, key)) {
+        service.entities.delete(key)
+      }
+    }
+    if (service.queries.size === 0 && service.entities.size === 0) {
+      this.#state.delete(serviceName)
+      this.#realtime.get(serviceName)?.()
+      this.#realtime.delete(serviceName)
+    }
   }
 
   // Internal helpers

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -3117,17 +3117,18 @@ export class QueryStore<
 
   #pruneService(serviceName: string): void {
     const service = this.#state.get(serviceName)
-    if (!service || service.materialized || this.#dependencyOwners.has(serviceName)) return
-    for (const key of service.entities.keys()) {
-      if (!service.itemQueryIndex.has(key) && !this.#mutationLanes.get(serviceName, key)) {
-        service.entities.delete(key)
+    if (service?.materialized || this.#dependencyOwners.has(serviceName)) return
+    if (service) {
+      for (const key of service.entities.keys()) {
+        if (!service.itemQueryIndex.has(key) && !this.#mutationLanes.get(serviceName, key)) {
+          service.entities.delete(key)
+        }
       }
-    }
-    if (service.queries.size === 0 && service.entities.size === 0) {
+      if (service.queries.size > 0 || service.entities.size > 0) return
       this.#state.delete(serviceName)
-      this.#realtime.get(serviceName)?.()
-      this.#realtime.delete(serviceName)
     }
+    this.#realtime.get(serviceName)?.()
+    this.#realtime.delete(serviceName)
   }
 
   // Internal helpers

--- a/lib/core/queryTelemetry.ts
+++ b/lib/core/queryTelemetry.ts
@@ -20,6 +20,12 @@ export class QueryTelemetry {
   #nextFetchId = 1
   readonly #activeFetchGraphs = new Map<string, Map<string, QueryGraphRef>>()
 
+  dispose(): void {
+    this.#events.dispose()
+    for (const graph of this.#activeFetchGraphs.values()) graph.clear()
+    this.#activeFetchGraphs.clear()
+  }
+
   get events(): FigbirdEventEmitter {
     return this.#events
   }

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -71,7 +71,7 @@ export interface RelationalQueryHost<TParams, TMeta extends Record<string, unkno
     isObservabilityActive(): boolean
     subscribeToProcessedEvents(fn: (event: ProcessedCacheEvent) => void): () => void
     subscribeToProjectionSettlements(fn: (event: ProcessedProjectionEvent) => void): () => void
-    ensureRealtimeSubscription(serviceName: string): void
+    ensureRealtimeSubscription(serviceName: string): () => void
     reapplyQuery(queryId: string, mutationLaneKeys: ReadonlySet<string>): void
   }
   getState(): Map<string, ServiceState<TMeta>>
@@ -1536,9 +1536,9 @@ export class RelationalQueryRef<
     const dependencies = collectRelationalFilterDependencies(this.#schema, this.#ast, paths)
     if (dependencies.length === 0) return
 
-    for (const dependency of dependencies) {
-      this.#host.queryStore.ensureRealtimeSubscription(dependency.serviceName)
-    }
+    const releaseDependencies = dependencies.map(dependency =>
+      this.#host.queryStore.ensureRealtimeSubscription(dependency.serviceName),
+    )
 
     const affectsFilter = (event: ProcessedCacheEvent) =>
       shouldRefetchRelationalFilterQuery(
@@ -1568,6 +1568,7 @@ export class RelationalQueryRef<
     this.#processedEventUnsub = () => {
       unsubscribeEvents()
       unsubscribeSettlements()
+      for (const release of releaseDependencies) release()
     }
   }
 
@@ -1678,6 +1679,13 @@ export class RelationalQueryRef<
       this.#settleSuspense(this.getSnapshot())
     }
     return this.#suspensePromise
+  }
+
+  /** @internal Release readers and pending Suspense work when the instance closes. */
+  dispose(): void {
+    this.#rejectSuspense?.(new Error('figbird: instance has been disposed'))
+    this.#listeners.clear()
+    this.#cleanup()
   }
 
   #cleanup(): void {

--- a/lib/core/windowQuery.ts
+++ b/lib/core/windowQuery.ts
@@ -570,6 +570,15 @@ export class WindowQueryRef<
     if (this.#subscribers.size === 0 && this.#coldReads.size === 0) this.#scheduleCleanup()
   }
 
+  /** @internal Release readers and pending Suspense work when the instance closes. */
+  dispose(): void {
+    for (const read of this.#coldReads.values()) {
+      if (read.status === 'pending') read.reject(new Error('figbird: instance has been disposed'))
+    }
+    this.#subscribers.clear()
+    this.#cleanup()
+  }
+
   #cleanup(): void {
     for (const page of this.#pages.values()) page.unsubscribe()
     this.#pages.clear()

--- a/test/figbird-instance.test.ts
+++ b/test/figbird-instance.test.ts
@@ -26,7 +26,7 @@ const schema = createSchema({
   },
 })
 
-test('Figbird instance can be created', t => {
+test('Figbird instance retains idle queries and releases owned resources on disposal', async t => {
   const feathers = mockFeathers({
     notes: {
       data: {
@@ -40,9 +40,69 @@ test('Figbird instance can be created', t => {
     },
   })
   const adapter = new FeathersAdapter(feathers)
-  const figbird = new Figbird({ schema, adapter })
+  let realtimeSubscriptions = 0
+  let visibilitySubscriptions = 0
+  let connectionSubscriptions = 0
+  const subscribe = adapter.subscribe.bind(adapter)
+  adapter.subscribe = (name, handlers) => {
+    realtimeSubscriptions++
+    const unsubscribe = subscribe(name, handlers)
+    return () => {
+      realtimeSubscriptions--
+      unsubscribe()
+    }
+  }
+  adapter.subscribeToConnectionEvents = () => {
+    connectionSubscriptions++
+    return () => {
+      connectionSubscriptions--
+    }
+  }
+  const figbird = new Figbird({
+    schema,
+    adapter,
+    gcTime: 10,
+    visibility: {
+      isHidden: () => false,
+      onChange: () => {
+        visibilitySubscriptions++
+        return () => {
+          visibilitySubscriptions--
+        }
+      },
+    },
+  })
+  const ref = figbird.query(figbird.q.notes)
+  const unsubscribe = ref.subscribe(() => {})
+  await ref.suspensePromise()
+  unsubscribe()
+  t.true(figbird.inspect().length > 0, 'idle cache survives immediate unmount')
+  await new Promise(resolve => setTimeout(resolve, 30))
+  t.is(figbird.inspect().length, 0, 'idle queries expire')
+  t.is(figbird.getState().size, 0, 'unreferenced entities and services expire')
+  t.is(realtimeSubscriptions, 0)
 
-  t.truthy(figbird)
+  const all = figbird.query(figbird.q.notes.all())
+  const releaseAll = all.subscribe(() => {})
+  await all.suspensePromise()
+  releaseAll()
+  await new Promise(resolve => setTimeout(resolve, 30))
+  t.true(figbird.getState().has('notes'), 'complete materializations remain available')
+
+  const queue = figbird.createMutationQueue({ schedule: () => ({ wait: 10_000 }) })
+  const pending = queue.m.notes.patch(1, { content: 'saved during disposal' })
+  const second = queue.m.notes.patch(1, { content: 'second write' })
+  figbird.dispose()
+  figbird.dispose()
+  await Promise.all([pending, second])
+  t.is(feathers.service('notes').data[1]?.content, 'second write')
+  t.is(figbird.getState().size, 0, 'late writes cannot resurrect the disposed cache')
+  t.is(realtimeSubscriptions, 0)
+  t.is(visibilitySubscriptions, 0)
+  t.is(connectionSubscriptions, 0)
+  t.throws(() => figbird.query(figbird.q.notes), { message: /disposed/ })
+  t.throws(() => figbird.m.notes.patch(1, { content: 'too late' }), { message: /disposed/ })
+  t.throws(() => new Figbird({ adapter, schema, gcTime: -1 }), { message: /gcTime/ })
 })
 
 test('figbird.query with get returns typed data', async t => {

--- a/test/figbird-instance.test.ts
+++ b/test/figbird-instance.test.ts
@@ -75,12 +75,23 @@ test('Figbird instance retains idle queries and releases owned resources on disp
   const ref = figbird.query(figbird.q.notes)
   const unsubscribe = ref.subscribe(() => {})
   await ref.suspensePromise()
+  const idleQueue = figbird.createMutationQueue({ schedule: () => ({ wait: 10_000 }) })
+  const idleWrite = idleQueue.m.notes.patch(1, { content: 'saved after expiry' })
   unsubscribe()
   t.true(figbird.inspect().length > 0, 'idle cache survives immediate unmount')
   await new Promise(resolve => setTimeout(resolve, 30))
   t.is(figbird.inspect().length, 0, 'idle queries expire')
+  t.is(figbird.getState().get('notes')?.entities.size, 1, 'pending mutation retains its row')
+  t.is(realtimeSubscriptions, 1)
+  idleQueue.flush()
+  await idleWrite
   t.is(figbird.getState().size, 0, 'unreferenced entities and services expire')
   t.is(realtimeSubscriptions, 0)
+
+  await figbird.m.notes.patch(1, { content: 'written without a query' })
+  t.is(figbird.getState().size, 0, 'settled writes release services recreated after expiry')
+  await figbird.m.notes.create([{ id: 2, content: 'created without a query' }])
+  t.is(figbird.getState().size, 0, 'unkeyed writes release unreferenced entities too')
 
   const all = figbird.query(figbird.q.notes.all())
   const releaseAll = all.subscribe(() => {})

--- a/test/figbird-instance.test.ts
+++ b/test/figbird-instance.test.ts
@@ -93,6 +93,16 @@ test('Figbird instance retains idle queries and releases owned resources on disp
   await figbird.m.notes.create([{ id: 2, content: 'created without a query' }])
   t.is(figbird.getState().size, 0, 'unkeyed writes release unreferenced entities too')
 
+  const releaseDependency = figbird.queryStore.ensureRealtimeSubscription('posts')
+  const releaseSecondDependency = figbird.queryStore.ensureRealtimeSubscription('posts')
+  t.false(figbird.getState().has('posts'), 'dependency subscriptions need no cached rows')
+  t.is(realtimeSubscriptions, 1)
+  releaseDependency()
+  releaseDependency()
+  t.is(realtimeSubscriptions, 1, 'another dependency owner keeps the subscription alive')
+  releaseSecondDependency()
+  t.is(realtimeSubscriptions, 0, 'the last dependency owner releases the subscription')
+
   const all = figbird.query(figbird.q.notes.all())
   const releaseAll = all.subscribe(() => {})
   await all.suspensePromise()


### PR DESCRIPTION
Add `gcTime`, defaulting to thirty minutes after the last query reader releases its subscription. One timer expires idle queries, removes unreferenced entities, and releases unused service subscriptions. Active queries, relation-filter dependencies, pending optimistic entities, and complete `.all()` materializations remain protected. `Infinity` preserves lifetime retention.

Add idempotent `figbird.dispose()` for instance replacement and application teardown. It releases query graphs, speculative reads, cache state, realtime/connection/visibility subscriptions, retry waits, and devtools sessions. New work is rejected. Already registered mutations finish in order; owned queues flush and cannot pause indefinitely awaiting an absent owner. Late responses cannot repopulate the disposed cache. Shared adapter transports are not disconnected.

The existing instance lifecycle test now checks expiry, protected materialization, resource cleanup, disposal during queued writes, idempotence, and invalid configuration. Public behavior is documented.

Validation: `npm run tsc`, `npm run lint`, `npm run ava`, and `npm run test` pass, including all 365 tests.

Stacked on #120, which follows #119. Merge in that order, then retarget to master if necessary. This introduces finite default idle retention; set `gcTime: Infinity` to retain the previous policy.

