### PR TITLE
Keep materialized queries local and reuse relation subscriptions

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1291,6 +1291,11 @@ you searched".
 
 ### Exhaustive reads: .all()
 
+Live finds with a known sort order over a fully materialized service recompute locally
+after data changes. They do not wait for the network reconciliation cooldown or tab
+visibility. Snapshot queries and reads requiring server evaluation keep their existing
+behavior.
+
 `.all()` fetches **every row matching the query**. All pages are drained, so the server's
 default page cap never silently truncates the result. Without it, an unwindowed find returns a
 single server page; that cap is the safety mechanism (an unbounded query shouldn't slurp the

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -1744,7 +1744,7 @@ export class QueryStore<
         }
         return pageSource.find(desc.params as TParams, desc.page)
       }
-      const local = this.#tryLocalFind(query)
+      const local = this.#selectMaterializedFind(query)
       if (local) return Promise.resolve(local)
       const findConfig = config as FindQueryConfig<unknown, unknown>
       return findConfig.allPages
@@ -1795,20 +1795,11 @@ export class QueryStore<
     return { data: entity } as QueryResponse<unknown, TMeta | undefined>
   }
 
-  /**
-   * Answer a find locally when the service is fully materialized (an `.all()` query
-   * succeeded): filter the entity cache with the adapter matcher, then sort and slice
-   * any window client-side. Windowed queries against a materialized service classify
-   * server-window, so realtime events refetch them — and the "refetch" lands here,
-   * recomputing from the local set with no network.
-   *
-   * Returns null (fall through to the network) for: non-materialized services, the
-   * materialization root itself, `.server()` queries, and predicates the local matcher
-   * cannot decide ($select, $regex, custom operators).
-   */
-  #tryLocalFind(
+  /** Select a deterministically ordered find from a complete local service. */
+  #selectMaterializedFind(
     query: Query<unknown, TMeta, unknown>,
-  ): QueryResponse<unknown, TMeta | undefined> | null {
+  ): { data: unknown[]; meta: TMeta } | null {
+    if (query.desc.method !== 'find' || query.desc.page) return null
     const service = this.#state.get(query.desc.serviceName)
     if (!service?.materialized) return null
     if (service.materialized.queryId === query.queryId) return null
@@ -1824,7 +1815,9 @@ export class QueryStore<
     if (query.classification === 'server-authoritative') return null
 
     const q = queryOfParams(query.desc.params)
-    const { filters, sort, limit, skip } = splitWindow(q)
+    const { filters, sort, ...window } = splitWindow(q)
+    const limit = config.allPages ? undefined : window.limit
+    const skip = config.allPages ? 0 : window.skip
     const effectiveSort = sort ?? this.#defaultSort
     // A complete entity set proves membership, but it does not reveal the
     // backend's implicit order. Without an explicit or configured sort, serving
@@ -1836,11 +1829,21 @@ export class QueryStore<
     const total = rows.length
     const data = rows.slice(skip, limit !== undefined ? skip + limit : undefined)
     // The adapter owns the meta envelope — the store only knows the window numbers.
-    // (Cast because QueryResponse's meta arm can't resolve for an unresolved TMeta.)
     return {
       data,
       meta: this.#adapter.findMeta({ total, limit: limit ?? total, skip }),
-    } as QueryResponse<unknown, TMeta>
+    }
+  }
+
+  #reapplyMaterializedFind(service: ServiceState<TMeta>, query: Query<unknown, TMeta>): boolean {
+    if (query.config.realtime !== 'merge' || query.state.status !== 'success') return false
+    const local = this.#selectMaterializedFind(query)
+    if (!local) return false
+    commitQuery(service, {
+      ...query,
+      state: { ...query.state, data: local.data, meta: local.meta },
+    })
+    return true
   }
 
   #fetching({ queryId }: { queryId: string }): void {
@@ -2018,7 +2021,7 @@ export class QueryStore<
 
       // A successful unfiltered allPages fetch (`.all()` with no filters) means the
       // complete row set is now local: mark the service materialized so matcher-
-      // decidable finds are answered from the cache (see #tryLocalFind). A *filtered*
+      // decidable finds are answered from the cache (see #selectMaterializedFind). A *filtered*
       // allPages fetch is complete only for its own filter — it must not materialize
       // the service.
       if (isCompleteSet) {
@@ -2400,15 +2403,25 @@ export class QueryStore<
     touch: (queryId: string) => void
     excludeQueryId?: string
   }): AppliedEventEffect[] {
+    if (processedEvents.length === 0) return []
+    const selectedQueries = new Set<string>()
+    for (const [queryId, query] of service.queries) {
+      if (queryId === excludeQueryId || !this.#reapplyMaterializedFind(service, query)) continue
+      selectedQueries.add(queryId)
+      touch(queryId)
+    }
     const getId = this.#getIdReader(serviceName)
     return processedEvents.map(event => {
       const reconcileQueryIds = new Set<string>()
       const queryEffects = this.#telemetry.active
-        ? new Map<string, 'merged' | 'reconcile'>()
+        ? new Map<string, 'merged' | 'reconcile'>(
+            [...selectedQueries].map(queryId => [queryId, 'merged']),
+          )
         : undefined
       updateQueriesFromEvents({
         service,
         appliedItems: [event],
+        excludeQueryIds: selectedQueries,
         touch,
         getId,
         itemAdded: meta => this.#adapter.itemAdded(meta),
@@ -2678,6 +2691,16 @@ export class QueryStore<
     if (!force && this.#listenerCount(queryId) === 0) {
       this.#emitReconcileDecision(queryId, 'inactive', mergedCauses)
       this.#markQueryPending(queryId)
+      return
+    }
+
+    let selected = false
+    const touched = this.#transactOverService(queryId, (service, query) => {
+      if (query) selected = this.#reapplyMaterializedFind(service, query)
+    })
+    if (selected) {
+      this.#clearReconcileState(queryId)
+      this.#notify(touched)
       return
     }
 

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -79,6 +79,7 @@ import {
 import { defaultRetryDelay, resolveRetryDelay } from './retryDelay.js'
 import { normalizeError } from './errors.js'
 import { isWithinStaleTime } from './staleTime.js'
+import { sameValue } from './valueEquality.js'
 
 /**
  * Where the store learns whether the tab is visible. Injectable for tests and
@@ -1835,15 +1836,26 @@ export class QueryStore<
     }
   }
 
-  #reapplyMaterializedFind(service: ServiceState<TMeta>, query: Query<unknown, TMeta>): boolean {
-    if (query.config.realtime !== 'merge' || query.state.status !== 'success') return false
+  #reapplyMaterializedFind(
+    service: ServiceState<TMeta>,
+    query: Query<unknown, TMeta>,
+  ): 'unavailable' | 'unchanged' | 'changed' {
+    if (query.config.realtime !== 'merge' || query.state.status !== 'success') return 'unavailable'
     const local = this.#selectMaterializedFind(query)
-    if (!local) return false
+    if (!local) return 'unavailable'
+    const previous = query.state.data
+    if (
+      Array.isArray(previous) &&
+      previous.length === local.data.length &&
+      previous.every((row, index) => row === local.data[index]) &&
+      sameValue(query.state.meta, local.meta)
+    )
+      return 'unchanged'
     commitQuery(service, {
       ...query,
       state: { ...query.state, data: local.data, meta: local.meta },
     })
-    return true
+    return 'changed'
   }
 
   #fetching({ queryId }: { queryId: string }): void {
@@ -2405,17 +2417,23 @@ export class QueryStore<
   }): AppliedEventEffect[] {
     if (processedEvents.length === 0) return []
     const selectedQueries = new Set<string>()
+    const changedQueries = new Set<string>()
     for (const [queryId, query] of service.queries) {
-      if (queryId === excludeQueryId || !this.#reapplyMaterializedFind(service, query)) continue
+      if (queryId === excludeQueryId) continue
+      const result = this.#reapplyMaterializedFind(service, query)
+      if (result === 'unavailable') continue
       selectedQueries.add(queryId)
-      touch(queryId)
+      if (result === 'changed') {
+        changedQueries.add(queryId)
+        touch(queryId)
+      }
     }
     const getId = this.#getIdReader(serviceName)
     return processedEvents.map(event => {
       const reconcileQueryIds = new Set<string>()
       const queryEffects = this.#telemetry.active
         ? new Map<string, 'merged' | 'reconcile'>(
-            [...selectedQueries].map(queryId => [queryId, 'merged']),
+            [...changedQueries].map(queryId => [queryId, 'merged']),
           )
         : undefined
       updateQueriesFromEvents({
@@ -2695,12 +2713,20 @@ export class QueryStore<
     }
 
     let selected = false
+    let changed = false
     const touched = this.#transactOverService(queryId, (service, query) => {
-      if (query) selected = this.#reapplyMaterializedFind(service, query)
+      if (!query) return
+      const result = this.#reapplyMaterializedFind(service, query)
+      selected = result !== 'unavailable'
+      changed = result === 'changed'
+      const current = service.queries.get(queryId)
+      if (selected && current?.pending) {
+        commitQuery(service, { ...current, pending: false })
+      }
     })
     if (selected) {
       this.#clearReconcileState(queryId)
-      this.#notify(touched)
+      if (changed) this.#notify(touched)
       return
     }
 

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -327,25 +327,8 @@ export class RelationalQueryRef<
     for (const queryId of this.#root?.queryIds() ?? []) {
       nodes.push({ path: '(root)', queryId })
     }
-    for (const [path, sub] of this.#relationSubs) {
-      switch (sub.kind) {
-        case 'empty':
-          break
-        case 'fanIn':
-          nodes.push({
-            path: path.endsWith('#dest') ? path.slice(0, -'#dest'.length) : path,
-            queryId: sub.queryRef.details().queryId,
-          })
-          break
-        case 'junction':
-          nodes.push({ path, role: 'junction', queryId: sub.queryRef.details().queryId })
-          break
-        case 'perParent':
-          for (const child of sub.children.values()) {
-            nodes.push({ path, queryId: child.queryRef.details().queryId })
-          }
-          break
-      }
+    for (const { queryRef, path, role } of this.#queryLeaves()) {
+      nodes.push({ path, ...(role ? { role } : {}), queryId: queryRef.details().queryId })
     }
     const snapshot = this.getSnapshot()
     const listenerMetadata = [...this.#listeners.values()]
@@ -540,37 +523,35 @@ export class RelationalQueryRef<
   #ensureFresh(staleTime: number): void {
     if (!this.#graphRunId) this.#beginGraphRun()
     this.#root?.ensureFresh(staleTime, this.#graph('(root)'))
-    for (const sub of this.#relationSubs.values()) {
-      this.#ensureRelationSubFresh(sub, staleTime)
+    for (const { queryRef, path, role } of this.#queryLeaves()) {
+      queryRef.ensureFresh({ staleTime, graph: this.#graph(path, role) })
     }
     this.#scheduleGraphRunCompletion(this.getSnapshot())
   }
 
-  #ensureRelationSubFresh(sub: RelationSub<S, TParams, TMeta, TQuery>, staleTime: number): void {
-    switch (sub.kind) {
-      case 'empty':
-        return
-      case 'fanIn':
-        sub.queryRef.ensureFresh({ staleTime, graph: this.#graph(this.#pathForSub(sub)) })
-        return
-      case 'junction':
-        sub.queryRef.ensureFresh({
-          staleTime,
-          graph: this.#graph(this.#pathForSub(sub), 'junction'),
-        })
-        return
-      case 'perParent':
-        for (const child of sub.children.values()) {
-          child.queryRef.ensureFresh({ staleTime, graph: this.#graph(this.#pathForSub(sub)) })
-        }
+  *#queryLeaves(): Generator<{
+    queryRef: QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>
+    path: string
+    role?: 'junction'
+  }> {
+    for (const [key, sub] of this.#relationSubs) {
+      const path = key.endsWith('#dest') ? key.slice(0, -'#dest'.length) : key
+      switch (sub.kind) {
+        case 'empty':
+          break
+        case 'fanIn':
+          yield { queryRef: sub.queryRef, path }
+          break
+        case 'junction':
+          yield { queryRef: sub.queryRef, path, role: 'junction' }
+          break
+        case 'perParent':
+          for (const child of sub.children.values()) {
+            yield { queryRef: child.queryRef, path }
+          }
+          break
+      }
     }
-  }
-
-  #pathForSub(target: RelationSub<S, TParams, TMeta, TQuery>): string {
-    for (const [path, sub] of this.#relationSubs) {
-      if (sub === target) return path.endsWith('#dest') ? path.slice(0, -'#dest'.length) : path
-    }
-    return '(unknown)'
   }
 
   #scheduleCleanup(): void {
@@ -937,32 +918,10 @@ export class RelationalQueryRef<
     this.#beginGraphRun()
     this.#root?.refetch(this.#graph('(root)'))
     const seen = new Set<QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>>()
-    for (const sub of this.#relationSubs.values()) {
-      switch (sub.kind) {
-        case 'empty':
-          break
-        case 'fanIn':
-          if (!seen.has(sub.queryRef)) {
-            seen.add(sub.queryRef)
-            sub.queryRef.refetch({ graph: this.#graph(this.#pathForSub(sub)) })
-          }
-          break
-        case 'junction':
-          if (!seen.has(sub.queryRef)) {
-            seen.add(sub.queryRef)
-            sub.queryRef.refetch({
-              graph: this.#graph(this.#pathForSub(sub), 'junction'),
-            })
-          }
-          break
-        case 'perParent':
-          for (const child of sub.children.values()) {
-            if (seen.has(child.queryRef)) continue
-            seen.add(child.queryRef)
-            child.queryRef.refetch({ graph: this.#graph(this.#pathForSub(sub)) })
-          }
-          break
-      }
+    for (const { queryRef, path, role } of this.#queryLeaves()) {
+      if (seen.has(queryRef)) continue
+      seen.add(queryRef)
+      queryRef.refetch({ graph: this.#graph(path, role) })
     }
     this.#scheduleGraphRunCompletion(this.getSnapshot())
   }

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -1254,9 +1254,10 @@ export class RelationalQueryRef<
       return
     }
 
-    if (existing) this.#disposeRelationSub(existing, key)
+    if (existing && existing.kind !== 'perParent') this.#disposeRelationSub(existing, key)
 
     if (uniqueValues.length === 0) {
+      if (existing?.kind === 'perParent') this.#disposeRelationSub(existing, key)
       this.#relationSubs.set(key, { kind: 'empty', sourceKey: newSourceKey })
       return
     }
@@ -1275,14 +1276,24 @@ export class RelationalQueryRef<
       )
     }
 
-    const entry: RelationSub<S, TParams, TMeta, TQuery> = {
-      kind: 'perParent',
-      sourceKey: newSourceKey,
-      children: new Map(),
-    }
+    const entry: Extract<
+      RelationSub<S, TParams, TMeta, TQuery>,
+      { kind: 'perParent' }
+    > = existing?.kind === 'perParent'
+      ? existing
+      : { kind: 'perParent', sourceKey: newSourceKey, children: new Map() }
+    entry.sourceKey = newSourceKey
+    const previousChildren = entry.children
+    entry.children = new Map()
     this.#relationSubs.set(key, entry)
 
     for (const sourceValue of uniqueValues) {
+      const childKey = sourceValueKey(sourceValue)
+      const retained = previousChildren.get(childKey)
+      if (retained) {
+        entry.children.set(childKey, retained)
+        continue
+      }
       const queryRef = this.#buildSingleParentRelationQueryRef(
         relDef.destService,
         relDef,
@@ -1299,9 +1310,12 @@ export class RelationalQueryRef<
         { staleTime: this.#staleTime, graph: this.#graph(key) },
       )
 
-      entry.children.set(sourceValueKey(sourceValue), { queryRef, unsub, sourceValue })
+      entry.children.set(childKey, { queryRef, unsub, sourceValue })
     }
 
+    for (const [childKey, child] of previousChildren) {
+      if (!entry.children.has(childKey)) child.unsub()
+    }
     this.#syncNestedWindowedRelationIfReady(entry, relAST, key)
   }
 

--- a/lib/core/windowMaintenance.ts
+++ b/lib/core/windowMaintenance.ts
@@ -418,6 +418,7 @@ export function updateQueriesFromEvents<TMeta>({
   serverMaintainedQueriesToRefetch,
   onEffect,
   excludeQueryId,
+  excludeQueryIds,
   defaultSort,
 }: {
   service: ServiceState<TMeta>
@@ -430,6 +431,7 @@ export function updateQueriesFromEvents<TMeta>({
   onEffect?: (queryId: string, effect: 'merged' | 'reconcile') => void
   /** A query whose state already reflects the applied items (e.g. the fetch they came from). */
   excludeQueryId?: string
+  excludeQueryIds?: ReadonlySet<string>
   /** The backend's implicit order for queries without `$sort` — see QueryStore options. */
   defaultSort?: Record<string, number> | undefined
 }): void {
@@ -443,7 +445,8 @@ export function updateQueriesFromEvents<TMeta>({
   }
   for (const event of appliedItems) {
     for (const [queryId, query] of service.queries) {
-      if (queryId === excludeQueryId || query.config.realtime !== 'merge') continue
+      if (queryId === excludeQueryId || excludeQueryIds?.has(queryId)) continue
+      if (query.config.realtime !== 'merge') continue
       if (query.desc.method === 'find' && query.config.fetchPolicy === 'network-only') continue
       if (
         isServerMaintained(query.classification) &&

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -3056,12 +3056,15 @@ test('inspect: stable read-only projection of live queries', async t => {
 
 test('.all(): materialized reads stay local only when their ordering is knowable', async t => {
   const { feathers } = createApp()
+  const reconnectEvents = new EventEmitter()
+  ;(feathers as ReturnType<typeof mockFeathers> & { io: EventEmitter }).io = reconnectEvents
   let hidden = false
   const figbird = new Figbird({
     schema,
     adapter: new FeathersAdapter(feathers),
     eventBatchInterval: 0,
     retry: false,
+    reconnectJitter: 0,
     visibility: { isHidden: () => hidden, onChange: () => () => {} },
   })
 
@@ -3106,12 +3109,22 @@ test('.all(): materialized reads stay local only when their ordering is knowable
     },
     { allPages: true },
   )
-  const unsubExhaustive = exhaustive.subscribe(() => {})
+  let exhaustiveNotifications = 0
+  const unsubExhaustive = exhaustive.subscribe(() => {
+    exhaustiveNotifications++
+  })
   await new Promise(resolve => setTimeout(resolve, 10))
   t.deepEqual(
     exhaustive.getSnapshot()?.data?.map(issue => issue.id),
     [1, 3],
   )
+
+  const beforeUnrelatedPatch = exhaustive.getSnapshot()
+  exhaustiveNotifications = 0
+  await figbird.m.issues.patch(2, { title: 'Closed issue updated' })
+  await new Promise(resolve => setTimeout(resolve, 10))
+  t.is(exhaustive.getSnapshot(), beforeUnrelatedPatch)
+  t.is(exhaustiveNotifications, 0)
 
   // Realtime maintains the set; the windowed subset recomputes locally — still no fetch.
   await feathers.service('issues').create({ id: 9, title: 'Newest', status: 'open', creatorId: 1 })
@@ -3180,6 +3193,18 @@ test('.all(): materialized reads stay local only when their ordering is knowable
     [1],
   )
   t.is(feathers.service('issues').counts.find, findsBeforeHiddenChanges)
+
+  hidden = false
+  reconnectEvents.emit('reconnect')
+  await new Promise(resolve => setTimeout(resolve, 20))
+  const settled = figbird.getState().get('issues')?.queries.get(exhaustive.details().queryId)
+  t.is(settled?.pending, false, 'local reconciliation settles pending work')
+  const beforeEnsureFresh = exhaustive.getSnapshot()
+  exhaustiveNotifications = 0
+  exhaustive.ensureFresh({ staleTime: Infinity })
+  await new Promise(resolve => setTimeout(resolve, 10))
+  t.is(exhaustive.getSnapshot(), beforeEnsureFresh)
+  t.is(exhaustiveNotifications, 0)
 
   unsubExhaustive()
   unsubLocal()

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -3038,7 +3038,15 @@ test('inspect: stable read-only projection of live queries', async t => {
 })
 
 test('.all(): materialized reads stay local only when their ordering is knowable', async t => {
-  const { figbird, feathers } = createApp()
+  const { feathers } = createApp()
+  let hidden = false
+  const figbird = new Figbird({
+    schema,
+    adapter: new FeathersAdapter(feathers),
+    eventBatchInterval: 0,
+    retry: false,
+    visibility: { isHidden: () => hidden, onChange: () => () => {} },
+  })
 
   // Preload the complete set ($sort doesn't affect completeness, so it still materializes).
   const allRef = figbird.query(figbird.q.issues.orderBy('title').all())
@@ -3072,6 +3080,21 @@ test('.all(): materialized reads stay local only when their ordering is knowable
     [3, 2],
   )
   t.is(feathers.service('issues').counts.find, findsAfterUnsorted, 'window computed locally')
+
+  const exhaustive = figbird.queryDesc(
+    {
+      serviceName: 'issues',
+      method: 'find',
+      params: { query: { status: 'open', $sort: { id: 1 }, $limit: 1 } },
+    },
+    { allPages: true },
+  )
+  const unsubExhaustive = exhaustive.subscribe(() => {})
+  await new Promise(resolve => setTimeout(resolve, 10))
+  t.deepEqual(
+    exhaustive.getSnapshot()?.data?.map(issue => issue.id),
+    [1, 3],
+  )
 
   // Realtime maintains the set; the windowed subset recomputes locally — still no fetch.
   await feathers.service('issues').create({ id: 9, title: 'Newest', status: 'open', creatorId: 1 })
@@ -3122,6 +3145,26 @@ test('.all(): materialized reads stay local only when their ordering is knowable
     local.getSnapshot().data?.map(issue => issue.id),
     [1, 2, 3, 10],
   )
+  const findsBeforeHiddenChanges = feathers.service('issues').counts.find
+  hidden = true
+  await figbird.m.issues.remove(10)
+  t.deepEqual(
+    winRef.getSnapshot().data?.map(issue => issue.id),
+    [3, 2],
+  )
+  await figbird.m.issues.remove(3)
+  t.deepEqual(
+    winRef.getSnapshot().data?.map(issue => issue.id),
+    [2, 1],
+  )
+  t.is(winRef.rootMetadata().total, 2)
+  t.deepEqual(
+    exhaustive.getSnapshot()?.data?.map(issue => issue.id),
+    [1],
+  )
+  t.is(feathers.service('issues').counts.find, findsBeforeHiddenChanges)
+
+  unsubExhaustive()
   unsubLocal()
   unsubServerAll()
   unsubDetail()
@@ -3130,6 +3173,7 @@ test('.all(): materialized reads stay local only when their ordering is knowable
   unsubOpen()
   unsubWin()
   unsubAll()
+  figbird.dispose()
 })
 
 test('.all(): accepts filters — complete slice, no materialization; rejects windowing', async t => {

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -2777,7 +2777,7 @@ it('useQuery: limited sorted relation refetches its server window after a visibl
 
 it('useQuery: limited sorted many relation applies the window per parent', async t => {
   const { render, unmount, flush, $ } = dom()
-  const { App, figbird } = createWindowQueryApp()
+  const { App, figbird, feathers } = createWindowQueryApp()
 
   function CompaniesView() {
     const data = useQuery(
@@ -2789,6 +2789,7 @@ it('useQuery: limited sorted many relation applies the window per parent', async
           .limit(2)
           .related('currentEmployment', e => e.where({ effectiveAt: '2025-04-23' })),
       ),
+      { staleTime: 0 },
     )
 
     return (
@@ -2818,6 +2819,22 @@ it('useQuery: limited sorted many relation applies the window per parent', async
   await flush()
 
   t.truthy($('.companies'))
+  t.is($('.companies')!.getAttribute('data-people'), 'Acme:Alice,Bob|Globex:Eve,Finn')
+  t.is(
+    $('.companies')!.getAttribute('data-employment'),
+    'Acme:Alice role,Bob role|Globex:Eve role,Finn role',
+  )
+
+  const initialPeopleFinds = feathers.service('people').counts.find
+  await flush(async () => {
+    await feathers.service('companies').create({ id: 3, name: 'Newco' })
+  })
+  t.is(feathers.service('people').counts.find, initialPeopleFinds + 1)
+  t.is($('.companies')!.getAttribute('data-people'), 'Acme:Alice,Bob|Globex:Eve,Finn|Newco:')
+  await flush(async () => {
+    await feathers.service('companies').remove(3)
+  })
+  t.is(feathers.service('people').counts.find, initialPeopleFinds + 1)
   t.is($('.companies')!.getAttribute('data-people'), 'Acme:Alice,Bob|Globex:Eve,Finn')
   t.is(
     $('.companies')!.getAttribute('data-employment'),


### PR DESCRIPTION
Windows over a fully materialized service could retain a deleted row until the server reconciliation cooldown expired, even though the replacement was already in the local cache. Eligible live finds now select and commit their results directly after an entity batch. Explicit reconciliation uses the same local selection before network cooldown or visibility gating. Exhaustive reads retain the full result when their query carries a page-size hint.

Per-parent relations now retain subscriptions for unchanged parents, create children only for new parents, and release children only for removed parents. This avoids unnecessary child refetches when the parent set changes. With `staleTime: 0`, the reproduction's cumulative child-find counts go from 3 → 7 → 10 to 3 → 4 → 4 across initial load, adding one parent, and removing one parent.

Inspection, freshness checks, and manual refetch now share one relation-query traversal. It carries graph paths and junction roles directly, removing repeated strategy switches and reverse path searches while preserving refetch deduplication.

The PR contains three commits, one per change. Existing tests cover consecutive hidden-tab deletions, exhaustive local reads, retained child subscriptions, and nested relation results.

Validation: `npm run tsc`, `npm run lint`, `npm run ava`, `npm run test`, and `npm run build` pass. All 365 tests pass. Both standalone reproductions also produce the expected results.
