### PR TITLE
Fix detail reads during optimistic creation and demo error states

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -32,7 +32,7 @@ function EmptyDetail() {
  * viewing keeps the last data and surfaces ItemRemoved, which the screen handles.
  */
 class DetailErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
-  state = { error: null }
+  state: { error: Error | null } = { error: null }
 
   static getDerivedStateFromError(error: Error) {
     return { error }
@@ -43,10 +43,15 @@ class DetailErrorBoundary extends Component<{ children: ReactNode }, { error: Er
       return (
         <main className='detail'>
           <div className='detail-empty'>
-            <div className='detail-empty-title'>Issue not found</div>
-            <div className='detail-empty-hint'>
-              It may have been removed, or the id doesn't exist on the server.
+            <div className='detail-empty-title'>
+              {'code' in this.state.error && this.state.error.code === 404
+                ? 'Issue not found'
+                : 'Could not load issue'}
             </div>
+            <div className='detail-empty-hint'>{this.state.error.message}</div>
+            <button className='link' onClick={() => window.location.reload()}>
+              Try again
+            </button>
           </div>
         </main>
       )

--- a/demo/src/pages/Archive/components.tsx
+++ b/demo/src/pages/Archive/components.tsx
@@ -66,13 +66,13 @@ export function ArchiveToolbar({
       </div>
       <div className='archive-stat archive-stat-wide'>
         <span className='archive-stat-value'>
-          {visibleStart + 1}–{Math.min(visibleEnd + 1, total ?? Infinity)}
+          {total === 0 ? '0' : `${visibleStart + 1}–${Math.min(visibleEnd + 1, total ?? Infinity)}`}
         </span>
         <span>of {total?.toLocaleString() ?? 'unknown'}</span>
       </div>
       <StatusDot active={isFetching} />
       <span className='archive-prefetch-state'>
-        {isFetching ? 'fetching window…' : 'adjacent pages ready'}
+        {isFetching ? 'fetching window…' : total === 0 ? 'no matches' : 'adjacent pages ready'}
       </span>
       <button className='link archive-top-button' onClick={onJumpToTop}>
         ↑ Top

--- a/demo/src/pages/Archive/screen.tsx
+++ b/demo/src/pages/Archive/screen.tsx
@@ -187,6 +187,12 @@ function ArchiveWindow({
         <span>Deleted</span>
       </div>
 
+      {total === 0 ? (
+        <p className='empty-line' role='status'>
+          No archived issues match your search.
+        </p>
+      ) : null}
+
       <div ref={scrollRef} className='archive-scroll' role='list' aria-label='Archived issues'>
         <div className='archive-virtual-space' style={{ height: virtualizer.getTotalSize() }}>
           {virtualRows.map(virtualRow => {

--- a/lib/core/mutationExecutor.ts
+++ b/lib/core/mutationExecutor.ts
@@ -132,6 +132,10 @@ export class MutationExecutor {
     return this.#mutationLanes.get(serviceName, id) !== undefined
   }
 
+  hasOptimisticCreate(serviceName: string, id: ItemId): boolean {
+    return this.#mutationLanes.hasOptimisticCreate(serviceName, id)
+  }
+
   acceptAuthoritative(
     serviceName: string,
     type: Event['type'],

--- a/lib/core/mutationLanes.ts
+++ b/lib/core/mutationLanes.ts
@@ -71,6 +71,14 @@ export class MutationLanes<TEntry extends MutationLaneEntry> {
     return this.#lanes.get(this.#key(serviceName, id))
   }
 
+  hasOptimisticCreate(serviceName: string, id: ItemId): boolean {
+    return (
+      this.#lanes
+        .get(this.#key(serviceName, id))
+        ?.entries.some(entry => entry.optimistic && entry.desc.method === 'create') ?? false
+    )
+  }
+
   ensure(serviceName: string, id: ItemId, cached: unknown): MutationLane {
     const key = this.#key(serviceName, id)
     let lane = this.#lanes.get(key)

--- a/lib/core/queryStore.ts
+++ b/lib/core/queryStore.ts
@@ -927,7 +927,8 @@ export class QueryStore<
     })
 
     try {
-      const result = await this.#fetch(queryId)
+      const local = this.#tryLocalGet(query) ?? this.#selectMaterializedFind(query)
+      const result = await (local ?? this.#fetch(queryId))
       const endedAt = this.#clock.now()
       const durationMs = endedAt - startedAt
       const current = this.#getQuery(queryId)
@@ -940,6 +941,7 @@ export class QueryStore<
           this.#fetched({
             queryId,
             result,
+            source: local ? 'cache' : 'server',
             journalEvents: journal.events,
             ...(cacheCause === undefined ? {} : { cause: cacheCause }),
           })
@@ -1048,8 +1050,6 @@ export class QueryStore<
     const { desc, config } = query
 
     if (desc.method === 'get') {
-      const local = this.#tryLocalGet(query)
-      if (local) return Promise.resolve(local)
       return this.#adapter.get(desc.serviceName, desc.resourceId, desc.params as TParams)
     } else {
       if (desc.page) {
@@ -1064,8 +1064,6 @@ export class QueryStore<
           return result
         })
       }
-      const local = this.#selectMaterializedFind(query)
-      if (local) return Promise.resolve(local)
       const findConfig = config as FindQueryConfig<unknown, unknown>
       return findConfig.allPages
         ? this.#adapter.findAll(desc.serviceName, desc.params as TParams)
@@ -1074,7 +1072,8 @@ export class QueryStore<
   }
 
   /**
-   * Answer a get locally when the service is fully materialized (an `.all()` query
+   * Pending optimistic creates are readable before the server acknowledges them.
+   * Otherwise, answer a get locally when the service is fully materialized (an `.all()` query
    * succeeded): the entity cache is the complete row set, so a present entity is
    * the answer with no roundtrip — realtime events, the reconnect sweep, and
    * complete-set fetch diffs keep it fresh, the same soundness argument local finds
@@ -1097,7 +1096,13 @@ export class QueryStore<
     // materialize time (see classifyStoredQuery) — never answered locally.
     if (query.maintenance.classification !== 'get') return null
     const service = this.#state.get(desc.serviceName)
-    if (!service?.materialized) return null
+    if (!service) return null
+    if (
+      !service.materialized &&
+      (query.config.realtime !== 'merge' ||
+        !this.#mutationExecutor.hasOptimisticCreate(desc.serviceName, desc.resourceId))
+    )
+      return null
 
     const config = query.config as GetQueryConfig<unknown, unknown>
     if (config.server) return null
@@ -1206,11 +1211,13 @@ export class QueryStore<
   #fetched({
     queryId,
     result,
+    source,
     journalEvents,
     cause,
   }: {
     queryId: string
     result: StoreResponse<TMeta>
+    source: 'cache' | 'server'
     journalEvents: readonly ProcessedCacheEvent[]
     cause?: TraceCause
   }): void {
@@ -1237,7 +1244,7 @@ export class QueryStore<
         isItemStale: (current, next) => this.#adapter.isItemStale(current, next),
       })
       const fetchedProjectionEvents: QueuedEvent[] = []
-      if (responseMode === 'entity') {
+      if (source === 'server' && responseMode === 'entity') {
         for (const item of responseItems) {
           const itemId = getId(item)
           if (itemId === undefined || rebasePlan.itemIds.has(entityKey(itemId))) continue
@@ -1309,7 +1316,7 @@ export class QueryStore<
       // (isItemStale can't catch a projection: same updatedAt as the row it shadows).
       const fetchedEvents: ProcessedCacheEvent[] = []
       const fetchedRows: QueuedEvent[] = []
-      if (!isProjection) {
+      if (source === 'server' && !isProjection) {
         for (const item of rebasedResponse.items) {
           const id = getId(item)
           if (id === undefined || journaledItemIds.has(entityKey(id))) continue

--- a/test/mutations.test.ts
+++ b/test/mutations.test.ts
@@ -5,7 +5,7 @@ import {
   type FigbirdEvent,
   type QueryState,
 } from '../lib'
-import { createTestApp } from './helpers'
+import { createTestApp, waitForEmissions } from './helpers'
 import {
   collectEvents,
   deferred,
@@ -598,7 +598,8 @@ test('id contract: a failed optimistic create rolls the item back out of the cac
   await new Promise(r => setTimeout(r, 10))
 
   let patchCalls = 0
-  feathers.service('notes').create = (() => Promise.reject(new Error('rejected'))) as never
+  const createGate = deferred<MockItem>()
+  feathers.service('notes').create = (() => createGate.promise) as never
   feathers.service('notes').patch = (() => {
     patchCalls += 1
     return Promise.resolve({ id: 77, content: 'should not run' })
@@ -611,8 +612,23 @@ test('id contract: a failed optimistic create rolls the item back out of the cac
     { optimisticItem: { id: 77, content: 'explicitly doomed' } },
   )
   t.is(latest?.data?.find(note => note.id === 77)?.content, 'explicitly doomed')
-  await t.throwsAsync(() => create, { message: 'rejected' })
-  await t.throwsAsync(() => dependentPatch, { message: /cancelled queued mutations/ })
+  const detail = figbird.query(figbird.q.notes.get(77))
+  const getCount = feathers.service('notes').counts.get
+  const unsubscribe = detail.subscribe(() => {})
+  t.teardown(unsubscribe)
+  await detail.suspensePromise()
+  t.is(detail.getSnapshot().data?.content, 'explicitly doomed')
+  t.is(feathers.service('notes').counts.get, getCount, 'pending creates are read locally')
+  detail.refetch()
+  await waitForEmissions()
+  t.is(detail.getSnapshot().data?.content, 'explicitly doomed')
+
+  const rejectedCreate = t.throwsAsync(create, { message: 'rejected' })
+  const cancelledPatch = t.throwsAsync(dependentPatch, { message: /cancelled queued mutations/ })
+  createGate.reject(new Error('rejected'))
+  await Promise.all([rejectedCreate, cancelledPatch])
+  await waitForEmissions()
+  t.is(detail.getSnapshot().error?.message, 'Item with id 77 not found')
   t.false(latest?.data?.some(note => note.id === 77))
   t.is(latest?.data?.length, 2)
   t.is(patchCalls, 0)


### PR DESCRIPTION
Opening a detail query while its optimistic create is pending could fetch the record before it existed on the server, leaving the demo stuck on a 404 even after creation succeeded.

Allow locally decidable realtime-merge gets to read pending optimistic creates without requiring a fully materialized service. Keep cache responses separate from server responses so reading an optimistic item never confirms it or prevents rollback. Explicit server and network-only reads retain their existing behavior.

The demo now offers a reload retry for failed detail loads, distinguishes 404s from other errors, and displays an explicit archive empty state with a valid zero-result range.

Validation: type checking, lint, all 365 tests, full npm test with coverage, demo TypeScript check, and browser checks for slow optimistic creation, detail retry, and empty archive search. Extended the existing failed-create test to cover local detail reads/refetches and rollback; no new test cases or changelog entries.
