### PR TITLE
Compile relation plans and centralize reconciliation scheduling

### DIFF
--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -1,3 +1,4 @@
+import { ReconcileScheduler } from './reconcileScheduler.js'
 import { commitQuery, deleteQuery } from './queryResults.js'
 import { QueryRetention } from './queryRetention.js'
 import {
@@ -247,17 +248,11 @@ export class QueryStore<
   #fetchEventJournal = new FetchEventJournal()
   #mutationLanes: MutationLanes<QueuedMutation>
 
-  // Reconciliation gate state (see #requestReconcile): per-query cooldown windows
-  // with trailing timers, and the set of reconciliations deferred while hidden.
-  #reconcileCooldown: number
+  // Scheduling owns pending work; query snapshots retain its diagnostic pending flag.
+  #reconciliation: ReconcileScheduler
   #staleTime: number
   #visibility: VisibilitySource
   #hiddenAt: number | null
-  #reconcileWindows: Map<
-    string,
-    { lastAt: number; trailing: ReturnType<typeof setTimeout> | null; causes?: TraceCause[] }
-  > = new Map()
-  #deferredWhileHidden: Map<string, TraceCause[] | undefined> = new Map()
 
   #defaultSort: Record<string, number> | undefined
   #retry: number | false
@@ -334,7 +329,21 @@ export class QueryStore<
     this.#eventBatchInterval = eventBatchInterval
     this.#telemetry = new QueryTelemetry()
     this.#mutations = new MutationTracker()
-    this.#reconcileCooldown = reconcileCooldown
+    this.#reconciliation = new ReconcileScheduler(reconcileCooldown, {
+      prepare: (queryId, force) => this.#prepareReconcile(queryId, force),
+      fetch: (queryId, causes) => {
+        this.#emitReconcileStarted(queryId, causes)
+        this.refetch(queryId, { reason: 'reconcile', ...(causes ? { causes: [...causes] } : {}) })
+      },
+      pendingChanged: (queryId, pending) => {
+        this.#transactOverService(queryId, (service, query) => {
+          if (query) commitQuery(service, { ...query, pending })
+        })
+      },
+      decision: (queryId, decision, causes) =>
+        this.#emitReconcileDecision(queryId, decision, causes),
+      merge: (left, right) => this.#telemetry.merge(left, right),
+    })
     this.#staleTime = staleTime
     this.#retry = this.#normalizeRetry(retry)
     this.#retryDelay = retryDelay
@@ -408,7 +417,7 @@ export class QueryStore<
     this.#connectionUnsub?.()
     for (const unsubscribe of this.#realtime.values()) unsubscribe()
     this.#realtime.clear()
-    for (const queryId of this.#reconcileWindows.keys()) this.#clearReconcileState(queryId)
+    this.#reconciliation.dispose()
     if (this.#reconnectSweepTimer) clearTimeout(this.#reconnectSweepTimer)
     if (this.#eventBatchProcessingTimer) clearTimeout(this.#eventBatchProcessingTimer)
     for (const cancel of this.#retryWaits) cancel()
@@ -417,7 +426,6 @@ export class QueryStore<
     this.#queryGenerations.clear()
     this.#queryStats.clear()
     this.#followupFetchContexts.clear()
-    this.#deferredWhileHidden.clear()
     this.#reconnectQueryIds.clear()
     this.#dependencyOwners.clear()
     this.#eventQueue = []
@@ -569,13 +577,14 @@ export class QueryStore<
         localOperators: locallySupportedOperators(this.#adapter, desc.serviceName),
       })
 
+      if (!config.skip) this.#reconciliation.markPending(queryId)
       this.#transactOverService(queryId, service => {
         commitQuery(service, {
           queryId,
           desc,
           config: config as QueryConfig<unknown, unknown>,
           classification,
-          pending: !config.skip,
+          pending: this.#reconciliation.isPending(queryId),
           dirty: false,
           filterItem: this.#createItemFilter<unknown, unknown>(
             desc,
@@ -672,7 +681,7 @@ export class QueryStore<
     for (const laneKey of mutationLaneKeys) {
       deferred = this.#mutationLanes.deferQueryIds(laneKey, [queryId]) || deferred
     }
-    if (!deferred) this.#requestReconcile(queryId)
+    if (!deferred) this.#reconciliation.request(queryId)
   }
 
   /**
@@ -716,7 +725,7 @@ export class QueryStore<
     const staleTime = options.staleTime ?? this.#staleTime
     const isFresh = isWithinStaleTime(q.fetchedAt, staleTime)
     if (
-      q.pending ||
+      this.#reconciliation.isPending(queryId) ||
       (q.state.status === 'success' &&
         q.config.fetchPolicy === 'swr' &&
         !q.state.isFetching &&
@@ -761,7 +770,7 @@ export class QueryStore<
 
   /** Route an event-driven refetch through cooldown and visibility handling. @internal */
   reconcile(queryId: string): void {
-    this.#requestReconcile(queryId)
+    this.#reconciliation.request(queryId)
   }
 
   /** Replace/remove a row already visible in one query without changing membership. @internal */
@@ -1366,7 +1375,7 @@ export class QueryStore<
     if (!effects) return
 
     if (effects.projection) this.#emitProjectionSettlement(effects.projection)
-    for (const queryId of effects.queryIds) this.#requestReconcile(queryId)
+    for (const queryId of effects.queryIds) this.#reconciliation.request(queryId)
   }
 
   /** Active optimistic projections must survive fetches that started after them. */
@@ -1859,6 +1868,7 @@ export class QueryStore<
   }
 
   #fetching({ queryId }: { queryId: string }): void {
+    this.#reconciliation.settle(queryId)
     // This is the only listener-notifying transition reachable synchronously from
     // a React render (useQuery → suspensePromise → root/relation setup → subscribe
     // → #queue → here); everything past `await #fetch` is already async. Deferring
@@ -1871,7 +1881,6 @@ export class QueryStore<
 
         commitQuery(service, {
           ...query,
-          pending: false,
           dirty: false,
           // error and loading states both restart as a clean loading state.
           state:
@@ -2127,7 +2136,7 @@ export class QueryStore<
     }
 
     for (const id of serverMaintainedQueriesToRefetch) {
-      this.#requestReconcile(id, {
+      this.#reconciliation.request(id, {
         force: id === service?.materialized?.queryId,
         ...(publishedEffects.reconcileCauses.has(id)
           ? { causes: publishedEffects.reconcileCauses.get(id)! }
@@ -2178,7 +2187,7 @@ export class QueryStore<
     const serviceName = this.#serviceNamesByQueryId.get(queryId)
     const isMaterializedRoot =
       serviceName !== undefined && this.#state.get(serviceName)?.materialized?.queryId === queryId
-    this.#requestReconcile(queryId, {
+    this.#reconciliation.request(queryId, {
       force: isMaterializedRoot,
       ...this.#causeContext('fetch-rebase'),
     })
@@ -2641,7 +2650,7 @@ export class QueryStore<
           // ones through the gate (cooldown + hidden-tab deferral); the gate marks
           // inactive cached ones pending so their next subscription reconciles.
           for (const queryId of publishedEffects.reconcileQueryIds) {
-            this.#requestReconcile(queryId, {
+            this.#reconciliation.request(queryId, {
               ...(publishedEffects.reconcileCauses.has(queryId)
                 ? { causes: publishedEffects.reconcileCauses.get(queryId)! }
                 : {}),
@@ -2701,16 +2710,12 @@ export class QueryStore<
    *   edge — isolated changes stay as fast as today); further events within
    *   `reconcileCooldown` coalesce into one guaranteed trailing refetch.
    */
-  #requestReconcile(
+  #prepareReconcile(
     queryId: string,
-    { force = false, causes }: { force?: boolean; causes?: readonly TraceCause[] } = {},
-  ): void {
-    const mergedCauses = this.#telemetry.merge(undefined, causes)
-    if (!force && this.#listenerCount(queryId) === 0) {
-      this.#emitReconcileDecision(queryId, 'inactive', mergedCauses)
-      this.#markQueryPending(queryId)
-      return
-    }
+    force: boolean,
+  ): 'missing' | 'inactive' | 'local' | 'hidden' | 'network' {
+    if (!this.#getQuery(queryId)) return 'missing'
+    if (!force && this.#listenerCount(queryId) === 0) return 'inactive'
 
     let selected = false
     let changed = false
@@ -2719,80 +2724,12 @@ export class QueryStore<
       const result = this.#reapplyMaterializedFind(service, query)
       selected = result !== 'unavailable'
       changed = result === 'changed'
-      const current = service.queries.get(queryId)
-      if (selected && current?.pending) {
-        commitQuery(service, { ...current, pending: false })
-      }
     })
     if (selected) {
-      this.#clearReconcileState(queryId)
       if (changed) this.#notify(touched)
-      return
+      return 'local'
     }
-
-    if (this.#visibility.isHidden()) {
-      this.#deferredWhileHidden.set(
-        queryId,
-        this.#telemetry.merge(this.#deferredWhileHidden.get(queryId), mergedCauses),
-      )
-      this.#emitReconcileDecision(queryId, 'deferred-hidden', mergedCauses)
-      this.#markQueryPending(queryId)
-      return
-    }
-
-    if (this.#reconcileCooldown <= 0) {
-      this.#emitReconcileDecision(queryId, 'fetch-now', mergedCauses)
-      this.#emitReconcileStarted(queryId, mergedCauses)
-      this.refetch(queryId, {
-        reason: 'reconcile',
-        ...(mergedCauses ? { causes: mergedCauses } : {}),
-      })
-      return
-    }
-
-    const now = Date.now()
-    const window = this.#reconcileWindows.get(queryId)
-
-    if (!window || now - window.lastAt >= this.#reconcileCooldown) {
-      this.#reconcileWindows.set(queryId, {
-        lastAt: now,
-        trailing: window?.trailing ?? null,
-      })
-      this.#emitReconcileDecision(queryId, 'fetch-now', mergedCauses)
-      this.#emitReconcileStarted(queryId, mergedCauses)
-      this.refetch(queryId, {
-        reason: 'reconcile',
-        ...(mergedCauses ? { causes: mergedCauses } : {}),
-      })
-      return
-    }
-
-    const coalescedCauses = this.#telemetry.merge(window.causes, mergedCauses)
-    if (coalescedCauses) window.causes = coalescedCauses
-    this.#emitReconcileDecision(queryId, 'coalesced', mergedCauses)
-    if (window.trailing) return // the pending trailing refetch already covers this
-
-    const timer = setTimeout(
-      () => {
-        const current = this.#reconcileWindows.get(queryId)
-        const trailingCauses = current?.causes
-        if (current) {
-          current.trailing = null
-          delete current.causes
-        }
-        if (!this.#getQuery(queryId)) {
-          this.#reconcileWindows.delete(queryId)
-          return
-        }
-        // Re-enter the gate after the window expires unless the tab went hidden or
-        // the last subscriber left in the meantime.
-        this.#requestReconcile(queryId, trailingCauses ? { causes: trailingCauses } : {})
-      },
-      window.lastAt + this.#reconcileCooldown - now,
-    )
-    // Never keep a Node process alive for a pending reconciliation.
-    ;(timer as { unref?: () => void }).unref?.()
-    window.trailing = timer
+    return this.#visibility.isHidden() ? 'hidden' : 'network'
   }
 
   #emitReconcileDecision(
@@ -2839,34 +2776,13 @@ export class QueryStore<
         query => !isWithinStaleTime(query.fetchedAt, this.#staleTime, now),
       )
     }
-    const reconciled = this.#drainDeferredReconciles()
+    const reconciled = this.#reconciliation.drainHidden()
     if (!sleptPastStaleTime) return
 
     const queries = this.#activePendingReconciliationQueries().filter(
       query => !reconciled.has(query.queryId),
     )
     this.#refetchActiveQueries(queries, this.#telemetry.cause('visibility'))
-  }
-
-  /** On becoming visible, reconcile everything that deferred while hidden. */
-  #drainDeferredReconciles(): Set<string> {
-    const reconciled = new Set<string>()
-    if (this.#visibility.isHidden() || this.#deferredWhileHidden.size === 0) return reconciled
-    const deferred = Array.from(this.#deferredWhileHidden)
-    this.#deferredWhileHidden.clear()
-    for (const [queryId, causes] of deferred) {
-      if (!this.#getQuery(queryId)) continue
-      reconciled.add(queryId)
-      this.#requestReconcile(queryId, causes ? { causes } : {})
-    }
-    return reconciled
-  }
-
-  #clearReconcileState(queryId: string): void {
-    const window = this.#reconcileWindows.get(queryId)
-    if (window?.trailing) clearTimeout(window.trailing)
-    this.#reconcileWindows.delete(queryId)
-    this.#deferredWhileHidden.delete(queryId)
   }
 
   /**
@@ -2892,7 +2808,7 @@ export class QueryStore<
           // follow-up instead of dispatching a second fetch in the same generation.
           this.refetch(query.queryId)
         } else {
-          this.#markQueryPending(query.queryId)
+          this.#reconciliation.markPending(query.queryId)
         }
       }
     }
@@ -2904,12 +2820,12 @@ export class QueryStore<
     for (const service of this.getState().values()) {
       if (service.materialized) {
         const root = service.queries.get(service.materialized.queryId)
-        if (root && shouldMark(root)) this.#markQueryPending(root.queryId)
+        if (root && shouldMark(root)) this.#reconciliation.markPending(root.queryId)
       }
       for (const query of service.queries.values()) {
         if (query.queryId === service.materialized?.queryId) continue
         if (this.#reconcilesAfterMissedEvents(query) && shouldMark(query)) {
-          this.#markQueryPending(query.queryId)
+          this.#reconciliation.markPending(query.queryId)
         }
       }
     }
@@ -2929,12 +2845,12 @@ export class QueryStore<
       // depends on their completeness, and events may have been missed while offline.
       if (service.materialized) {
         const root = service.queries.get(service.materialized.queryId)
-        if (root?.pending) queryIds.set(root.queryId, true)
+        if (root && this.#reconciliation.isPending(root.queryId)) queryIds.set(root.queryId, true)
       }
       for (const query of service.queries.values()) {
         if (query.queryId === service.materialized?.queryId) continue
         if (
-          query.pending &&
+          this.#reconciliation.isPending(query.queryId) &&
           this.#reconcilesAfterMissedEvents(query) &&
           this.#listenerCount(query.queryId) > 0
         ) {
@@ -2950,7 +2866,7 @@ export class QueryStore<
     cause?: TraceCause,
   ): void {
     for (const query of queries) {
-      this.#requestReconcile(query.queryId, {
+      this.#reconciliation.request(query.queryId, {
         force: query.force,
         ...(cause === undefined ? {} : { causes: [cause] }),
       })
@@ -3011,17 +2927,6 @@ export class QueryStore<
     const first = Math.max(0, value[0])
     const second = Math.max(0, value[1])
     return first <= second ? [first, second] : [second, first]
-  }
-
-  #markQueryPending(queryId: string): void {
-    this.#transactOverService(queryId, (service, query) => {
-      if (!query) return
-
-      commitQuery(service, {
-        ...query,
-        pending: true,
-      })
-    })
   }
 
   // Optimistic mutation support
@@ -3148,7 +3053,7 @@ export class QueryStore<
     const serviceName = this.#serviceNamesByQueryId.get(queryId)
     this.#retention.cancel(queryId)
     this.#followupFetchContexts.delete(queryId)
-    this.#clearReconcileState(queryId)
+    this.#reconciliation.forget(queryId)
     this.#transactOverService(queryId, (service, query) => {
       if (query) {
         deleteQuery(service, queryId)

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -1,4 +1,4 @@
-import { ReconcileScheduler } from './reconcileScheduler.js'
+import { ReconcileScheduler, type ReconcilePreparation } from './reconcileScheduler.js'
 import { commitQuery, deleteQuery } from './queryResults.js'
 import { QueryRetention } from './queryRetention.js'
 import {
@@ -331,6 +331,7 @@ export class QueryStore<
     this.#mutations = new MutationTracker()
     this.#reconciliation = new ReconcileScheduler(reconcileCooldown, {
       prepare: (queryId, force) => this.#prepareReconcile(queryId, force),
+      notify: queryId => this.#notify(new Set([queryId])),
       fetch: (queryId, causes) => {
         this.#emitReconcileStarted(queryId, causes)
         this.refetch(queryId, { reason: 'reconcile', ...(causes ? { causes: [...causes] } : {}) })
@@ -2710,26 +2711,20 @@ export class QueryStore<
    *   edge — isolated changes stay as fast as today); further events within
    *   `reconcileCooldown` coalesce into one guaranteed trailing refetch.
    */
-  #prepareReconcile(
-    queryId: string,
-    force: boolean,
-  ): 'missing' | 'inactive' | 'local' | 'hidden' | 'network' {
-    if (!this.#getQuery(queryId)) return 'missing'
-    if (!force && this.#listenerCount(queryId) === 0) return 'inactive'
+  #prepareReconcile(queryId: string, force: boolean): ReconcilePreparation {
+    if (!this.#getQuery(queryId)) return { kind: 'missing' }
+    if (!force && this.#listenerCount(queryId) === 0) return { kind: 'inactive' }
 
     let selected = false
     let changed = false
-    const touched = this.#transactOverService(queryId, (service, query) => {
+    this.#transactOverService(queryId, (service, query) => {
       if (!query) return
       const result = this.#reapplyMaterializedFind(service, query)
       selected = result !== 'unavailable'
       changed = result === 'changed'
     })
-    if (selected) {
-      if (changed) this.#notify(touched)
-      return 'local'
-    }
-    return this.#visibility.isHidden() ? 'hidden' : 'network'
+    if (selected) return { kind: 'local', changed }
+    return { kind: this.#visibility.isHidden() ? 'hidden' : 'network' }
   }
 
   #emitReconcileDecision(

--- a/lib/core/queryTypes.ts
+++ b/lib/core/queryTypes.ts
@@ -161,6 +161,7 @@ export interface Query<T = unknown, TMeta = Record<string, unknown>, TQuery = un
    * loop reads this instead of re-walking the query per item.
    */
   classification: StoredQueryClass
+  /** Diagnostic projection of the reconciliation scheduler; only the scheduler updates it. */
   pending: boolean
   dirty: boolean
   filterItem: (item: ElementType<T>) => boolean

--- a/lib/core/reconcileScheduler.ts
+++ b/lib/core/reconcileScheduler.ts
@@ -1,0 +1,161 @@
+import type { TraceCause } from './events.js'
+
+type Request = {
+  force: boolean
+  causes: readonly TraceCause[] | undefined
+} & ({ kind: 'pending' | 'hidden' } | { kind: 'cooldown'; eligibleAt: number })
+
+interface Entry {
+  lastAt: number | undefined
+  request: Request | undefined
+}
+
+type Decision = 'inactive' | 'deferred-hidden' | 'fetch-now' | 'coalesced'
+
+interface SchedulerHost {
+  prepare(queryId: string, force: boolean): 'missing' | 'inactive' | 'hidden' | 'local' | 'network'
+  fetch(queryId: string, causes: readonly TraceCause[] | undefined): void
+  pendingChanged(queryId: string, pending: boolean): void
+  decision(queryId: string, decision: Decision, causes: readonly TraceCause[] | undefined): void
+  merge(
+    left: readonly TraceCause[] | undefined,
+    right: readonly TraceCause[] | undefined,
+  ): readonly TraceCause[] | undefined
+}
+
+/** Owns outstanding reconciliations and cooldowns; the store owns how queries resolve. */
+export class ReconcileScheduler {
+  readonly #entries = new Map<string, Entry>()
+  readonly #host: SchedulerHost
+  readonly #cooldown: number
+  #timer: ReturnType<typeof setTimeout> | undefined
+  #timerAt = Infinity
+
+  constructor(cooldown: number, host: SchedulerHost) {
+    this.#cooldown = cooldown
+    this.#host = host
+  }
+
+  isPending(queryId: string): boolean {
+    const request = this.#entries.get(queryId)?.request
+    return request !== undefined && request.kind !== 'cooldown'
+  }
+
+  markPending(queryId: string): void {
+    const entry = this.#entries.get(queryId)
+    this.#set(queryId, {
+      lastAt: entry?.lastAt,
+      request: {
+        kind: 'pending',
+        force: entry?.request?.force ?? false,
+        causes: entry?.request?.causes,
+      },
+    })
+  }
+
+  request(
+    queryId: string,
+    { force = false, causes }: { force?: boolean; causes?: readonly TraceCause[] } = {},
+  ): void {
+    const entry = this.#entries.get(queryId)
+    const merged = this.#host.merge(entry?.request?.causes, causes)
+    force ||= entry?.request?.force ?? false
+    const disposition = this.#host.prepare(queryId, force)
+    if (disposition === 'missing' || disposition === 'local') {
+      this.forget(queryId)
+      return
+    }
+    if (disposition === 'inactive' || disposition === 'hidden') {
+      this.#set(queryId, {
+        lastAt: entry?.lastAt,
+        request: {
+          kind: disposition === 'hidden' ? 'hidden' : 'pending',
+          force,
+          causes: merged,
+        },
+      })
+      this.#host.decision(
+        queryId,
+        disposition === 'hidden' ? 'deferred-hidden' : 'inactive',
+        merged,
+      )
+    } else {
+      const now = Date.now()
+      const eligibleAt = (entry?.lastAt ?? -Infinity) + this.#cooldown
+      if (this.#cooldown <= 0 || now >= eligibleAt) {
+        this.#set(queryId, { lastAt: now, request: undefined })
+        this.#host.decision(queryId, 'fetch-now', merged)
+        this.#host.fetch(queryId, merged)
+      } else {
+        this.#set(queryId, {
+          lastAt: entry?.lastAt,
+          request: { kind: 'cooldown', eligibleAt, force, causes: merged },
+        })
+        this.#host.decision(queryId, 'coalesced', causes)
+        this.#schedule(eligibleAt)
+      }
+    }
+  }
+
+  /** A dispatched fetch consumes pending work but retains its cooldown history. */
+  settle(queryId: string): void {
+    const entry = this.#entries.get(queryId)
+    if (entry?.lastAt === undefined) this.forget(queryId)
+    else this.#set(queryId, { lastAt: entry.lastAt, request: undefined })
+  }
+
+  drainHidden(): Set<string> {
+    const ids = [...this.#entries]
+      .filter(([, entry]) => entry.request?.kind === 'hidden')
+      .map(([id]) => id)
+    for (const id of ids) this.request(id)
+    return new Set(ids)
+  }
+
+  forget(queryId: string): void {
+    const pending = this.isPending(queryId)
+    this.#entries.delete(queryId)
+    if (pending) this.#host.pendingChanged(queryId, false)
+  }
+
+  dispose(): void {
+    if (this.#timer !== undefined) clearTimeout(this.#timer)
+    this.#timer = undefined
+    this.#timerAt = Infinity
+    this.#entries.clear()
+  }
+
+  #set(queryId: string, entry: Entry): void {
+    const previous = this.isPending(queryId)
+    this.#entries.set(queryId, entry)
+    const pending = this.isPending(queryId)
+    if (previous !== pending) this.#host.pendingChanged(queryId, pending)
+  }
+
+  #schedule(next: number): void {
+    if (next >= this.#timerAt) return
+    if (this.#timer !== undefined) clearTimeout(this.#timer)
+    this.#timerAt = next
+    this.#timer = setTimeout(
+      () => {
+        this.#timer = undefined
+        this.#timerAt = Infinity
+        const now = Date.now()
+        const due = [...this.#entries].filter(
+          ([, entry]) => entry.request?.kind === 'cooldown' && entry.request.eligibleAt <= now,
+        )
+        for (const [id, entry] of due) {
+          if (this.#entries.get(id) === entry) this.request(id)
+        }
+        let next = Infinity
+        for (const { request } of this.#entries.values()) {
+          if (request?.kind === 'cooldown') next = Math.min(next, request.eligibleAt)
+        }
+        this.#schedule(next)
+      },
+      Math.max(0, next - Date.now()),
+    )
+    const timer = this.#timer as ReturnType<typeof setTimeout> & { unref?: () => void }
+    timer.unref?.()
+  }
+}

--- a/lib/core/reconcileScheduler.ts
+++ b/lib/core/reconcileScheduler.ts
@@ -12,8 +12,13 @@ interface Entry {
 
 type Decision = 'inactive' | 'deferred-hidden' | 'fetch-now' | 'coalesced'
 
+export type ReconcilePreparation =
+  | { kind: 'local'; changed: boolean }
+  | { kind: 'missing' | 'inactive' | 'hidden' | 'network' }
+
 interface SchedulerHost {
-  prepare(queryId: string, force: boolean): 'missing' | 'inactive' | 'hidden' | 'local' | 'network'
+  prepare(queryId: string, force: boolean): ReconcilePreparation
+  notify(queryId: string): void
   fetch(queryId: string, causes: readonly TraceCause[] | undefined): void
   pendingChanged(queryId: string, pending: boolean): void
   decision(queryId: string, decision: Decision, causes: readonly TraceCause[] | undefined): void
@@ -60,11 +65,13 @@ export class ReconcileScheduler {
     const entry = this.#entries.get(queryId)
     const merged = this.#host.merge(entry?.request?.causes, causes)
     force ||= entry?.request?.force ?? false
-    const disposition = this.#host.prepare(queryId, force)
-    if (disposition === 'missing' || disposition === 'local') {
+    const prepared = this.#host.prepare(queryId, force)
+    if (prepared.kind === 'missing' || prepared.kind === 'local') {
       this.forget(queryId)
+      if (prepared.kind === 'local' && prepared.changed) this.#host.notify(queryId)
       return
     }
+    const disposition = prepared.kind
     if (disposition === 'inactive' || disposition === 'hidden') {
       this.#set(queryId, {
         lastAt: entry?.lastAt,

--- a/lib/core/relationPlan.ts
+++ b/lib/core/relationPlan.ts
@@ -1,0 +1,96 @@
+import type { QueryAST } from './queryBuilder.js'
+import { planRelation } from './queryClassification.js'
+import { relationKey } from './relationalAssembly.js'
+import { resolveServicePath, type RelationshipDef, type Schema } from './schema.js'
+import type { FindDescriptor, FindQueryConfig } from './queryTypes.js'
+
+type RelationValue = string | number
+
+interface RelationQueryPlan {
+  descriptor(value: RelationValue | { $in: RelationValue[] }): FindDescriptor
+  config: FindQueryConfig
+}
+
+interface PlannedRelation {
+  key: string
+  definition: RelationshipDef
+  children: RelationPlan[]
+  destination: RelationQueryPlan
+}
+
+export type RelationPlan =
+  | { kind: 'missing'; key: string; name: string; service: string }
+  | (PlannedRelation & { kind: 'fanIn' | 'perParent' })
+  | (PlannedRelation & { kind: 'junction'; junction: RelationQueryPlan })
+
+function queryPlan(
+  schema: Schema,
+  service: string,
+  field: string,
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+  config: FindQueryConfig,
+): RelationQueryPlan {
+  const serviceName = resolveServicePath(schema, service)
+  return {
+    descriptor: value => ({
+      serviceName,
+      method: 'find',
+      params: { query: { ...before, [field]: value, ...after } },
+    }),
+    config,
+  }
+}
+
+/** Resolve immutable schema/AST decisions once; only source values vary at runtime. */
+export function compileRelations(
+  ast: QueryAST,
+  schema: Schema,
+  realtime: 'merge' | 'disabled',
+  parentKey: string | null = null,
+): RelationPlan[] {
+  return Object.entries(ast.related).map(([name, child]) => {
+    const key = relationKey(parentKey, name)
+    const definition = schema.relationships?.[ast.service]?.[name]
+    if (!definition) return { kind: 'missing', key, name, service: ast.service }
+    const { strategy, allPages } = planRelation(definition, child.query)
+    const hasSort = '$sort' in child.query || '$sort' in (definition.query ?? {})
+    const sort =
+      strategy !== 'perParent' &&
+      !hasSort &&
+      (definition.cardinality === 'one' || definition.cardinality === 'embedded' || definition.via)
+        ? { $sort: { [definition.destField]: 1 } }
+        : {}
+    const common = {
+      key,
+      definition,
+      children: compileRelations(child, schema, realtime, key),
+      destination: queryPlan(
+        schema,
+        definition.destService,
+        definition.destField,
+        { ...child.query, ...sort },
+        definition.query ?? {},
+        {
+          realtime,
+          fetchPolicy: 'swr',
+          ...(strategy !== 'perParent' && allPages ? { allPages: true } : {}),
+          ...(child.server ? { server: true } : {}),
+        },
+      ),
+    }
+    if (strategy === 'junction' && definition.via) {
+      const via = definition.via
+      return {
+        ...common,
+        kind: 'junction',
+        junction: queryPlan(schema, via.destService, via.destField, {}, via.query ?? {}, {
+          realtime,
+          fetchPolicy: 'swr',
+          allPages: true,
+        }),
+      }
+    }
+    return { ...common, kind: strategy === 'perParent' ? 'perParent' : 'fanIn' }
+  })
+}

--- a/lib/core/relationalAssembly.ts
+++ b/lib/core/relationalAssembly.ts
@@ -78,11 +78,18 @@ interface RelationIndex {
  * - `listByKey` groups entities by dest-key value in result order ('many').
  * - `junctionsByParent` groups junction rows by the parent-side join value (two-hop).
  */
+interface CachedRelationIndex {
+  items: unknown[]
+  junctionItems: unknown[] | undefined
+  index: RelationIndex
+}
+
 function buildIndexes(
   ast: QueryAST,
   parentKey: string | null,
   relationships: Record<string, RelationshipDef>,
   relationData: Map<string, AssembledRelationData>,
+  cache: Map<string, CachedRelationIndex>,
 ): Map<string, RelationIndex> {
   const indexes = new Map<string, RelationIndex>()
 
@@ -93,8 +100,18 @@ function buildIndexes(
     const key = relationKey(parentKey, relName)
     const rel = relationData.get(key)
     // Per-parent data is already keyed by parent; 'none' has nothing to index.
-    if (!rel || rel.kind === 'none' || rel.kind === 'perParent') continue
+    if (!rel || rel.kind === 'none' || rel.kind === 'perParent') {
+      cache.delete(key)
+      continue
+    }
+    const junctionItems = rel.kind === 'junction' ? rel.junctionItems : undefined
+    const previous = cache.get(key)
+    if (previous) {
+      indexes.set(relName, previous.index)
+      continue
+    }
 
+    let index: RelationIndex
     if (rel.kind === 'junction') {
       const byKey = firstMatchIndex(rel.items, relDef.destField)
       const junctionsByParent = new Map<string | number, unknown[]>()
@@ -108,9 +125,9 @@ function buildIndexes(
         }
         list.push(j)
       }
-      indexes.set(relName, { byKey, junctionsByParent })
+      index = { byKey, junctionsByParent }
     } else if (relDef.cardinality === 'one' || relDef.cardinality === 'embedded') {
-      indexes.set(relName, { byKey: firstMatchIndex(rel.items, relDef.destField) })
+      index = { byKey: firstMatchIndex(rel.items, relDef.destField) }
     } else {
       const listByKey = new Map<string | number, unknown[]>()
       for (const entity of rel.items) {
@@ -123,8 +140,10 @@ function buildIndexes(
         }
         list.push(entity)
       }
-      indexes.set(relName, { listByKey })
+      index = { listByKey }
     }
+    indexes.set(relName, index)
+    cache.set(key, { items: rel.items, junctionItems, index })
   }
 
   return indexes
@@ -149,6 +168,7 @@ function firstMatchIndex(items: unknown[], destField: string): Map<string | numb
 interface AssemblyContext {
   schema: Schema
   relationData: Map<string, AssembledRelationData>
+  indexCache: Map<string, CachedRelationIndex>
   indexesByPath: Map<string | null, Map<string, RelationIndex>>
   previousByPath: Map<string | null, WeakMap<object, Record<string, unknown>>>
 }
@@ -164,7 +184,7 @@ function assembleRelations(
   if (Object.keys(ast.related).length === 0) return items
   let indexes = indexesByPath.get(parentKey)
   if (!indexes) {
-    indexes = buildIndexes(ast, parentKey, relationships, relationData)
+    indexes = buildIndexes(ast, parentKey, relationships, relationData, context.indexCache)
     indexesByPath.set(parentKey, indexes)
   }
   let previousRows = previousByPath.get(parentKey)
@@ -270,17 +290,31 @@ function reuseArray(previous: unknown, next: unknown[]): unknown[] {
     : next
 }
 
-/** Each query owns weak row caches; each assembly builds an index once per relation path. */
+/** Each query retains row identities and indexes for the latest relation arrays. */
 export function createRelationAssembler(ast: QueryAST, schema: Schema) {
   const previousByPath = new Map<string | null, WeakMap<object, Record<string, unknown>>>()
+  const indexCache = new Map<string, CachedRelationIndex>()
   let previous: unknown[] = []
   return (items: unknown[], relationData: Map<string, AssembledRelationData>): unknown[] => {
+    for (const [key, cached] of indexCache) {
+      const data = relationData.get(key)
+      if (
+        !data ||
+        data.kind === 'none' ||
+        data.kind === 'perParent' ||
+        cached.items !== data.items ||
+        cached.junctionItems !== (data.kind === 'junction' ? data.junctionItems : undefined)
+      ) {
+        indexCache.delete(key)
+      }
+    }
     previous = reuseArray(
       previous,
       assembleRelations(items, ast, null, {
         schema,
         relationData,
         indexesByPath: new Map(),
+        indexCache,
         previousByPath,
       }),
     )

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -1,8 +1,9 @@
+import { compileRelations, type RelationPlan } from './relationPlan.js'
 import { hashObject } from './hash.js'
 import type { MatcherContext, PageSource } from '../adapters/adapter.js'
 import { cursorQueryCanKeepPrefix, cursorQueryInputsUnchanged } from './cursorMaintenance.js'
 import type { QueryAST } from './queryBuilder.js'
-import { planRelation, planRootPagination, rootAllPages } from './queryClassification.js'
+import { planRootPagination, rootAllPages } from './queryClassification.js'
 import type { QueryRef } from './queryRef.js'
 import type { QueryLifecycleConfig } from './queryIdentity.js'
 import type {
@@ -39,7 +40,7 @@ import {
   materializeRelationalFilterItem,
   shouldRefetchRelationalFilterQuery,
 } from './relationalFilters.js'
-import type { AnySchema, RelationshipDef, Schema } from './schema.js'
+import type { AnySchema, Schema } from './schema.js'
 import { resolveServicePath } from './schema.js'
 import { validateStaleTime } from './staleTime.js'
 
@@ -288,6 +289,7 @@ export class RelationalQueryRef<
   #defaultStaleTime: number
   #name: string | undefined
   #rootOverride: RelationalRootOverride | null
+  #relationPlans: RelationPlan[]
 
   constructor(
     host: RelationalQueryHost<TParams, TMeta, TQuery>,
@@ -299,6 +301,7 @@ export class RelationalQueryRef<
     this.#host = host
     this.#ast = ast
     this.#schema = schema
+    this.#relationPlans = compileRelations(ast, schema, ast.snapshot ? 'disabled' : 'merge')
     this.#queryId = `rq/${hashObject(options?.root ? { ast, root: options.root } : ast)}`
     this.#onEvict = onEvict ?? null
     this.#defaultStaleTime = options?.defaultStaleTime ?? 0
@@ -944,7 +947,7 @@ export class RelationalQueryRef<
       // Sync (create/recreate/dispose) relation queries based on current root data.
       // Called on every root success — not just first — so realtime-inserted root
       // entities cause their relations to be fetched.
-      if (hasRelations) this.#syncRelations(rows, this.#ast, null)
+      if (hasRelations) this.#syncRelations(rows, this.#relationPlans)
     }
     const matcherConfig = hasRelationalFilter(this.#schema, this.#ast)
       ? { matcher: this.#createRelationalMatcher(this.#ast) }
@@ -1087,50 +1090,35 @@ export class RelationalQueryRef<
    * - two-hop `'many'` (`relDef.via` set) — first fetch the junction service, then fetch
    *   the destination keyed by ids collected from the junction
    */
-  #syncRelations(parentData: unknown[], ast: QueryAST, parentKey: string | null): void {
-    const relationships = this.#schema.relationships?.[ast.service] ?? {}
-
-    for (const [relName, relAST] of Object.entries(ast.related)) {
-      const key = relationKey(parentKey, relName)
-      const relDef = relationships[relName]
-      if (!relDef) {
-        console.warn(`Relationship "${relName}" not found for service "${ast.service}"`)
-        // Mark as synced with no query so loading detection doesn't hang.
-        if (!this.#relationSubs.has(key)) {
-          this.#relationSubs.set(key, { kind: 'empty', sourceKey: '' })
-        }
-      } else {
-        // The strategy is decided in one place (planRelation) — explain() reads
-        // the same plan, so what it reports is what runs here.
-        const { strategy } = planRelation(relDef, relAST.query)
-        if (strategy === 'junction') {
-          this.#syncJunctionRelation(parentData, relDef, relAST, key)
-        } else if (strategy === 'perParent') {
-          this.#syncWindowedManyRelation(parentData, relDef, relAST, key)
-        } else {
-          this.#syncFanInRelation(parentData, relDef, relAST, key)
-        }
+  #syncRelations(parentData: unknown[], plans: RelationPlan[]): void {
+    for (const plan of plans) {
+      switch (plan.kind) {
+        case 'missing':
+          console.warn(`Relationship "${plan.name}" not found for service "${plan.service}"`)
+          if (!this.#relationSubs.has(plan.key)) {
+            this.#relationSubs.set(plan.key, { kind: 'empty', sourceKey: '' })
+          }
+          break
+        case 'junction':
+          this.#syncJunctionRelation(parentData, plan)
+          break
+        case 'perParent':
+          this.#syncWindowedManyRelation(parentData, plan)
+          break
+        case 'fanIn':
+          this.#syncFanInRelation(parentData, plan)
+          break
       }
     }
   }
 
-  /** Recurse into a relation's own nested relations, if it declares any. */
-  #syncNested(data: unknown[], relAST: QueryAST, key: string): void {
-    if (Object.keys(relAST.related).length === 0) return
-    this.#syncRelations(data, relAST, key)
-  }
-
-  /** Like #syncNested, but reading the relation's current (possibly resolved) snapshot. */
   #syncNestedFromSnapshot(
     queryRef: QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>,
-    relAST: QueryAST,
-    key: string,
+    plan: Exclude<RelationPlan, { kind: 'missing' }>,
   ): void {
-    if (Object.keys(relAST.related).length === 0) return
+    if (plan.children.length === 0) return
     const s = queryRef.getSnapshot()
-    if (s?.status === 'success') {
-      this.#syncRelations(s.data as unknown[], relAST, key)
-    }
+    if (s?.status === 'success') this.#syncRelations(s.data, plan.children)
   }
 
   /**
@@ -1142,11 +1130,10 @@ export class RelationalQueryRef<
    */
   #syncFanInRelation(
     parentData: unknown[],
-    relDef: RelationshipDef,
-    relAST: QueryAST,
-    subKey: string,
-    nestedKey: string = subKey,
+    plan: Exclude<RelationPlan, { kind: 'missing' }>,
+    subKey: string = plan.key,
   ): void {
+    const { definition: relDef, key: nestedKey } = plan
     // Collect the set of ids we need to IN(...) for this relation. For 'embedded' the
     // parent's sourceField is itself a list — flat-map across parents.
     let values: (string | number)[]
@@ -1171,7 +1158,7 @@ export class RelationalQueryRef<
       // nested relations in case this relation's data already resolved and its own
       // children need to be synced.
       if (existing.kind === 'fanIn') {
-        this.#syncNestedFromSnapshot(existing.queryRef, relAST, nestedKey)
+        this.#syncNestedFromSnapshot(existing.queryRef, plan)
       }
       return
     }
@@ -1184,10 +1171,13 @@ export class RelationalQueryRef<
       return
     }
 
-    const queryRef = this.#buildRelationQueryRef(relDef.destService, relDef, relAST, values)
+    const queryRef = this.#query(
+      plan.destination.descriptor({ $in: values }),
+      plan.destination.config,
+    )
     const unsub = subscribeAndSeed(
       queryRef,
-      data => this.#syncNested(data, relAST, nestedKey),
+      data => this.#syncRelations(data, plan.children),
       () => this.#notifyListeners(),
       this.#staleTime,
       this.#graph(nestedKey),
@@ -1198,10 +1188,9 @@ export class RelationalQueryRef<
 
   #syncWindowedManyRelation(
     parentData: unknown[],
-    relDef: RelationshipDef,
-    relAST: QueryAST,
-    key: string,
+    plan: Exclude<RelationPlan, { kind: 'missing' }>,
   ): void {
+    const { definition: relDef, key } = plan
     const { values: uniqueValues, key: newSourceKey } = uniqueSourceValues(
       parentData,
       relDef.sourceField,
@@ -1209,7 +1198,7 @@ export class RelationalQueryRef<
 
     const existing = this.#relationSubs.get(key)
     if (existing?.kind === 'perParent' && existing.sourceKey === newSourceKey) {
-      this.#syncNestedWindowedRelationIfReady(existing, relAST, key)
+      this.#syncNestedWindowedRelationIfReady(existing, plan)
       return
     }
 
@@ -1253,16 +1242,14 @@ export class RelationalQueryRef<
         entry.children.set(childKey, retained)
         continue
       }
-      const queryRef = this.#buildSingleParentRelationQueryRef(
-        relDef.destService,
-        relDef,
-        relAST,
-        sourceValue,
+      const queryRef = this.#query(
+        plan.destination.descriptor(sourceValue),
+        plan.destination.config,
       )
       const unsub = queryRef.subscribe(
         state => {
           if (state.status === 'success') {
-            this.#syncNestedWindowedRelationIfReady(entry, relAST, key)
+            this.#syncNestedWindowedRelationIfReady(entry, plan)
           }
           this.#notifyListeners()
         },
@@ -1275,18 +1262,17 @@ export class RelationalQueryRef<
     for (const [childKey, child] of previousChildren) {
       if (!entry.children.has(childKey)) child.unsub()
     }
-    this.#syncNestedWindowedRelationIfReady(entry, relAST, key)
+    this.#syncNestedWindowedRelationIfReady(entry, plan)
   }
 
   #syncNestedWindowedRelationIfReady(
     sub: RelationSub<S, TParams, TMeta, TQuery> & { kind: 'perParent' },
-    relAST: QueryAST,
-    key: string,
+    plan: Exclude<RelationPlan, { kind: 'missing' }>,
   ): void {
-    if (Object.keys(relAST.related).length === 0) return
+    if (plan.children.length === 0) return
     const childData = this.#perParentDataIfReady(sub)
     if (childData) {
-      this.#syncRelations(childData, relAST, key)
+      this.#syncRelations(childData, plan.children)
     }
   }
 
@@ -1301,10 +1287,9 @@ export class RelationalQueryRef<
    */
   #syncJunctionRelation(
     parentData: unknown[],
-    relDef: RelationshipDef,
-    relAST: QueryAST,
-    key: string,
+    plan: Extract<RelationPlan, { kind: 'junction' }>,
   ): void {
+    const { definition: relDef, key } = plan
     const via = relDef.via!
 
     const { values: uniqueParentIds, key: junctionSourceKey } = uniqueSourceValues(
@@ -1318,7 +1303,7 @@ export class RelationalQueryRef<
     // current snapshot — the fan-in's own sourceKey check makes it a no-op when the
     // dest set hasn't changed, and it recurses into nested relations either way.
     if (existing?.kind === 'junction' && existing.sourceKey === junctionSourceKey) {
-      this.#syncDestFromJunction(existing.queryRef, relDef, relAST, key)
+      this.#syncDestFromJunction(existing.queryRef, plan)
       return
     }
 
@@ -1333,28 +1318,15 @@ export class RelationalQueryRef<
     // Build the junction queryRef. Junction never windows from the consumer's API surface;
     // it must be exhaustive for the parents we asked about so assembly doesn't drop edges.
     const junctionRef = this.#query(
-      {
-        serviceName: resolveServicePath(this.#schema, via.destService),
-        method: 'find',
-        params: {
-          query: {
-            [via.destField]: { $in: uniqueParentIds },
-            ...(via.query || {}),
-          },
-        },
-      },
-      {
-        realtime: this.#realtimeMode,
-        fetchPolicy: 'swr',
-        allPages: true,
-      },
+      plan.junction.descriptor({ $in: uniqueParentIds }),
+      plan.junction.config,
     )
 
     // Phase 2 is the shared fan-in reconcile with the junction rows as parents: the
     // dest sub lives at `${key}#dest` and its nested relations key under `key`.
     const unsub = subscribeAndSeed(
       junctionRef,
-      junctionItems => this.#syncFanInRelation(junctionItems, relDef, relAST, `${key}#dest`, key),
+      junctionItems => this.#syncFanInRelation(junctionItems, plan, `${key}#dest`),
       () => this.#notifyListeners(),
       this.#staleTime,
       this.#graph(key, 'junction'),
@@ -1370,91 +1342,12 @@ export class RelationalQueryRef<
   /** Phase 2 from the junction's current snapshot, for an already-live junction sub. */
   #syncDestFromJunction(
     junctionRef: QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery>,
-    relDef: RelationshipDef,
-    relAST: QueryAST,
-    key: string,
+    plan: Extract<RelationPlan, { kind: 'junction' }>,
   ): void {
     const s = junctionRef.getSnapshot()
     if (s?.status === 'success') {
-      this.#syncFanInRelation(s.data as unknown[], relDef, relAST, `${key}#dest`, key)
+      this.#syncFanInRelation(s.data as unknown[], plan, `${plan.key}#dest`)
     }
-  }
-
-  /**
-   * Build the destination `find` queryRef for a relation. Shared between single-hop and the
-   * second hop of two-hop `many`. The query is built as `WHERE destField IN (uniqueIds)`
-   * merged with any `relAST.query` (user-provided constraints) and `relDef.query` (schema-
-   * level filter). `allPages` is enabled when no windowing is requested so the IN(...) set
-   * isn't silently truncated by the default page cap.
-   */
-  #buildRelationQueryRef(
-    destService: string,
-    relDef: RelationshipDef,
-    relAST: QueryAST,
-    uniqueValues: (string | number)[],
-  ): QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery> {
-    const hasExplicitSort = '$sort' in relAST.query || '$sort' in (relDef.query ?? {})
-    // A fully materialized service can answer filtered finds locally only when their
-    // order is deterministic. These relation shapes do not expose destination-query
-    // order (assembly follows the parent id list / junction rows, or selects one), so
-    // an internal key sort is semantics-preserving and unlocks an immediate cache hit.
-    // Direct `many` keeps backend order unless the consumer supplied one.
-    const deterministicSort =
-      !hasExplicitSort &&
-      (relDef.cardinality === 'one' || relDef.cardinality === 'embedded' || Boolean(relDef.via))
-        ? { $sort: { [relDef.destField]: 1 } }
-        : {}
-    const query = {
-      ...relAST.query,
-      ...deterministicSort,
-      [relDef.destField]: { $in: uniqueValues },
-      ...(relDef.query || {}),
-    }
-
-    // allPages comes from the shared fetch plan (see planRelation): un-windowed
-    // relations drain every page so the IN(...) set isn't truncated; an explicit
-    // window is the consumer's intent and stays server-maintained.
-    const { allPages } = planRelation(relDef, relAST.query)
-
-    return this.#query(
-      {
-        serviceName: resolveServicePath(this.#schema, destService),
-        method: 'find',
-        params: { query },
-      },
-      {
-        realtime: this.#realtimeMode,
-        fetchPolicy: 'swr',
-        ...(allPages ? { allPages: true } : {}),
-        ...(relAST.server ? { server: true } : {}),
-      },
-    )
-  }
-
-  #buildSingleParentRelationQueryRef(
-    destService: string,
-    relDef: { destField: string; query?: Record<string, unknown> },
-    relAST: QueryAST,
-    sourceValue: string | number,
-  ): QueryRef<unknown[], unknown, S, TParams, TMeta, TQuery> {
-    const query = {
-      ...relAST.query,
-      [relDef.destField]: sourceValue,
-      ...(relDef.query || {}),
-    }
-
-    return this.#query(
-      {
-        serviceName: resolveServicePath(this.#schema, destService),
-        method: 'find',
-        params: { query },
-      },
-      {
-        realtime: this.#realtimeMode,
-        fetchPolicy: 'swr',
-        ...(relAST.server ? { server: true } : {}),
-      },
-    )
   }
 
   #perParentDataIfReady(

--- a/test/reconcile.test.tsx
+++ b/test/reconcile.test.tsx
@@ -3,7 +3,7 @@
  * edge) and hidden-tab deferral for event-driven refetches.
  *
  * These tests run at the store level with a `realtime: 'refetch'` query — any
- * service event routes it through the same `#requestReconcile` gate that
+ * service event routes it through the same reconciliation scheduler that
  * server-window and server-authoritative builder queries use.
  */
 
@@ -145,7 +145,7 @@ test('cooldown: sustained events cost roughly one refetch per window', async t =
 })
 
 test('cooldown: manual refetch() bypasses the gate', async t => {
-  const { figbird, feathers } = createApp({ reconcileCooldown: 5000 })
+  const { figbird, feathers } = createApp({ reconcileCooldown: 80 })
   const notes = feathers.service('notes')
   const { ref, unsub } = subscribeRefetchQuery(figbird)
   await sleep(20)
@@ -155,10 +155,20 @@ test('cooldown: manual refetch() bypasses the gate', async t => {
   await sleep(20)
   const afterLeading = notes.counts.find
 
+  notes.emit('created', { id: 11, content: 'y' })
+  await sleep(5)
+
   // ...manual refetches are user intent and fire immediately regardless.
   ref.refetch()
   await sleep(20)
   t.is(notes.counts.find, afterLeading + 1)
+
+  await sleep(100)
+  t.is(
+    notes.counts.find,
+    afterLeading + 1,
+    'manual fetch consumes the outstanding trailing request',
+  )
 
   unsub()
 })

--- a/test/relational-query.test.tsx
+++ b/test/relational-query.test.tsx
@@ -3206,6 +3206,29 @@ test('.all(): materialized reads stay local only when their ordering is knowable
   t.is(exhaustive.getSnapshot(), beforeEnsureFresh)
   t.is(exhaustiveNotifications, 0)
 
+  let selectedStatus = 'open'
+  const reentrant = figbird.queryDesc(
+    { serviceName: 'issues', method: 'find', params: { query: { $sort: { id: 1 } } } },
+    { matcherKey: 'reentrant-local', matcher: () => issue => issue.status === selectedStatus },
+  )
+  let invalidateOnChange = false
+  const unsubReentrant = reentrant.subscribe(() => {
+    if (!invalidateOnChange) return
+    invalidateOnChange = false
+    unsubReentrant()
+    figbird.refetch('issues')
+  })
+  await new Promise(resolve => setTimeout(resolve, 10))
+  selectedStatus = 'closed'
+  invalidateOnChange = true
+  figbird.queryStore.reconcile(reentrant.details().queryId)
+  t.is(
+    figbird.getState().get('issues')?.queries.get(reentrant.details().queryId)?.pending,
+    true,
+    'a subscriber can invalidate the query after local reconciliation settles',
+  )
+  await new Promise(resolve => setTimeout(resolve, 20))
+
   unsubExhaustive()
   unsubLocal()
   unsubServerAll()


### PR DESCRIPTION
Relation updates repeatedly resolved the same schema/AST decisions and rebuilt indexes for unchanged sibling data. Reconciliation also spread outstanding work across query flags, cooldown timers and hidden-tab deferrals.

This change:
- Compiles relation strategies, service paths, query templates and nested plans once per relational query, replacing the two runtime destination-query builders. Existing filter precedence, per-parent windows, junction exhaustion and snapshot behavior are preserved.
- Reuses relation indexes while their input arrays remain unchanged, with one cached entry per relation path and pruning when inputs change or disappear.
- Gives a reconciliation scheduler ownership of pending work, hidden deferral and cooldown deadlines, using one timer. The query's `pending` field remains a diagnostic projection. In-flight dirty handling and reconnect jitter stay separate. Manual fetches consume already-scheduled trailing work.

Validation: `npm run tsc`, `npm run lint`, `npm run ava`, `npm run test`, and `npm run build` pass; 365 tests. Extended the existing manual-refetch test to cover cancellation of an outstanding trailing request.

An isolated assembly check with 5,000 unchanged child rows and 50 sibling updates reduced index-field reads from 250,000 to 5,000, with matching assembled results. This measures indexing work, not application-wide speedup.
