### PR TITLE
Share query lifetime management and unify window state

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1688,6 +1688,12 @@ keeps the previous window mounted during later movement; pass `{ suspense: false
 for the tagged-union form. It accepts the same `skip` and `staleTime` options and the
 same builder, bound-request, and argumentless-definition inputs as `useQuery`.
 
+When the requested range has data, a background fetch failure preserves `status: 'success'`
+and exposes `error`, both through `figbird.window(...).getSnapshot(range)` and the hook.
+In non-Suspense mode, moving to an unloaded range returns `status: 'loading'` with the
+retained sparse map; a failed range returns `status: 'error'`. Suspense mode keeps an
+already-settled reader mounted during those range changes.
+
 Offset adapters jump directly; cursor adapters advance sequentially and reuse cursor
 checkpoints. Relations, filtering, and sorting are part of each fetched block. See
 [Virtualized windows](#virtualized-windows) for lifecycle and restoration semantics.

--- a/lib/core/queryLifetime.ts
+++ b/lib/core/queryLifetime.ts
@@ -1,0 +1,117 @@
+interface PendingRead<T> {
+  status: 'pending'
+  value: T
+  promise: Promise<void>
+  resolve: () => void
+  reject: (error: Error) => void
+}
+
+interface SettledRead<T> {
+  status: 'settled'
+  value: T
+  promise: Promise<void>
+  lastUsed: number
+}
+
+type ColdRead<T> = PendingRead<T> | SettledRead<T>
+
+/** Owns subscriptions, speculative reads, and deferred release for composite queries. */
+export class QueryLifetime<TListener, TOwner extends { staleTime: number }, TRead> {
+  #owners = new Map<TListener, TOwner>()
+  #reads = new Map<string, ColdRead<TRead>>()
+  #cleanupScheduled = false
+  #generation = 0
+  #clock = 0
+
+  get owners(): ReadonlyMap<TListener, TOwner> {
+    return this.#owners
+  }
+
+  get reads(): ReadonlyMap<string, ColdRead<TRead>> {
+    return this.#reads
+  }
+
+  acquire(listener: TListener, owner: TOwner): void {
+    this.#owners.set(listener, owner)
+  }
+
+  release(listener: TListener): void {
+    this.#owners.delete(listener)
+  }
+
+  staleTime(): number {
+    if (this.#owners.size === 0) return 0
+    let staleTime = Infinity
+    for (const owner of this.#owners.values()) staleTime = Math.min(staleTime, owner.staleTime)
+    return staleTime
+  }
+
+  read(key: string, value: TRead, start: () => void): Promise<void> {
+    const existing = this.#reads.get(key)
+    if (existing) {
+      if (existing.status === 'settled') existing.lastUsed = ++this.#clock
+      return existing.promise
+    }
+    let resolve = () => {}
+    let reject = (_error: Error) => {}
+    const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise
+      reject = rejectPromise
+    })
+    this.#reads.set(key, { status: 'pending', value, promise, resolve, reject })
+    start()
+    return promise
+  }
+
+  settle(key: string, value: TRead, error: Error | null): void {
+    const read = this.#reads.get(key)
+    if (read?.status === 'settled') return
+    this.#reads.set(key, {
+      status: 'settled',
+      value,
+      promise: read?.promise ?? Promise.resolve(),
+      lastUsed: ++this.#clock,
+    })
+    // A query may settle before anyone requests a Suspense promise.
+    if (read) {
+      if (error) read.reject(error)
+      else read.resolve()
+    }
+  }
+
+  releaseRead(key: string): void {
+    this.#reads.delete(key)
+  }
+
+  pruneSettledReads(limit: number): void {
+    const reads = Array.from(this.#reads.entries())
+      .filter((entry): entry is [string, SettledRead<TRead>] => entry[1].status === 'settled')
+      .sort((a, b) => b[1].lastUsed - a[1].lastUsed)
+    for (const [key] of reads.slice(limit)) this.#reads.delete(key)
+  }
+
+  scheduleCleanup(canCleanup: () => boolean, cleanup: () => void): void {
+    if (this.#cleanupScheduled) return
+    this.#cleanupScheduled = true
+    const generation = this.#generation
+    queueMicrotask(() => {
+      if (generation !== this.#generation) return
+      this.#cleanupScheduled = false
+      if (this.#owners.size === 0 && canCleanup()) cleanup()
+    })
+  }
+
+  reset(): void {
+    this.#generation += 1
+    this.#cleanupScheduled = false
+    this.#reads.clear()
+  }
+
+  dispose(): void {
+    for (const [key, read] of this.#reads) {
+      this.settle(key, read.value, new Error('figbird: instance has been disposed'))
+    }
+    this.#owners.clear()
+    this.reset()
+  }
+}

--- a/lib/core/relationalQuery.ts
+++ b/lib/core/relationalQuery.ts
@@ -1,3 +1,4 @@
+import { QueryLifetime } from './queryLifetime.js'
 import { compileRelations, type RelationPlan } from './relationPlan.js'
 import { hashObject } from './hash.js'
 import type { MatcherContext, PageSource } from '../adapters/adapter.js'
@@ -233,7 +234,11 @@ export class RelationalQueryRef<
   // "comments.reactions"). A relation is "synced" once its entry exists here — even a
   // kind:'empty' entry counts, so loading detection doesn't hang on empty relations.
   #relationSubs: Map<string, RelationSub<S, TParams, TMeta, TQuery>> = new Map()
-  #listeners: Map<(state: RelationalQueryState<T>) => void, RelationalListener> = new Map()
+  #lifetime = new QueryLifetime<
+    (state: RelationalQueryState<T>) => void,
+    RelationalListener,
+    null
+  >()
   #nextPreparationGeneration = 0
   #preparedAdoption: PreparedAdoption = { kind: 'idle', adoptedThrough: 0 }
   #processedEventUnsub: (() => void) | null = null
@@ -247,8 +252,6 @@ export class RelationalQueryRef<
   get #realtimeMode(): 'merge' | 'disabled' {
     return this.#ast.snapshot ? 'disabled' : 'merge'
   }
-  // A teardown is parked on the microtask queue (see #scheduleCleanup).
-  #cleanupScheduled = false
 
   // Snapshot identity caching — useSyncExternalStore requires getSnapshot() to return
   // ref-equal values when nothing has changed, otherwise React detects a tear and
@@ -268,14 +271,6 @@ export class RelationalQueryRef<
   #lastGatherWasPartial = false
   #assembleRelations: ReturnType<typeof createRelationAssembler> | null = null
 
-  // Suspense-support state. The promise is created lazily when suspensePromise() is
-  // first called and resolves/rejects on the first transition to success/error. Once
-  // settled, no new promise is created for this qRef instance — a cold start happens
-  // exactly once.
-  #suspensePromise: Promise<void> | null = null
-  #resolveSuspense: (() => void) | null = null
-  #rejectSuspense: ((error: Error) => void) | null = null
-  #suspenseSettled = false
   // A Suspense read materializes and fetches the graph before React can commit its
   // subscription. The first committed listener claims that fetch instead of treating
   // the just-resolved data as stale and immediately repeating the whole graph.
@@ -334,7 +329,7 @@ export class RelationalQueryRef<
       nodes.push({ path, ...(role ? { role } : {}), queryId: queryRef.details().queryId })
     }
     const snapshot = this.getSnapshot()
-    const listenerMetadata = [...this.#listeners.values()]
+    const listenerMetadata = [...this.#lifetime.owners.values()]
     return {
       key: this.#queryId,
       ...(this.#name ? { name: this.#name } : {}),
@@ -420,8 +415,8 @@ export class RelationalQueryRef<
     const adoptsPreparation = source === 'subscriber' && this.#claimPreparedAdoption()
     const adoptsPrefetch = source === 'prepare' && this.#claimPrefetch()
     const claimsColdStart = this.#coldStartAwaitingSubscriber
-    this.#listeners.set(fn, listener)
-    this.#staleTime = this.#currentStaleTime()
+    this.#lifetime.acquire(fn, listener)
+    this.#staleTime = this.#lifetime.staleTime()
 
     if (!this.#root) {
       this.#setupRoot()
@@ -444,8 +439,8 @@ export class RelationalQueryRef<
     // Don't call fn synchronously - useSyncExternalStore will call getSnapshot() instead
 
     return () => {
-      this.#listeners.delete(fn)
-      this.#staleTime = this.#currentStaleTime()
+      this.#lifetime.release(fn)
+      this.#staleTime = this.#lifetime.staleTime()
       this.#root?.setStaleTime(this.#staleTime)
 
       // Clean up if no more listeners — but not synchronously. React StrictMode
@@ -453,26 +448,17 @@ export class RelationalQueryRef<
       // spot would evict this ref and reset its state, so the resubscribed hook
       // would find a cold replacement on its next render and re-suspend, forever.
       // Deferring by a microtask lets a back-to-back resubscribe cancel the teardown.
-      if (this.#listeners.size === 0) {
+      if (this.#lifetime.owners.size === 0) {
         this.#scheduleCleanup()
       }
     }
-  }
-
-  #currentStaleTime(): number {
-    if (this.#listeners.size === 0) return 0
-    let staleTime = Infinity
-    for (const listener of this.#listeners.values()) {
-      staleTime = Math.min(staleTime, listener.staleTime)
-    }
-    return staleTime
   }
 
   #claimPreparedAdoption(): boolean {
     const adoption = this.#preparedAdoption
     const adoptedThrough = adoption.kind === 'wave' ? adoption.generation : adoption.adoptedThrough
     let newestActive = adoptedThrough
-    for (const listener of this.#listeners.values()) {
+    for (const listener of this.#lifetime.owners.values()) {
       if (listener.source === 'prepare') {
         newestActive = Math.max(newestActive, listener.preparationGeneration)
       }
@@ -494,7 +480,7 @@ export class RelationalQueryRef<
   #claimPrefetch(): boolean {
     const now = Date.now()
     let claimed = false
-    for (const listener of this.#listeners.values()) {
+    for (const listener of this.#lifetime.owners.values()) {
       if (listener.source === 'prefetch' && listener.adoptableUntil !== null) {
         claimed ||= now < listener.adoptableUntil
         listener.adoptableUntil = null
@@ -558,14 +544,10 @@ export class RelationalQueryRef<
   }
 
   #scheduleCleanup(): void {
-    if (this.#cleanupScheduled) return
-    this.#cleanupScheduled = true
-    queueMicrotask(() => {
-      this.#cleanupScheduled = false
-      if (this.#listeners.size === 0 && this.#root) {
-        this.#cleanup()
-      }
-    })
+    this.#lifetime.scheduleCleanup(
+      () => this.#root !== null,
+      () => this.#cleanup(),
+    )
   }
 
   /** Returns the latest snapshot of the relational query state. */
@@ -1446,7 +1428,7 @@ export class RelationalQueryRef<
     this.#relationalFilterRefetchQueued = true
     queueMicrotask(() => {
       this.#relationalFilterRefetchQueued = false
-      if (this.#listeners.size === 0) return
+      if (this.#lifetime.owners.size === 0) return
       this.refetch()
     })
   }
@@ -1476,7 +1458,7 @@ export class RelationalQueryRef<
     const snapshot = this.getSnapshot()
     this.#settleSuspense(snapshot)
     // Notify all listeners with the cached snapshot
-    for (const listener of this.#listeners.keys()) {
+    for (const listener of this.#lifetime.owners.keys()) {
       listener(snapshot)
     }
     this.#scheduleGraphRunCompletion(snapshot)
@@ -1500,16 +1482,8 @@ export class RelationalQueryRef<
    * because the keep-previous-data contract in the hook handles them without throwing.
    */
   #settleSuspense(snapshot: RelationalQueryState<T>): void {
-    if (this.#suspenseSettled) return
     if (snapshot.status !== 'success' && snapshot.status !== 'error') return
-    this.#suspenseSettled = true
-    if (snapshot.status === 'success') {
-      this.#resolveSuspense?.()
-    } else {
-      this.#rejectSuspense?.(snapshot.error)
-    }
-    this.#resolveSuspense = null
-    this.#rejectSuspense = null
+    this.#lifetime.settle('root', null, snapshot.status === 'error' ? snapshot.error : null)
   }
 
   /**
@@ -1520,7 +1494,10 @@ export class RelationalQueryRef<
    * eviction, a retry interns a fresh ref and cold-starts.
    */
   releaseColdStart(): void {
-    if (this.#suspenseSettled && this.#listeners.size === 0) {
+    if (
+      this.#lifetime.reads.get('root')?.status === 'settled' &&
+      this.#lifetime.owners.size === 0
+    ) {
       this.#scheduleCleanup()
     }
   }
@@ -1532,28 +1509,19 @@ export class RelationalQueryRef<
    * to the keep-previous-data path rather than throwing again.
    */
   suspensePromise(): Promise<void> {
-    if (this.#suspenseSettled) return Promise.resolve()
-    if (!this.#suspensePromise) {
-      this.#suspensePromise = new Promise<void>((resolve, reject) => {
-        this.#resolveSuspense = resolve
-        this.#rejectSuspense = reject
-      })
-      // Ensure the underlying queries are materialised — callers may reach this method via
-      // the hook before subscribe() runs in some orderings.
+    if (this.#lifetime.reads.get('root')?.status === 'settled') return Promise.resolve()
+    return this.#lifetime.read('root', null, () => {
       if (!this.#root) {
-        this.#coldStartAwaitingSubscriber = this.#listeners.size === 0
+        this.#coldStartAwaitingSubscriber = this.#lifetime.owners.size === 0
         this.#setupRoot()
       }
-      // If we've already reached a terminal state synchronously, settle immediately.
       this.#settleSuspense(this.getSnapshot())
-    }
-    return this.#suspensePromise
+    })
   }
 
   /** @internal Release readers and pending Suspense work when the instance closes. */
   dispose(): void {
-    this.#rejectSuspense?.(new Error('figbird: instance has been disposed'))
-    this.#listeners.clear()
+    this.#lifetime.dispose()
     this.#cleanup()
   }
 
@@ -1583,12 +1551,7 @@ export class RelationalQueryRef<
         adoptedThrough: this.#preparedAdoption.generation,
       }
     }
-    // Evict from the figbird-level cache so a subsequent query rebuilds a fresh ref.
-    // Reset the suspense promise state too — a fresh cold-start will need a fresh promise.
-    this.#suspensePromise = null
-    this.#resolveSuspense = null
-    this.#rejectSuspense = null
-    this.#suspenseSettled = false
+    this.#lifetime.reset()
     this.#coldStartAwaitingSubscriber = false
     this.#onEvict?.()
   }

--- a/lib/core/windowQuery.ts
+++ b/lib/core/windowQuery.ts
@@ -228,24 +228,25 @@ export class WindowQueryRef<
     })
     const missing = !this.#pager.rangeReady(range)
     let isFetching = false
-    let error: Error | null = null
+    let coldError: Error | null = null
+    let backgroundError: Error | null = null
     for (const page of required) {
       const state = page.ref.getSnapshot()
       if (state.isFetching) isFetching = true
-      if (state.status === 'error') error ??= state.error
-      if (state.status === 'success' && state.error) error ??= state.error
+      if (state.status === 'error') coldError ??= state.error
+      if (state.status === 'success') backgroundError ??= state.error
     }
     for (const start of this.#pager.fetchingStarts(range, this.#config.preloadPages)) {
       if (this.#pages.get(start)?.ref.getSnapshot().isFetching) isFetching = true
     }
 
     let state: WindowQueryState<T>
-    if (error && missing) {
+    if (coldError) {
       state = {
         status: 'error',
         data: this.#data,
         total: this.#total,
-        error,
+        error: coldError,
         isFetching: false,
       }
     } else if (missing) {
@@ -261,7 +262,7 @@ export class WindowQueryRef<
         status: 'success',
         data: this.#data,
         total: this.#total,
-        error,
+        error: backgroundError,
         isFetching,
       }
     }

--- a/lib/core/windowQuery.ts
+++ b/lib/core/windowQuery.ts
@@ -1,3 +1,4 @@
+import { QueryLifetime } from './queryLifetime.js'
 import { hashObject } from './hash.js'
 import type { QueryAST } from './queryBuilder.js'
 import { RelationalQueryRef, type RelationalQueryHost } from './relationalQuery.js'
@@ -61,23 +62,6 @@ interface WindowPage<T, S extends Schema, TParams, TMeta extends Record<string, 
   lastUsed: number
 }
 
-interface PendingColdRead {
-  status: 'pending'
-  range: WindowRange
-  promise: Promise<void>
-  resolve: () => void
-  reject: (error: Error) => void
-}
-
-interface SettledColdRead {
-  status: 'settled'
-  range: WindowRange
-  promise: Promise<void>
-  lastUsed: number
-}
-
-type ColdRead = PendingColdRead | SettledColdRead
-
 interface WindowQueryOptions {
   defaultStaleTime?: number
   onEvict?: () => void
@@ -130,9 +114,11 @@ export class WindowQueryRef<
   #onIdle: (() => void) | null
 
   #pages = new Map<number, WindowPage<T, S, TParams, TMeta, TQuery>>()
-  #subscribers = new Map<(state: WindowQueryState<T>) => void, WindowSubscriber<T>>()
-  #coldReads = new Map<string, ColdRead>()
-  #cleanupScheduled = false
+  #lifetime = new QueryLifetime<
+    (state: WindowQueryState<T>) => void,
+    WindowSubscriber<T>,
+    WindowRange
+  >()
   #syncScheduled = false
   #notifyScheduled = false
   #clock = 0
@@ -211,21 +197,22 @@ export class WindowQueryRef<
       options.staleTime === undefined
         ? this.#defaultStaleTime
         : validateStaleTime(options.staleTime, 'useWindowQuery(): staleTime')
-    this.#subscribers.set(listener, {
+    this.#lifetime.acquire(listener, {
       listener,
       range,
       staleTime,
     })
-    const coldRead = this.#coldReads.get(rangeKey(range))
+    const coldRead = this.#lifetime.reads.get(rangeKey(range))
     if (coldRead?.status === 'settled') {
-      this.#releaseColdRead(rangeKey(range), coldRead)
+      this.#releaseColdRead(rangeKey(range))
     }
     this.#syncPages()
 
     return () => {
-      this.#subscribers.delete(listener)
+      this.#lifetime.release(listener)
       this.#scheduleSync()
-      if (this.#subscribers.size === 0 && this.#coldReads.size === 0) this.#scheduleCleanup()
+      if (this.#lifetime.owners.size === 0 && this.#lifetime.reads.size === 0)
+        this.#scheduleCleanup()
     }
   }
 
@@ -253,7 +240,7 @@ export class WindowQueryRef<
     }
 
     let state: WindowQueryState<T>
-    if (error) {
+    if (error && missing) {
       state = {
         status: 'error',
         data: this.#data,
@@ -274,7 +261,7 @@ export class WindowQueryRef<
         status: 'success',
         data: this.#data,
         total: this.#total,
-        error: null,
+        error,
         isFetching,
       }
     }
@@ -293,28 +280,10 @@ export class WindowQueryRef<
     if (state.status === 'error') return Promise.reject(state.error)
 
     const key = rangeKey(range)
-    const existing = this.#coldReads.get(key)
-    if (existing) {
-      if (existing.status === 'settled') existing.lastUsed = ++this.#clock
-      return existing.promise
-    }
-
-    let resolve = () => {}
-    let reject = (_error: Error) => {}
-    const promise = new Promise<void>((resolvePromise, rejectPromise) => {
-      resolve = resolvePromise
-      reject = rejectPromise
+    return this.#lifetime.read(key, range, () => {
+      this.#syncPages()
+      this.#settleColdReads()
     })
-    this.#coldReads.set(key, {
-      status: 'pending',
-      range,
-      promise,
-      resolve,
-      reject,
-    })
-    this.#syncPages()
-    this.#settleColdReads()
-    return promise
   }
 
   releaseColdStart(rangeInput: WindowRange): void {
@@ -325,8 +294,8 @@ export class WindowQueryRef<
 
   /** @internal Evicts an abandoned render-phase read under Figbird cache pressure. */
   evictAbandonedRead(): boolean {
-    if (this.#subscribers.size > 0 || this.#coldReads.size === 0) return false
-    for (const read of this.#coldReads.values()) {
+    if (this.#lifetime.owners.size > 0 || this.#lifetime.reads.size === 0) return false
+    for (const read of this.#lifetime.reads.values()) {
       if (read.status === 'pending') return false
     }
     this.#cleanup()
@@ -335,13 +304,13 @@ export class WindowQueryRef<
 
   #desiredStarts(): Set<number> {
     const starts = new Set<number>()
-    for (const subscriber of this.#subscribers.values()) {
+    for (const subscriber of this.#lifetime.owners.values()) {
       for (const start of this.#pager.targetStarts(subscriber.range, this.#config.preloadPages)) {
         starts.add(start)
       }
     }
-    for (const read of this.#coldReads.values()) {
-      for (const start of this.#pager.targetStarts(read.range, this.#config.preloadPages)) {
+    for (const read of this.#lifetime.reads.values()) {
+      for (const start of this.#pager.targetStarts(read.value, this.#config.preloadPages)) {
         starts.add(start)
       }
     }
@@ -378,7 +347,7 @@ export class WindowQueryRef<
       },
     )
     ref.setDisplayName(this.#name ? `${this.#name} [${start}]` : undefined)
-    const staleTime = this.#currentStaleTime()
+    const staleTime = this.#lifetime.staleTime()
     const page: WindowPage<T, S, TParams, TMeta, TQuery> = {
       start,
       ref,
@@ -428,57 +397,24 @@ export class WindowQueryRef<
 
   #settleColdReads(): void {
     let settled = false
-    for (const [key, read] of this.#coldReads) {
+    for (const [key, read] of this.#lifetime.reads) {
       if (read.status === 'settled') continue
-      const required = this.#pager.requiredStarts(read.range).flatMap(start => {
-        const page = this.#pages.get(start)
-        return page ? [page] : []
-      })
-      let error: Error | null = null
-      for (const page of required) {
-        const state = page.ref.getSnapshot()
-        if (state.status === 'error') error ??= state.error
-      }
-      if (error) {
-        this.#coldReads.set(key, {
-          status: 'settled',
-          range: read.range,
-          promise: read.promise,
-          lastUsed: ++this.#clock,
-        })
-        read.reject(error)
-      } else if (this.#pager.rangeReady(read.range)) {
-        this.#coldReads.set(key, {
-          status: 'settled',
-          range: read.range,
-          promise: read.promise,
-          lastUsed: ++this.#clock,
-        })
-        read.resolve()
-      } else {
-        continue
-      }
+      const state = this.getSnapshot(read.value)
+      if (state.status === 'loading') continue
+      this.#lifetime.settle(key, read.value, state.status === 'error' ? state.error : null)
       settled = true
     }
     if (settled) {
       // Settled render-phase reads stay warm independently of maxPages so
       // concurrent Suspense retries cannot evict one another. The separate cap
       // bounds abandoned renders until React commits and subscribes a reader.
-      this.#pruneSettledColdReads()
+      this.#lifetime.pruneSettledReads(MAX_SETTLED_COLD_READS)
       this.#onIdle?.()
     }
   }
 
-  #pruneSettledColdReads(): void {
-    const reads = Array.from(this.#coldReads.entries())
-      .filter((entry): entry is [string, SettledColdRead] => entry[1].status === 'settled')
-      .sort((a, b) => b[1].lastUsed - a[1].lastUsed)
-
-    for (const [key] of reads.slice(MAX_SETTLED_COLD_READS)) this.#coldReads.delete(key)
-  }
-
   #syncPageFreshness(): void {
-    const staleTime = this.#currentStaleTime()
+    const staleTime = this.#lifetime.staleTime()
     for (const page of this.#pages.values()) {
       if (page.staleTime === staleTime) continue
       const unsubscribe = page.ref.subscribe(() => this.#pageChanged(page.start), { staleTime })
@@ -486,15 +422,6 @@ export class WindowQueryRef<
       page.unsubscribe = unsubscribe
       page.staleTime = staleTime
     }
-  }
-
-  #currentStaleTime(): number {
-    if (this.#subscribers.size === 0) return 0
-    let staleTime = Infinity
-    for (const subscriber of this.#subscribers.values()) {
-      staleTime = Math.min(staleTime, subscriber.staleTime)
-    }
-    return staleTime
   }
 
   #pagerPage(start: number): PagerPage | undefined {
@@ -548,34 +475,28 @@ export class WindowQueryRef<
     this.#notifyScheduled = true
     queueMicrotask(() => {
       this.#notifyScheduled = false
-      for (const subscriber of this.#subscribers.values()) {
+      for (const subscriber of this.#lifetime.owners.values()) {
         subscriber.listener(this.getSnapshot(subscriber.range))
       }
     })
   }
 
   #scheduleCleanup(): void {
-    if (this.#cleanupScheduled) return
-    this.#cleanupScheduled = true
-    queueMicrotask(() => {
-      this.#cleanupScheduled = false
-      if (this.#subscribers.size === 0 && this.#coldReads.size === 0) this.#cleanup()
-    })
+    this.#lifetime.scheduleCleanup(
+      () => this.#lifetime.reads.size === 0,
+      () => this.#cleanup(),
+    )
   }
 
-  #releaseColdRead(key: string, expected?: ColdRead): void {
-    const read = this.#coldReads.get(key)
-    if (!read || (expected && read !== expected)) return
-    this.#coldReads.delete(key)
-    if (this.#subscribers.size === 0 && this.#coldReads.size === 0) this.#scheduleCleanup()
+  #releaseColdRead(key: string): void {
+    if (!this.#lifetime.reads.has(key)) return
+    this.#lifetime.releaseRead(key)
+    this.#scheduleCleanup()
   }
 
   /** @internal Release readers and pending Suspense work when the instance closes. */
   dispose(): void {
-    for (const read of this.#coldReads.values()) {
-      if (read.status === 'pending') read.reject(new Error('figbird: instance has been disposed'))
-    }
-    this.#subscribers.clear()
+    this.#lifetime.dispose()
     this.#cleanup()
   }
 
@@ -586,7 +507,7 @@ export class WindowQueryRef<
     this.#data = EMPTY_DATA
     this.#total = undefined
     this.#snapshotCache.clear()
-    this.#coldReads.clear()
+    this.#lifetime.reset()
     this.#onEvict?.()
   }
 }

--- a/lib/react/useWindowQuery.ts
+++ b/lib/react/useWindowQuery.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useSyncExternalStore } from 'react'
+import { useCallback, useMemo, useState, useSyncExternalStore } from 'react'
 import type { AnyWindowQueryBuilder, QueryBuilderItem } from '../core/queryBuilder.js'
 import type { QueryInput, QueryRequest } from '../core/queryDefinition.js'
 import type { Schema } from '../core/schema.js'
@@ -75,51 +75,6 @@ interface WindowQueryRefLike<T> {
   releaseColdStart(range: WindowRange): void
 }
 
-/**
- * Reader-local projection of a shared window ref. A later viewport keeps the
- * reader's committed sparse map mounted, but a second hook using the same ref
- * still gets its own cold-start Suspense and error lifecycle.
- */
-class WindowQueryReader<T> {
-  #ref: WindowQueryRefLike<T>
-  #settled = false
-  #lastSource: WindowQueryState<T> | null = null
-  #lastProjection: WindowQueryState<T> | null = null
-
-  constructor(ref: WindowQueryRefLike<T>) {
-    this.#ref = ref
-  }
-
-  getSnapshot(range: WindowRange): WindowQueryState<T> {
-    const source = this.#ref.getSnapshot(range)
-    if (source === this.#lastSource) return this.#lastProjection!
-
-    let projection = source
-    if (source.status === 'success') {
-      this.#settled = true
-    } else if (this.#settled) {
-      projection = {
-        status: 'success',
-        data: source.data,
-        total: source.total,
-        error: source.status === 'error' ? source.error : null,
-        isFetching: source.status === 'loading',
-      }
-    }
-    this.#lastSource = source
-    this.#lastProjection = projection
-    return projection
-  }
-
-  suspensePromise(range: WindowRange): Promise<void> {
-    return this.#ref.suspensePromise(range)
-  }
-
-  releaseColdStart(range: WindowRange): void {
-    this.#ref.releaseColdStart(range)
-  }
-}
-
 interface FigbirdWindowLike {
   window<Args, B extends AnyWindowQueryBuilder>(
     query: QueryInput<B, Args>,
@@ -190,7 +145,7 @@ export function useWindowQueryImpl(
       : validateStaleTime(options.staleTime, 'useWindowQuery(): staleTime')
   const config = normalizeConfig(options)
   const qRef = skip || query === null ? null : figbird.window(query, config)
-  const reader = useMemo(() => (qRef ? new WindowQueryReader(qRef) : null), [qRef])
+  const [reader, setReader] = useState({ query: qRef, settled: false })
   const stableRange = useMemo(
     () => ({ start: range.start, end: range.end }),
     [range.start, range.end],
@@ -207,8 +162,8 @@ export function useWindowQueryImpl(
     [qRef, stableRange, staleTime],
   )
   const getSnapshot = useCallback(
-    () => (reader ? reader.getSnapshot(stableRange) : idleState),
-    [reader, stableRange],
+    () => (qRef ? qRef.getSnapshot(stableRange) : idleState),
+    [qRef, stableRange],
   )
   const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
   const refetch = useCallback(() => qRef?.refetch(), [qRef])
@@ -217,6 +172,11 @@ export function useWindowQueryImpl(
     () => ({ ...state, refetch }) as WindowQueryResult<unknown>,
     [state, refetch],
   )
+  // Remember only whether this reader has settled, without rewriting the shared snapshot.
+  const settled = state.status === 'success' || (reader.query === qRef && reader.settled)
+  if (reader.query !== qRef || reader.settled !== settled) {
+    setReader({ query: qRef, settled })
+  }
   if (!suspense) return taggedResult
 
   if (!qRef) {
@@ -228,11 +188,13 @@ export function useWindowQueryImpl(
       refetch,
     }
   }
-  if (state.status === 'error') {
-    reader!.releaseColdStart(stableRange)
-    throw state.error
+  if (!settled) {
+    if (state.status === 'error') {
+      qRef.releaseColdStart(stableRange)
+      throw state.error
+    }
+    throw qRef.suspensePromise(stableRange)
   }
-  if (state.status !== 'success') throw reader!.suspensePromise(stableRange)
 
   return {
     data: state.data,

--- a/test/window-query.test.tsx
+++ b/test/window-query.test.tsx
@@ -366,6 +366,17 @@ it('useWindowQuery: each hook gets an independent first-window Suspense lifecycl
   await ref.suspensePromise({ start: 0, end: 5 })
 
   items.find = workingFind
+  const crossingRange = { start: 5, end: 15 }
+  t.is(ref.getSnapshot(crossingRange).status, 'loading')
+  await flush(async () => {
+    await ref.suspensePromise(crossingRange)
+  })
+  const crossing = ref.getSnapshot(crossingRange)
+  t.is(crossing.status, 'success')
+  t.is(crossing.error, failure)
+  t.is(crossing.data.get(14)?.id, 15)
+  ref.releaseColdStart(crossingRange)
+
   await flush(async () => {
     ref.refetch()
     await new Promise(resolve => setTimeout(resolve, 60))
@@ -390,6 +401,7 @@ interface CursorCall {
 
 function createCursorWindowApp(initialRows: Item[]) {
   let rows = initialRows
+  let failure: Error | null = null
   const calls: CursorCall[] = []
   const listeners = new Map<string, Set<(item: unknown) => void>>()
   const cursorService = {
@@ -398,6 +410,7 @@ function createCursorWindowApp(initialRows: Item[]) {
       const after = (query.$after as string | null) ?? null
       const requestedLimit = query.$limit as number
       calls.push({ after, limit: requestedLimit })
+      if (failure) throw failure
       const start = after ? Number(after.slice('cursor:'.length)) : 0
       // Deliberately return short, non-terminal pages to prove that absolute
       // checkpoints follow actual row counts rather than requested page size.
@@ -432,6 +445,9 @@ function createCursorWindowApp(initialRows: Item[]) {
   return {
     calls,
     figbird,
+    failWith(error: Error | null) {
+      failure = error
+    },
     replaceRows(next: Item[]) {
       rows = next
     },
@@ -480,5 +496,29 @@ test('window query: cursor strategy walks short pages and rebuilds invalid check
   t.is(ref.getSnapshot(range).data.get(5)?.id, 5)
   t.true(app.calls.slice(callsBeforeRefetch).some(call => call.after === null))
   t.true(app.calls.slice(callsBeforeRefetch).some(call => call.after === 'cursor:4'))
+  const failure = new Error('cursor refresh failed')
+  app.failWith(failure)
+  const refresh = new Promise<void>(resolve => {
+    const unsubscribe = ref.subscribe(
+      state => {
+        if (state.error === failure && !state.isFetching) {
+          unsubscribe()
+          resolve()
+        }
+      },
+      { range },
+    )
+  })
+  ref.refetch()
+  await refresh
+  t.is(ref.getSnapshot(range).status, 'success')
+
+  app.failWith(null)
+  const seek = { start: 7, end: 8 }
+  t.is(ref.getSnapshot(seek).status, 'loading')
+  await ref.suspensePromise(seek)
+  t.is(ref.getSnapshot(seek).status, 'success')
+  t.is(ref.getSnapshot(seek).data.get(7)?.id, 7)
+  ref.releaseColdStart(seek)
   read.unsubscribe()
 })

--- a/test/window-query.test.tsx
+++ b/test/window-query.test.tsx
@@ -297,26 +297,33 @@ it('useWindowQuery: each hook gets an independent first-window Suspense lifecycl
   })
   const { render, flush, act, $, unmount } = dom()
   let showSecond = () => {}
+  let moveFirst = () => {}
+  const query = figbird.q.items.orderBy('rank', 'asc')
+  const config = { pageSize: 10, preloadPages: 0, maxPages: 3 }
+  const ref = figbird.window(query, config)
 
   function Reader({ className, range }: { className: string; range: WindowRange }) {
-    const { data } = useWindowQuery(figbird.q.items.orderBy('rank', 'asc'), {
-      range,
-      pageSize: 10,
-      preloadPages: 0,
-      maxPages: 3,
-    })
-    return <div className={className}>{Array.from(data.values(), row => row.id).join(',')}</div>
+    const options = { ...config, range }
+    const tagged = useWindowQuery(query, { ...options, suspense: false })
+    const { data, error } = useWindowQuery(query, options)
+    return (
+      <div className={className} data-status={tagged.status} data-error={error?.message}>
+        {Array.from(data.values(), row => row.id).join(',')}
+      </div>
+    )
   }
 
   function Harness() {
     const [second, setSecond] = useState(false)
+    const [firstStart, setFirstStart] = useState(0)
     useLayoutEffect(() => {
       showSecond = () => setSecond(true)
+      moveFirst = () => setFirstStart(20)
     })
     return (
       <>
         <Suspense fallback={<div className='first-loading' />}>
-          <Reader className='first' range={{ start: 0, end: 5 }} />
+          <Reader className='first' range={{ start: firstStart, end: firstStart + 5 }} />
         </Suspense>
         {second ? (
           <Suspense fallback={<div className='second-loading' />}>
@@ -343,6 +350,36 @@ it('useWindowQuery: each hook gets an independent first-window Suspense lifecycl
   await flush(() => new Promise(resolve => setTimeout(resolve, 60)))
   t.truthy($('.second'))
   t.falsy($('.second-loading'))
+  const items = feathers.service('items')
+  const workingFind = items.find.bind(items)
+  const failure = new Error('window refresh failed')
+  items.find = () => Promise.reject(failure)
+  await flush(() => ref.refetch())
+  const warm = ref.getSnapshot({ start: 0, end: 5 })
+  t.is(warm.status, 'success')
+  t.is(warm.error, failure)
+  t.false(warm.isFetching)
+  t.is(warm.data.get(0)?.id, 1)
+  t.is($('.first')?.getAttribute('data-status'), 'success')
+  t.is($('.first')?.getAttribute('data-error'), failure.message)
+  t.falsy($('.first-loading'))
+  await ref.suspensePromise({ start: 0, end: 5 })
+
+  items.find = workingFind
+  await flush(async () => {
+    ref.refetch()
+    await new Promise(resolve => setTimeout(resolve, 60))
+  })
+  t.is(ref.getSnapshot({ start: 0, end: 5 }).error, null)
+  t.is($('.first')?.getAttribute('data-error'), null)
+
+  act(moveFirst)
+  t.truthy($('.first'))
+  t.falsy($('.first-loading'))
+  t.is($('.first')?.getAttribute('data-status'), 'loading')
+  await flush(() => new Promise(resolve => setTimeout(resolve, 60)))
+  t.is($('.first')?.getAttribute('data-status'), 'success')
+  t.is(ref.getSnapshot({ start: 20, end: 25 }).data.get(20)?.id, 21)
   unmount()
 })
 


### PR DESCRIPTION
Composite queries duplicated ownership tracking, Suspense settlement, freshness aggregation, and deferred cleanup. Relational and window queries now share a QueryLifetime owner for that work, while preparation adoption and page retention remain with their respective query implementations.

Window snapshots now retain success and expose the background error when the requested range still has data. React reads the same snapshot as imperative consumers; the hook only remembers whether its reader has settled so later viewport movement stays mounted. Non-Suspense readers report loading or error for unavailable ranges instead of rewriting those states to success.

Updated the existing window lifecycle test to cover warm errors, recovery, independent cold readers, and viewport movement, and documented the state contract. Legacy APIs and realtime pagination strategies are unchanged.

Validation: npm run tsc, npm run lint, npm run ava, and npm run test all passed. The full suite has 365 passing tests.
